### PR TITLE
Cleaned up auth user types for easier debugging

### DIFF
--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -37,8 +37,8 @@ export class UserMetadata {
     // were cases in the past where users did not have creation date properly set.
     // This included legacy Firebase migrating project users and some anonymous users.
     // These bugs have already been addressed since then.
-    utils.addGetter(this, 'createdAt', parseDate(response.createdAt));
-    utils.addGetter(this, 'lastSignedInAt', parseDate(response.lastLoginAt));
+    utils.addReadonlyGetter(this, 'createdAt', parseDate(response.createdAt));
+    utils.addReadonlyGetter(this, 'lastSignedInAt', parseDate(response.lastLoginAt));
   }
 
   /** @return {Object} The plain object representation of the user's metadata. */
@@ -73,11 +73,11 @@ export class UserInfo {
         'INTERNAL ASSERT FAILED: Invalid user info response');
     }
 
-    utils.addGetter(this, 'uid', response.rawId);
-    utils.addGetter(this, 'displayName', response.displayName);
-    utils.addGetter(this, 'email', response.email);
-    utils.addGetter(this, 'photoURL', response.photoUrl);
-    utils.addGetter(this, 'providerId', response.providerId);
+    utils.addReadonlyGetter(this, 'uid', response.rawId);
+    utils.addReadonlyGetter(this, 'displayName', response.displayName);
+    utils.addReadonlyGetter(this, 'email', response.email);
+    utils.addReadonlyGetter(this, 'photoURL', response.photoUrl);
+    utils.addReadonlyGetter(this, 'providerId', response.providerId);
   }
 
   /** @return {Object} The plain object representation of the current provider data. */
@@ -118,19 +118,19 @@ export class UserRecord {
         'INTERNAL ASSERT FAILED: Invalid user response');
     }
 
-    utils.addGetter(this, 'uid', response.localId);
-    utils.addGetter(this, 'email', response.email);
-    utils.addGetter(this, 'emailVerified', !!response.emailVerified);
-    utils.addGetter(this, 'displayName', response.displayName);
-    utils.addGetter(this, 'photoURL', response.photoUrl);
+    utils.addReadonlyGetter(this, 'uid', response.localId);
+    utils.addReadonlyGetter(this, 'email', response.email);
+    utils.addReadonlyGetter(this, 'emailVerified', !!response.emailVerified);
+    utils.addReadonlyGetter(this, 'displayName', response.displayName);
+    utils.addReadonlyGetter(this, 'photoURL', response.photoUrl);
     // If disabled is not provided, the account is enabled by default.
-    utils.addGetter(this, 'disabled', response.disabled || false);
-    utils.addGetter(this, 'metadata', new UserMetadata(response));
+    utils.addReadonlyGetter(this, 'disabled', response.disabled || false);
+    utils.addReadonlyGetter(this, 'metadata', new UserMetadata(response));
     const providerData: UserInfo[] = [];
     for (let entry of (response.providerUserInfo || [])) {
       providerData.push(new UserInfo(entry));
     }
-    utils.addGetter(this, 'providerData', providerData);
+    utils.addReadonlyGetter(this, 'providerData', providerData);
   }
 
   /** @return {Object} The plain object representation of the user record. */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,8 +18,7 @@ export function renameProperties(obj: Object, keyMap: { [key: string]: string })
 }
 
 /**
- * Defines a new property directly on an object, or modifies an existing property on an object, and
- * returns the object.
+ * Defines a new read-only property directly on an object and returns the object.
  *
  * @param {Object} obj The object on which to define the property.
  * @param {string} prop The name of the property to be defined or modified.
@@ -27,7 +26,7 @@ export function renameProperties(obj: Object, keyMap: { [key: string]: string })
  *
  * @return {Object} The object that was passed to the function.
  */
-export function addGetter(obj: Object, prop: string, value: any): void {
+export function addReadonlyGetter(obj: Object, prop: string, value: any): void {
   Object.defineProperty(obj, prop, {
     value,
     // Make this property read-only.

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -4,6 +4,7 @@ import './firebase-app.spec';
 import './firebase-namespace.spec';
 
 // Utilities
+import './utils/index.spec';
 import './utils/error.spec';
 import './utils/validator.spec';
 import './utils/api-request.spec';

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -1,0 +1,32 @@
+import {expect} from 'chai';
+
+import {addReadonlyGetter} from '../../../src/utils/index';
+
+type Obj = {
+  [key: string]: any;
+};
+
+describe('addReadonlyGetter()', () => {
+  it('should add a new property to the provided object', () => {
+    const obj: Obj = {};
+    addReadonlyGetter(obj, 'foo', true);
+
+    expect(obj.foo).to.be.true;
+  });
+
+  it('should make the new property read-only', () => {
+    const obj: Obj = {};
+    addReadonlyGetter(obj, 'foo', true);
+
+    expect(() => {
+      obj.foo = false;
+    }).to.throw('Cannot assign to read only property \'foo\' of object \'#<Object>\'');
+  });
+
+  it('should make the new property enumerable', () => {
+    const obj: Obj = {};
+    addReadonlyGetter(obj, 'foo', true);
+
+    expect(obj).to.have.keys(['foo']);
+  });
+});


### PR DESCRIPTION
### Description

I’ve now seen several reports of people getting confused by the fact that when you log `UserRecord`, you get a bunch of properties which are named `<something>Internal`. People think those are what they should use instead of just `<something>`. This change has no functional difference other than cleaning up which these properties display when doing a `console.log()`.

### Code sample

Previous output:

```
UserRecord {
  uidInternal: '0aiHf8cXAhumgYbHqE05',
  emailInternal: '0aihf8cxahumgybhqe05@example.com',
  emailVerifiedInternal: false,
  displayNameInternal: 'Random User 0aiHf8cXAhumgYbHqE05',
  photoURLInternal: 'http://www.example.com/0aiHf8cXAhumgYbHqE05/photo.png',
  disabledInternal: false,
  metadataInternal: 
   UserMetadata {
     createdAtInternal: 2017-02-02T05:25:35.000Z,
     lastSignedInAtInternal: null },
  providerDataInternal: 
   [ UserInfo {
       uidInternal: '0aihf8cxahumgybhqe05@example.com',
       displayNameInternal: 'Random User 0aiHf8cXAhumgYbHqE05',
       emailInternal: '0aihf8cxahumgybhqe05@example.com',
       photoURLInternal: 'http://www.example.com/0aiHf8cXAhumgYbHqE05/photo.png',
       providerIdInternal: 'password' } ] }

```

New output:

```
UserRecord {
  uid: '0aiHf8cXAhumgYbHqE05',
  email: '0aihf8cxahumgybhqe05@example.com',
  emailVerified: false,
  displayName: 'Random User 0aiHf8cXAhumgYbHqE05',
  photoURL: 'http://www.example.com/0aiHf8cXAhumgYbHqE05/photo.png',
  disabled: false,
  metadata: UserMetadata { createdAt: 2017-02-02T05:25:35.000Z, lastSignedInAt: null },
  providerData: 
   [ UserInfo {
       uid: '0aihf8cxahumgybhqe05@example.com',
       displayName: 'Random User 0aiHf8cXAhumgYbHqE05',
       email: '0aihf8cxahumgybhqe05@example.com',
       photoURL: 'http://www.example.com/0aiHf8cXAhumgYbHqE05/photo.png',
       providerId: 'password' } ] }
```
