### PR TITLE
Loading the API key from a local file instead of a command-line arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 
 # Real key file should not be checked in
 test/resources/key.json
+test/resources/apikey.txt
 
 # Release tarballs should not be checked in
 firebase-admin-*.tgz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,17 +134,16 @@ $ gulp   # Lint, build, and run unit test suite
 To run the integration test suite:
 
 ```
-$ node test/integration <apiKey>   # Run integration test suite
+$ node test/integration   # Run integration test suite
 ```
 
-The integration test suite requires you to generate a service account key JSON file for a
-Firebase project and save it to `test/resources/key.json`. Create a new project in the
-[Firebase console](https://console.firebase.google.com) if you do not already have one.
-Use a separate, dedicated project for integration tests since the test suite makes a large
-number of writes to the Firebase realtime database. Download the service account key file
-from the "Settings > Service Accounts" page of the project, and copy it to
-`test/resources/key.json`. Also obtain the API key for the same project from "Settings > General".
-This API key should be passed into the test suite as a command-line argument.
+The integration test suite requires a service account JSON key file, and an API key for a Firebase
+project. Create a new project in the [Firebase console](https://console.firebase.google.com) if
+you do not already have one. Use a separate, dedicated project for integration tests since the
+test suite makes a large number of writes to the Firebase realtime database. Download the service
+account key file from the "Settings > Service Accounts" page of the project, and copy it to
+`test/resources/key.json`. Also obtain the API key for the same project from "Settings > General",
+and save it to `test/resource/apikey.txt`.
 
 ### Repo Organization
 

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -16,6 +16,8 @@
 
 var _ = require('lodash');
 var chalk = require('chalk');
+var fs = require('fs');
+var path = require('path');
 
 var failureCount = 0;
 var successCount = 0;
@@ -36,11 +38,16 @@ try {
   process.exit(1);
 }
 
-var apiKey = process.argv[2];
-if (typeof apiKey === 'undefined') {
+var apiKey;
+
+try {
+  apiKey = fs.readFileSync(path.join(__dirname, '../resources/apikey.txt'))
+} catch (error) {
   console.log(chalk.red(
     'The integration test suite requires an API key for a ' +
-    'Firebase project to be specified as a command-line argument.'));
+    'Firebase project to be saved to `test/resources/apikey.txt`.',
+    error
+  ));
   process.exit(1);
 }
 


### PR DESCRIPTION
It is easier to load the API key for integration tests from a local file, rather than having to pass in every time via the command-line. This makes it possible to set up the environment once for integration tests, and then reuse it over and over.
