### PR TITLE
Running Unit Tests without gcloud SDK in Automated Environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "7"
+  - "6"
+  - "5"
+  - "4"

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -27,7 +27,7 @@ import * as jwt from 'jsonwebtoken';
 import {FirebaseNamespace} from '../../src/firebase-namespace';
 import {FirebaseServiceInterface} from '../../src/firebase-service';
 import {FirebaseApp, FirebaseAppOptions} from '../../src/firebase-app';
-import {CertCredential, ApplicationDefaultCredential} from '../../src/auth/credential';
+import {Certificate, Credential, CertCredential, GoogleOAuthAccessToken} from '../../src/auth/credential';
 
 const ALGORITHM = 'RS256';
 const ONE_HOUR_IN_SECONDS = 60 * 60;
@@ -60,15 +60,28 @@ export let appOptionsNoDatabaseUrl: FirebaseAppOptions = {
   credential,
 };
 
+export class MockCredential implements Credential {
+  public getAccessToken(): Promise<GoogleOAuthAccessToken> {
+    return Promise.resolve({
+      access_token: 'mock-token',
+      expires_in: 3600,
+    });
+  }
+
+  public getCertificate(): Certificate {
+    return null;
+  }
+}
+
 export function app(): FirebaseApp {
   const namespaceInternals = new FirebaseNamespace().INTERNAL;
   namespaceInternals.removeApp = _.noop;
   return new FirebaseApp(appOptions, appName, namespaceInternals);
 }
 
-export function applicationDefaultApp(): FirebaseApp {
+export function mockCredentialApp(): FirebaseApp {
   return new FirebaseApp({
-    credential: new ApplicationDefaultCredential(),
+    credential: new MockCredential(),
     databaseURL,
   }, appName, new FirebaseNamespace().INTERNAL);
 }

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -169,7 +169,7 @@ describe('Auth', () => {
     });
 
     it('should throw if a cert credential is not specified', () => {
-      const applicationDefaultCredentialAuth = new Auth(mocks.applicationDefaultApp());
+      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
 
       expect(() => {
         applicationDefaultCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims);
@@ -215,7 +215,7 @@ describe('Auth', () => {
     afterEach(() => stub.restore());
 
     it('should throw if a cert credential is not specified', () => {
-      const applicationDefaultCredentialAuth = new Auth(mocks.applicationDefaultApp());
+      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
 
       expect(() => {
         applicationDefaultCredentialAuth.verifyIdToken(mockIdToken);
@@ -231,7 +231,7 @@ describe('Auth', () => {
     it('should work with a non-cert credential when the GCLOUD_PROJECT environment variable is present', () => {
       process.env.GCLOUD_PROJECT = mocks.projectId;
 
-      const applicationDefaultCredentialAuth = new Auth(mocks.applicationDefaultApp());
+      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
 
       return applicationDefaultCredentialAuth.verifyIdToken(mockIdToken).then(() => {
         expect(stub).to.have.been.calledOnce.and.calledWith(mockIdToken);

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -169,10 +169,10 @@ describe('Auth', () => {
     });
 
     it('should throw if a cert credential is not specified', () => {
-      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
+      const mockCredentialAuth = new Auth(mocks.mockCredentialApp());
 
       expect(() => {
-        applicationDefaultCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims);
+        mockCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims);
       }).to.throw('Must initialize app with a cert credential');
     });
 
@@ -215,10 +215,10 @@ describe('Auth', () => {
     afterEach(() => stub.restore());
 
     it('should throw if a cert credential is not specified', () => {
-      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
+      const mockCredentialAuth = new Auth(mocks.mockCredentialApp());
 
       expect(() => {
-        applicationDefaultCredentialAuth.verifyIdToken(mockIdToken);
+        mockCredentialAuth.verifyIdToken(mockIdToken);
       }).to.throw('Must initialize app with a cert credential');
     });
 
@@ -231,9 +231,9 @@ describe('Auth', () => {
     it('should work with a non-cert credential when the GCLOUD_PROJECT environment variable is present', () => {
       process.env.GCLOUD_PROJECT = mocks.projectId;
 
-      const applicationDefaultCredentialAuth = new Auth(mocks.mockCredentialApp());
+      const mockCredentialAuth = new Auth(mocks.mockCredentialApp());
 
-      return applicationDefaultCredentialAuth.verifyIdToken(mockIdToken).then(() => {
+      return mockCredentialAuth.verifyIdToken(mockIdToken).then(() => {
         expect(stub).to.have.been.calledOnce.and.calledWith(mockIdToken);
       });
     });

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -144,7 +144,7 @@ describe('Firebase', () => {
       });
 
       return firebaseAdmin.app().INTERNAL.getToken().then(token => {
-        if (credPath === 'undefined') {
+        if (typeof credPath === 'undefined') {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
         } else {
           process.env.GOOGLE_APPLICATION_CREDENTIALS = credPath;

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -136,12 +136,21 @@ describe('Firebase', () => {
     });
 
     it('should initialize SDK given an application default credential', () => {
+      let credPath: string;
+      credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../resources/mock.key.json');
       firebaseAdmin.initializeApp({
         credential: firebaseAdmin.credential.applicationDefault(),
       });
 
-      return firebaseAdmin.app().INTERNAL.getToken()
-        .should.eventually.have.keys(['accessToken', 'expirationTime']);
+      return firebaseAdmin.app().INTERNAL.getToken().then(token => {
+        if (credPath === 'undefined') {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        } else {
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = credPath;
+        }
+        return token;
+      }).should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
 
     // TODO(jwenger): mock out the refresh token endpoint so this test will work

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -36,7 +36,7 @@ describe('addReadonlyGetter()', () => {
 
     expect(() => {
       obj.foo = false;
-    }).to.throw('Cannot assign to read only property \'foo\' of object \'#<Object>\'');
+    }).to.throw(/Cannot assign to read only property \'foo\' of/);
   });
 
   it('should make the new property enumerable', () => {


### PR DESCRIPTION
The unit test framework requires a local installation of the gcloud SDK, and also to authorize it by running `gcloud auth application-default login`. This is an interactive process which cannot be fully automated. As a result we cannot run it in an automated environment like TravisCI. 

This patch updates application default credential tests to run by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. For a number of other auth tests, we introduce a new `MockCredential` (these tests simply require some non-cert credential).