### PR TITLE
Breaking changes for I/O 2017

### DIFF
--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -21,13 +21,13 @@ import {AuthClientErrorCode, FirebaseAuthError} from '../utils/error';
  * Parses a time stamp string or number and returns the corresponding date if valid.
  *
  * @param {any} time The unix timestamp string or number in milliseconds.
- * @return {Date} The corresponding date if valid.
+ * @return {string} The corresponding date as a UTC string, if valid.
  */
-function parseDate(time: any): Date {
+function parseDate(time: any): string {
   try {
     let date = new Date(parseInt(time, 10));
     if (!isNaN(date.getTime())) {
-      return date;
+      return date.toUTCString();
     }
   } catch (e) {
     // Do nothing. null will be returned.
@@ -45,23 +45,23 @@ function parseDate(time: any): Date {
  * @constructor
  */
 export class UserMetadata {
-  public readonly createdAt: Date;
-  public readonly lastSignedInAt: Date;
+  public readonly creationTime: string;
+  public readonly lastSignInTime: string;
 
   constructor(response: any) {
     // Creation date should always be available but due to some backend bugs there
     // were cases in the past where users did not have creation date properly set.
     // This included legacy Firebase migrating project users and some anonymous users.
     // These bugs have already been addressed since then.
-    utils.addReadonlyGetter(this, 'createdAt', parseDate(response.createdAt));
-    utils.addReadonlyGetter(this, 'lastSignedInAt', parseDate(response.lastLoginAt));
+    utils.addReadonlyGetter(this, 'creationTime', parseDate(response.createdAt));
+    utils.addReadonlyGetter(this, 'lastSignInTime', parseDate(response.lastLoginAt));
   }
 
   /** @return {Object} The plain object representation of the user's metadata. */
   public toJSON(): Object {
     return {
-      lastSignedInAt: this.lastSignedInAt,
-      createdAt: this.createdAt,
+      lastSignInTime: this.lastSignInTime,
+      creationTime: this.creationTime,
     };
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,6 @@ declare namespace admin {
     credential?: admin.credential.Credential;
     databaseAuthVariableOverride?: Object;
     databaseURL?: string;
-    serviceAccount?: string|admin.ServiceAccount;
     storageBucket?: string;
   }
 
@@ -71,8 +70,8 @@ declare namespace admin.app {
 
 declare namespace admin.auth {
   interface UserMetadata {
-    lastSignedInAt: Date;
-    createdAt: Date;
+    lastSignInTime: string;
+    creationTime: string;
 
     toJSON(): Object;
   }

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -90,8 +90,8 @@ function getUserJSON(): Object {
     ],
     photoURL: 'https://lh3.googleusercontent.com/1234567890/photo.jpg',
     metadata: {
-      lastSignedInAt: new Date(1476235905000),
-      createdAt: new Date(1476136676000),
+      lastSignInTime: new Date(1476235905000).toUTCString(),
+      creationTime: new Date(1476136676000).toUTCString(),
     },
   };
 }
@@ -217,62 +217,62 @@ describe('UserMetadata', () => {
   const expectedLastLoginAt = 1476235905000;
   const expectedCreatedAt = 1476136676000;
   const actualMetadata: UserMetadata = new UserMetadata({
-    lastLoginAt: expectedLastLoginAt.toString(),
-    createdAt: expectedCreatedAt.toString(),
+    lastLoginAt: expectedLastLoginAt,
+    createdAt: expectedCreatedAt,
   });
   const expectedMetadataJSON = {
-    lastSignedInAt: new Date(expectedLastLoginAt),
-    createdAt: new Date(expectedCreatedAt),
+    lastSignInTime: new Date(expectedLastLoginAt).toUTCString(),
+    creationTime: new Date(expectedCreatedAt).toUTCString(),
   };
 
   describe('constructor', () =>  {
-    it('should initialize as expected when a valid createdAt is provided', () => {
+    it('should initialize as expected when a valid creationTime is provided', () => {
       expect(() => {
         return new UserMetadata({createdAt: '1476136676000'});
       }).not.to.throw(Error);
     });
 
-    it('should set createdAt and lastSignedInAt to null when not provided', () => {
+    it('should set creationTime and lastSignInTime to null when not provided', () => {
       let metadata = new UserMetadata({});
-      expect(metadata.createdAt).to.be.null;
-      expect(metadata.lastSignedInAt).to.be.null;
+      expect(metadata.creationTime).to.be.null;
+      expect(metadata.lastSignInTime).to.be.null;
     });
 
-    it('should set createdAt to null when createdAt value is invalid', () => {
+    it('should set creationTime to null when creationTime value is invalid', () => {
       let metadata = new UserMetadata({
         createdAt: 'invalid',
       });
-      expect(metadata.createdAt).to.be.null;
-      expect(metadata.lastSignedInAt).to.be.null;
+      expect(metadata.creationTime).to.be.null;
+      expect(metadata.lastSignInTime).to.be.null;
     });
 
-    it('should set lastSignedInAt to null when lastLoginAt value is invalid', () => {
+    it('should set lastSignInTime to null when lastLoginAt value is invalid', () => {
       let metadata = new UserMetadata({
         createdAt: '1476235905000',
         lastLoginAt: 'invalid',
       });
-      expect(metadata.lastSignedInAt).to.be.null;
+      expect(metadata.lastSignInTime).to.be.null;
     });
   });
 
   describe('getters', () => {
-    it('should return expected lastSignedInAt', () => {
-      expect(actualMetadata.lastSignedInAt.getTime()).to.equal(expectedLastLoginAt);
+    it('should return expected lastSignInTime', () => {
+      expect(actualMetadata.lastSignInTime).to.equal(expectedMetadataJSON.lastSignInTime);
     });
 
-    it('should throw when modifying readonly lastSignedInAt property', () => {
+    it('should throw when modifying readonly lastSignInTime property', () => {
       expect(() => {
-        (actualMetadata as any).lastSignedInAt = new Date();
+        (actualMetadata as any).lastSignInTime = new Date();
       }).to.throw(Error);
     });
 
-    it('should return expected createdAt', () => {
-      expect(actualMetadata.createdAt.getTime()).to.equal(expectedCreatedAt);
+    it('should return expected creationTime', () => {
+      expect(actualMetadata.creationTime).to.equal(expectedMetadataJSON.creationTime);
     });
 
-    it('should throw when modifying readonly createdAt property', () => {
+    it('should throw when modifying readonly creationTime property', () => {
       expect(() => {
-        (actualMetadata as any).createdAt = new Date();
+        (actualMetadata as any).creationTime = new Date();
       }).to.throw(Error);
     });
   });
@@ -373,15 +373,15 @@ describe('UserRecord', () => {
     it('should throw when modifying readonly metadata property', () => {
       expect(() => {
         (userRecord as any).metadata = new UserMetadata({
-          lastLoginAt: new Date().getTime(),
-          createdAt: new Date().getTime(),
+          createdAt: new Date().toUTCString(),
+          lastLoginAt: new Date().toUTCString(),
         });
       }).to.throw(Error);
     });
 
     it('should throw when modifying readonly metadata internals', () => {
       expect(() => {
-        (userRecord as any).metadata.lastSignedInAt = new Date();
+        (userRecord as any).metadata.lastSignInTime = new Date();
       }).to.throw(Error);
     });
 

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -75,18 +75,9 @@ describe('Firebase', () => {
       }).to.throw('Invalid Firebase app options');
     });
 
-    it('should throw given an options object containing neither a "serviceAccount" nor a "credential" key', () => {
+    it('should throw given an options object containing no "credential" key', () => {
       expect(() => {
         firebaseAdmin.initializeApp(mocks.appOptionsNoAuth);
-      }).to.throw('Invalid Firebase app options');
-    });
-
-    it('should throw given an options object containing both the "serviceAccount" and "credential" keys', () => {
-      expect(() => {
-        firebaseAdmin.initializeApp({
-          credential: firebaseAdmin.credential.applicationDefault(),
-          serviceAccount: mocks.certificateObject,
-        });
       }).to.throw('Invalid Firebase app options');
     });
 
@@ -96,212 +87,72 @@ describe('Firebase', () => {
       expect(optionsClone).to.deep.equal(mocks.appOptions);
     });
 
-    describe('"serviceAccount" key', () => {
-      const invalidServiceAccounts = [undefined, null, NaN, 0, 1, true, false, _.noop];
-      invalidServiceAccounts.forEach((invalidServiceAccount) => {
-        it('should throw given invalid service account: ' + JSON.stringify(invalidServiceAccount), () => {
-          expect(() => {
-            firebaseAdmin.initializeApp({
-              serviceAccount: invalidServiceAccount,
-            });
-          }).to.throw('Invalid Firebase app options');
-        });
-      });
-
-      it('should throw if service account points to an invalid path', () => {
+    const invalidCredentials = [undefined, null, NaN, 0, 1, '', 'a', true, false, '', _.noop];
+    invalidCredentials.forEach((invalidCredential) => {
+      it('should throw given non-object credential: ' + JSON.stringify(invalidCredential), () => {
         expect(() => {
           firebaseAdmin.initializeApp({
-            serviceAccount: 'invalid-file',
+            credential: invalidCredential as any,
           });
-        }).to.throw('Failed to parse certificate key file');
-      });
-
-      it('should throw if service account is an empty string', () => {
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: '',
-          });
-        }).to.throw('Failed to parse certificate key file');
-      });
-
-      it('should throw if certificate object does not contain a valid "client_email"', () => {
-        const mockCertificateObject = _.clone(mocks.certificateObject);
-        mockCertificateObject.client_email = '';
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).to.throw('Certificate object must contain a string "client_email" property');
-
-        delete mockCertificateObject.client_email;
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).to.throw('Certificate object must contain a string "client_email" property');
-      });
-
-      it('should throw if certificate object does not contain a valid "private_key"', () => {
-        const mockCertificateObject = _.clone(mocks.certificateObject);
-        mockCertificateObject.private_key = '';
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).to.throw('Certificate object must contain a string "private_key" property');
-
-        delete mockCertificateObject.private_key;
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).to.throw('Certificate object must contain a string "private_key" property');
-      });
-
-      it('should not throw given a valid path to a certificate key file', () => {
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: path.resolve(__dirname, '../resources/mock.key.json'),
-          });
-        }).not.to.throw();
-      });
-
-      it('should not throw given a valid certificate object', () => {
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mocks.certificateObject,
-          });
-        }).not.to.throw();
-      });
-
-      it('should accept "clientEmail" in place of "client_email" within the certificate object', () => {
-        const mockCertificateObject = _.clone(mocks.certificateObject);
-        mockCertificateObject.clientEmail = mockCertificateObject.client_email;
-        delete mockCertificateObject.client_email;
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).not.to.throw();
-      });
-
-      it('should accept "privateKey" in place of "private_key" within the certificate object', () => {
-        const mockCertificateObject = _.clone(mocks.certificateObject);
-        mockCertificateObject.privateKey = mockCertificateObject.private_key;
-        delete mockCertificateObject.private_key;
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mockCertificateObject,
-          });
-        }).not.to.throw();
-      });
-
-      it('should not mutate the provided certificate object', () => {
-        const mockCertificateObject = _.clone(mocks.certificateObject);
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            serviceAccount: mocks.certificateObject,
-          });
-        }).not.to.throw();
-
-        expect(mocks.certificateObject).to.deep.equal(mockCertificateObject);
-      });
-
-      it('should initialize SDK given a certificate object', () => {
-
-        firebaseAdmin.initializeApp({
-          serviceAccount: mocks.certificateObject,
-        });
-
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
-      });
-
-      it('should initialize SDK given a valid path to a certificate key file', () => {
-        firebaseAdmin.initializeApp({
-          serviceAccount: path.resolve(__dirname, '../resources/mock.key.json'),
-        });
-
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
+        }).to.throw('Invalid Firebase app options');
       });
     });
 
-    describe('"credential" key', () => {
-      const invalidCredentials = [undefined, null, NaN, 0, 1, '', 'a', true, false, '', _.noop];
-      invalidCredentials.forEach((invalidCredential) => {
-        it('should throw given non-object credential: ' + JSON.stringify(invalidCredential), () => {
-          expect(() => {
-            firebaseAdmin.initializeApp({
-              credential: invalidCredential as any,
-            });
-          }).to.throw('Invalid Firebase app options');
-        });
-      });
-
-      it('should throw given a credential which doesn\'t implement the Credential interface', () => {
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            credential: {
-              foo: () => null,
-            },
-          } as any);
-        }).to.throw('Invalid Firebase app options');
-
-        expect(() => {
-          firebaseAdmin.initializeApp({
-            credential: {
-              getAccessToken: true,
-            },
-          } as any);
-        }).to.throw('Invalid Firebase app options');
-      });
-
-      it('should initialize SDK given a cert credential with a certificate object', () => {
+    it('should throw given a credential which doesn\'t implement the Credential interface', () => {
+      expect(() => {
         firebaseAdmin.initializeApp({
-          credential: firebaseAdmin.credential.cert(mocks.certificateObject),
-        });
+          credential: {
+            foo: () => null,
+          },
+        } as any);
+      }).to.throw('Invalid Firebase app options');
 
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
-      });
-
-      it('should initialize SDK given a cert credential with a valid path to a certificate key file', () => {
-        const keyPath = path.resolve(__dirname, '../resources/mock.key.json');
+      expect(() => {
         firebaseAdmin.initializeApp({
-          credential: firebaseAdmin.credential.cert(keyPath),
-        });
+          credential: {
+            getAccessToken: true,
+          },
+        } as any);
+      }).to.throw('Invalid Firebase app options');
+    });
 
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    it('should initialize SDK given a cert credential with a certificate object', () => {
+      firebaseAdmin.initializeApp({
+        credential: firebaseAdmin.credential.cert(mocks.certificateObject),
       });
 
-      it('should initialize SDK given an application default credential', () => {
-        firebaseAdmin.initializeApp({
-          credential: firebaseAdmin.credential.applicationDefault(),
-        });
+      return firebaseAdmin.app().INTERNAL.getToken()
+        .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    });
 
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    it('should initialize SDK given a cert credential with a valid path to a certificate key file', () => {
+      const keyPath = path.resolve(__dirname, '../resources/mock.key.json');
+      firebaseAdmin.initializeApp({
+        credential: firebaseAdmin.credential.cert(keyPath),
       });
 
-      // TODO(jwenger): mock out the refresh token endpoint so this test will work
-      xit('should initialize SDK given a refresh token credential', () => {
-        nock.recorder.rec();
-        firebaseAdmin.initializeApp({
-          credential: firebaseAdmin.credential.refreshToken(mocks.refreshToken),
-        });
+      return firebaseAdmin.app().INTERNAL.getToken()
+        .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    });
 
-        return firebaseAdmin.app().INTERNAL.getToken()
-          .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    it('should initialize SDK given an application default credential', () => {
+      firebaseAdmin.initializeApp({
+        credential: firebaseAdmin.credential.applicationDefault(),
       });
+
+      return firebaseAdmin.app().INTERNAL.getToken()
+        .should.eventually.have.keys(['accessToken', 'expirationTime']);
+    });
+
+    // TODO(jwenger): mock out the refresh token endpoint so this test will work
+    xit('should initialize SDK given a refresh token credential', () => {
+      nock.recorder.rec();
+      firebaseAdmin.initializeApp({
+        credential: firebaseAdmin.credential.refreshToken(mocks.refreshToken),
+      });
+
+      return firebaseAdmin.app().INTERNAL.getToken()
+        .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
   });
 


### PR DESCRIPTION
**Note: this PR is against the `io-2017` branch, not `master`**

### Description

These are all breaking changes planned for I/O 2017:
* Remove deprecated `serviceAccount` property as part of the options passed to `initializeApp()`.
* Throw error if no `credential` property is passed as part of the options passed to `initializeApp()`.
* Rename `createdAt` to `creationTime` and `lastSignedInAt` to `lastSignInTime` and remove the old properties.

### Code sample

N/A
