### PR TITLE
Validating the private key string

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@types/jsonwebtoken": "^7.1.33",
     "faye-websocket": "0.9.3",
-    "jsonwebtoken": "7.1.9"
+    "jsonwebtoken": "7.1.9",
+    "node-forge": "0.7.1"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -15,6 +15,7 @@
  */
 
 import * as jwt from 'jsonwebtoken';
+import * as forge from 'node-forge';
 
 // Use untyped import syntax for Node built-ins
 import fs = require('fs');
@@ -166,6 +167,14 @@ export class Certificate {
 
     if (typeof errorMessage !== 'undefined') {
       throw new FirebaseAppError(AppErrorCodes.INVALID_CREDENTIAL, errorMessage);
+    }
+
+    try {
+      forge.pki.privateKeyFromPem(this.privateKey);
+    } catch (error) {
+      throw new FirebaseAppError(
+        AppErrorCodes.INVALID_CREDENTIAL,
+        'Failed to parse private key: ' + error);
     }
   }
 }

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -171,7 +171,7 @@ describe('Credential', () => {
         }).to.throw('Certificate object must contain a string "client_email" property');
       });
 
-      it('should throw if certificate object does not contain a valid "private_key"', () => {
+      it('should throw if certificate object does not contain a "private_key"', () => {
         mockCertificateObject.private_key = '';
 
         expect(() => {
@@ -183,6 +183,14 @@ describe('Credential', () => {
         expect(() => {
           return new Certificate(mockCertificateObject);
         }).to.throw('Certificate object must contain a string "private_key" property');
+      });
+
+      it('should throw if certificate object does not contain a valid "private_key"', () => {
+        mockCertificateObject.private_key = 'invalid.key';
+
+        expect(() => {
+          return new Certificate(mockCertificateObject);
+        }).to.throw('Failed to parse private key: Error: Invalid PEM formatted message.');
       });
 
       it('should not throw given a valid certificate object', () => {


### PR DESCRIPTION
Currently the admin SDK can be initialized with an invalid private key. The error won't be caught until we try to make an API request using the key, at which point the error would manifest as a server side error:

```
{ Error: An internal error has occurred. Raw server response: "{}"
    at FirebaseAuthError.Error (native)
```

This fix parses the private key field when the certificate credential is initialized, and presents the user with a more meaningful error:

```
Error: Failed to parse private key: Error: Invalid PEM formatted message.
    at FirebaseAppError.Error (native)
```

I had to bring in node-forge as a dependency to parse private key in PEM. Not sure if that's the best thing to do here. Appreciate any feedback on that.