### PR TITLE
[WIP] Prototyping adding GCS support

### DIFF
--- a/storageTestRunner.js
+++ b/storageTestRunner.js
@@ -4,7 +4,6 @@ var serviceAccount = require('./test/resources/key.json');
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: 'https://admin-sdks-test.firebaseio.com',
   storageBucket: 'admin-sdks-test.appspot.com',
 });
 


### PR DESCRIPTION
### Description

Still very much a WIP, but this is a prototype which adds GCS support via `admin.storage()`. `admin.storage().bucket` exports the [standard GCS `Bucket` API](https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.0.0/storage/bucket).

Initialization of the underlying `google-cloud` SDK is probably going to be a bit tricky since they don't provide a standard credential interface like our SDK does which allows you to provide your own Google OAuth2 access tokens. But we can make it work without too much effort via  the certificate credential (which this PR does) and via the Application Default Credential (which this PR does not do). I'm still not sure how we will make it work using a refresh token credential since we don't have the right fields that the `google-cloud` SDK provides as initialization options (see the table in "Advanced Usage" [here](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/v0.51.1/google-cloud?method=gcloud)).

I didn't do anything for multi-bucket support although it shouldn't be too bad to support.

cc/ @mcdonamp, @sphippen, @hiranya911, @depoll

### Code sample

```
var admin = require('firebase-admin');

var serviceAccount = require('./path/to/key.json');

admin.initializeApp({
  credential: admin.credential.cert(serviceAccount),
  storageBucket: 'admin-sdks-test.appspot.com',
});

admin.storage().bucket.file('firebase.png').download({
  destination: './firebase.png'
}, function(error) {
  if (error) {
    console.log('Error downloading file:', error);
  } else {
    console.log('File successfully downloaded!');
  }
});
```