### PR TITLE
[WIP] Prototyping adding GCS support

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,18 @@
   "name": "firebase-admin",
   "version": "4.2.1",
   "dependencies": {
+    "@google-cloud/common": {
+      "version": "0.13.0",
+      "from": "@google-cloud/common@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.0.tgz",
+      "optional": true
+    },
+    "@google-cloud/storage": {
+      "version": "1.0.0",
+      "from": "@google-cloud/storage@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.0.0.tgz",
+      "optional": true
+    },
     "@types/jsonwebtoken": {
       "version": "7.2.0",
       "from": "@types/jsonwebtoken@>=7.1.33 <8.0.0",
@@ -12,45 +24,458 @@
       "from": "@types/node@*",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.12.tgz"
     },
+    "ajv": {
+      "version": "4.11.6",
+      "from": "ajv@>=4.9.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz"
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "optional": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
+    "async": {
+      "version": "2.3.0",
+      "from": "async@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz"
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+    },
     "base64url": {
       "version": "2.0.0",
       "from": "base64url@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "optional": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "from": "buffer-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "optional": true
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "from": "buffer-equal-constant-time@1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "from": "buffer-shims@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "from": "commander@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
+    },
+    "configstore": {
+      "version": "3.0.0",
+      "from": "configstore@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "from": "create-error-class@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "from": "crypto-random-string@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "optional": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "dot-prop": {
+      "version": "4.1.1",
+      "from": "dot-prop@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+      "optional": true
+    },
+    "duplexify": {
+      "version": "3.5.0",
+      "from": "duplexify@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.9",
       "from": "ecdsa-sig-formatter@1.0.9",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz"
+    },
+    "end-of-stream": {
+      "version": "1.0.0",
+      "from": "end-of-stream@1.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        }
+      }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "from": "ent@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "extend": {
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "faye-websocket": {
       "version": "0.9.3",
       "from": "faye-websocket@0.9.3",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz"
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "from": "form-data@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+    },
+    "gcp-metadata": {
+      "version": "0.1.0",
+      "from": "gcp-metadata@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz"
+    },
+    "gcs-resumable-upload": {
+      "version": "0.7.6",
+      "from": "gcs-resumable-upload@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.6.tgz",
+      "optional": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "google-auth-library": {
+      "version": "0.10.0",
+      "from": "google-auth-library@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz"
+    },
+    "google-auto-auth": {
+      "version": "0.6.0",
+      "from": "google-auto-auth@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.0.tgz"
+    },
+    "google-p12-pem": {
+      "version": "0.1.2",
+      "from": "google-p12-pem@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz"
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+    },
+    "gtoken": {
+      "version": "1.2.2",
+      "from": "gtoken@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.2.tgz"
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "from": "har-schema@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "hash-stream-validation": {
+      "version": "0.2.1",
+      "from": "hash-stream-validation@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
+      "optional": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "optional": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "is": {
+      "version": "3.2.1",
+      "from": "is@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "from": "is-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "optional": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-stream-ended": {
+      "version": "0.1.0",
+      "from": "is-stream-ended@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.0.tgz",
+      "optional": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isemail": {
       "version": "1.2.0",
       "from": "isemail@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
     },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "optional": true
+    },
     "joi": {
       "version": "6.10.1",
       "from": "joi@>=6.10.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+    },
     "jsonwebtoken": {
       "version": "7.1.9",
       "from": "jsonwebtoken@7.1.9",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.1.9.tgz"
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "jwa": {
       "version": "1.1.5",
@@ -59,13 +484,68 @@
     },
     "jws": {
       "version": "3.1.4",
-      "from": "jws@>=3.1.3 <4.0.0",
+      "from": "jws@>=3.1.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz"
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "from": "lodash@>=4.14.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "lodash.noop": {
+      "version": "3.0.1",
+      "from": "lodash.noop@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz"
     },
     "lodash.once": {
       "version": "4.1.1",
       "from": "lodash.once@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "from": "log-driver@>=1.2.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "optional": true
+    },
+    "methmeth": {
+      "version": "1.1.0",
+      "from": "methmeth@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
+      "optional": true
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@>=1.2.11 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "from": "mime-db@>=1.27.0 <1.28.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "from": "mime-types@>=2.0.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "from": "minimist@0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "optional": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "optional": true
+    },
+    "modelo": {
+      "version": "4.2.0",
+      "from": "modelo@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.0.tgz",
+      "optional": true
     },
     "moment": {
       "version": "2.18.1",
@@ -77,15 +557,255 @@
       "from": "ms@>=0.7.1 <0.8.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
     },
+    "node-forge": {
+      "version": "0.7.1",
+      "from": "node-forge@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz"
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "from": "object-assign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+    },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "from": "performance-now@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+    },
+    "pump": {
+      "version": "1.0.2",
+      "from": "pump@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.0",
+          "from": "end-of-stream@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
+        }
+      }
+    },
+    "pumpify": {
+      "version": "1.3.5",
+      "from": "pumpify@>=1.3.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz"
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+    },
+    "qs": {
+      "version": "6.3.2",
+      "from": "qs@>=6.3.0 <6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
+    },
+    "readable-stream": {
+      "version": "2.2.9",
+      "from": "readable-stream@>=2.2.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+    },
+    "request": {
+      "version": "2.81.0",
+      "from": "request@>=2.79.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "dependencies": {
+        "caseless": {
+          "version": "0.12.0",
+          "from": "caseless@>=0.12.0 <0.13.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "from": "har-validator@>=4.2.1 <4.3.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "qs@>=6.4.0 <6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "from": "tunnel-agent@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+        }
+      }
+    },
+    "retry-request": {
+      "version": "1.3.2",
+      "from": "retry-request@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
+      "dependencies": {
+        "request": {
+          "version": "2.76.0",
+          "from": "request@2.76.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz"
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.0.1",
       "from": "safe-buffer@>=5.0.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
     },
+    "slide": {
+      "version": "1.1.6",
+      "from": "slide@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "optional": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "split-array-stream": {
+      "version": "1.0.0",
+      "from": "split-array-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.0.tgz",
+      "optional": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "optional": true
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.13.0",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "stream-events": {
+      "version": "1.0.1",
+      "from": "stream-events@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.1.tgz"
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "from": "stream-shift@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+    },
+    "string_decoder": {
+      "version": "1.0.0",
+      "from": "string_decoder@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+    },
+    "string-format-obj": {
+      "version": "1.1.0",
+      "from": "string-format-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "stubs": {
+      "version": "1.1.2",
+      "from": "stubs@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-1.1.2.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "through2": {
+      "version": "2.0.3",
+      "from": "through2@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+    },
     "topo": {
       "version": "1.1.0",
       "from": "topo@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "from": "unique-string@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "optional": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "websocket-driver": {
       "version": "0.6.5",
@@ -97,9 +817,26 @@
       "from": "websocket-extensions@>=0.1.1",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "write-file-atomic": {
+      "version": "1.3.1",
+      "from": "write-file-atomic@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "optional": true
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "from": "xdg-basedir@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "optional": true
+    },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <5.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "faye-websocket": "0.9.3",
     "jsonwebtoken": "7.1.9"
   },
+  "optionalDependencies": {
+    "@google-cloud/storage": "^1.0.0"
+  },
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/chai-as-promised": "0.0.29",

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -315,6 +315,14 @@ export class FirebaseApp {
     );
   }
 
+  /* istanbul ignore next */
+  public storage(): FirebaseServiceInterface {
+    throw new FirebaseAppError(
+      AppErrorCodes.INTERNAL_ERROR,
+      'INTERNAL ASSERT FAILED: Firebase storage() service has not been registered.',
+    );
+  }
+
   /**
    * Returns the name of the FirebaseApp instance.
    *

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -284,6 +284,14 @@ export class FirebaseNamespace {
     );
   }
 
+  /* istanbul ignore next */
+  public storage(): FirebaseServiceInterface {
+    throw new FirebaseAppError(
+      AppErrorCodes.INTERNAL_ERROR,
+      'INTERNAL ASSERT FAILED: Firebase storage() service has not been registered.',
+    );
+  }
+
   /**
    * Initializes the FirebaseApp instance.
    *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,6 +38,7 @@ declare namespace admin {
   function auth(app?: admin.app.App): admin.auth.Auth;
   function database(app?: admin.app.App): admin.database.Database;
   function messaging(app?: admin.app.App): admin.messaging.Messaging;
+  function storage(app?: admin.app.App): admin.storage.Storage;
   function initializeApp(options: admin.AppOptions, name?: string): admin.app.App;
 }
 
@@ -49,6 +50,7 @@ declare namespace admin.app {
     auth(): admin.auth.Auth;
     database(): admin.database.Database;
     messaging(): admin.messaging.Messaging;
+    storage(): admin.storage.Storage;
     delete(): Promise<void>;
   }
 }
@@ -351,6 +353,15 @@ declare namespace admin.messaging {
       registrationTokens: string[],
       topic: string
     ): Promise<admin.messaging.MessagingTopicManagementResponse>;
+  }
+}
+
+declare namespace admin.storage {
+  interface Storage {
+    app: admin.app.App;
+
+    // TODO: add stricter type
+    bucket: any;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as firebase from './default-namespace';
 import registerAuth from './auth/register-auth';
+import registerStorage from './storage/register-storage';
 import registerMessaging from './messaging/register-messaging';
 
 // Register the Database service
@@ -14,5 +15,8 @@ registerAuth();
 
 // Register the Messaging service
 registerMessaging();
+
+// Register the Storage service
+registerStorage();
 
 export = firebase;

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -246,7 +246,7 @@ function mapRawResponseToTopicManagementResponse(response): MessagingTopicManage
 /**
  * Internals of a Messaging instance.
  */
-export class MessagingInternals implements FirebaseServiceInternalsInterface {
+class MessagingInternals implements FirebaseServiceInternalsInterface {
   /**
    * Deletes the service and its associated resources.
    *
@@ -262,7 +262,7 @@ export class MessagingInternals implements FirebaseServiceInternalsInterface {
 /**
  * Messaging service bound to the provided app.
  */
-class Messaging implements FirebaseServiceInterface {
+export class Messaging implements FirebaseServiceInterface {
   public INTERNAL: MessagingInternals = new MessagingInternals();
 
   private appInternal: FirebaseApp;
@@ -926,8 +926,3 @@ class Messaging implements FirebaseServiceInterface {
     return topic;
   }
 };
-
-
-export {
-  Messaging,
-}

--- a/src/storage/register-storage.ts
+++ b/src/storage/register-storage.ts
@@ -1,0 +1,36 @@
+import {Storage} from './storage';
+import {AppHook, FirebaseApp} from '../firebase-app';
+import {FirebaseServiceInterface} from '../firebase-service';
+import * as firebase from '../default-namespace';
+import {FirebaseServiceNamespace} from '../firebase-namespace';
+
+/**
+ * Factory function that creates a new Storage service.
+ *
+ * @param {Object} app The app for this service.
+ * @param {function(Object)} extendApp An extend function to extend the app namespace.
+ *
+ * @return {Storage} The Storage service for the specified app.
+ */
+function serviceFactory(app: FirebaseApp, extendApp: (props: Object) => void): FirebaseServiceInterface {
+  return new Storage(app);
+}
+
+/**
+ * Handles app life-cycle events.
+ *
+ * @param {string} event The app event that is occurring.
+ * @param {FirebaseApp} app The app for which the app hook is firing.
+ */
+let appHook: AppHook = (event: string, app: FirebaseApp) => {
+  return;
+};
+
+export default function(): FirebaseServiceNamespace<FirebaseServiceInterface> {
+  return firebase.INTERNAL.registerService(
+    'storage',
+    serviceFactory,
+    {Storage},
+    appHook
+  );
+}

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,0 +1,88 @@
+import * as storage from '@google-cloud/storage';
+
+import {FirebaseApp} from '../firebase-app';
+import {FirebaseError} from '../utils/error';
+import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
+
+import * as validator from '../utils/validator';
+
+/**
+ * Internals of a Storage instance.
+ */
+class StorageInternals implements FirebaseServiceInternalsInterface {
+  /**
+   * Deletes the service and its associated resources.
+   *
+   * @return {Promise<()>} An empty Promise that will be fulfilled when the service is deleted.
+   */
+  public delete(): Promise<void> {
+    // There are no resources to clean up.
+    return Promise.resolve(undefined);
+  }
+}
+
+/**
+ * Storage service bound to the provided app.
+ */
+export class Storage implements FirebaseServiceInterface {
+  public INTERNAL: StorageInternals = new StorageInternals();
+
+  // TODO: get stricter type for this; check if gcloud export TypeScript types
+  public bucket: any;
+
+  private appInternal: FirebaseApp;
+
+  /**
+   * @param {Object} app The app for this Storage service.
+   * @constructor
+   */
+  constructor(app: FirebaseApp) {
+    if (!validator.isNonNullObject(app) || !('options' in app)) {
+      // TODO: create FirebaseStorageError and StorageClientErrorCode type
+      // throw new FirebaseStorageError(
+      //   StorageClientErrorCode.INVALID_ARGUMENT,
+      //   'First argument passed to admin.storage() must be a valid Firebase app instance.'
+      // );
+
+      throw new FirebaseError({
+        code: 'storage/invalid-argument',
+        message: 'First argument passed to admin.storage() must be a valid Firebase app instance.',
+      });
+    }
+
+    // TODO: properly validate storageBucket option (although maybe this should be done in the
+    //       FirebaseApp constructor instead?)
+    // if (!validator.isNonEmptyString(app.options.storageBucket)) {
+    // }
+
+    const cert = app.options.credential.getCertificate();
+
+    const gcs = storage({
+      // TODO: as far as I can tell, this is not required...
+      // projectId: cert.projectId,
+
+      // TODO: this will only work for cert credential; need to figure out a way to authenticate
+      //       gcloud via our existing credentials.
+      // Relevant code:
+      //       https://github.com/GoogleCloudPlatform/google-cloud-node/blob/
+      //       895529e11318bb849777cf9fa94e7117e5b3b203/packages/common/src/util.js#L326
+      credentials: {
+        private_key: cert.privateKey,
+        client_email: cert.clientEmail,
+      },
+    });
+
+    this.bucket = gcs.bucket(app.options.storageBucket);
+
+    this.appInternal = app;
+  }
+
+  /**
+   * Returns the app associated with this Storage instance.
+   *
+   * @return {FirebaseApp} The app associated with this Storage instance.
+   */
+  get app(): FirebaseApp {
+    return this.appInternal;
+  }
+};

--- a/storageTestRunner.js
+++ b/storageTestRunner.js
@@ -4,7 +4,6 @@ var serviceAccount = require('./test/resources/key.json');
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: 'https://admin-sdks-test.firebaseio.com',
   storageBucket: 'admin-sdks-test.appspot.com',
 });
 

--- a/storageTestRunner.js
+++ b/storageTestRunner.js
@@ -1,0 +1,19 @@
+var admin = require('./lib/index');
+
+var serviceAccount = require('./test/resources/key.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://admin-sdks-test.firebaseio.com',
+  storageBucket: 'admin-sdks-test.appspot.com',
+});
+
+admin.storage().bucket.file('firebase.png').download({
+  destination: './firebase.png'
+}, function(error) {
+  if (error) {
+    console.log('Error downloading file:', error);
+  } else {
+    console.log('File successfully downloaded!');
+  }
+});


### PR DESCRIPTION
Restoring #14 

### Description

Still very much a WIP, but this is a prototype which adds GCS support via `admin.storage()`. `admin.storage().bucket` exports the [standard GCS `Bucket` API](https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.0.0/storage/bucket).

Initialization of the underlying `google-cloud` SDK is probably going to be a bit tricky since they don't provide a standard credential interface like our SDK does which allows you to provide your own Google OAuth2 access tokens. But we can make it work without too much effort via  the certificate credential (which this PR does) and via the Application Default Credential (which this PR does not do). I'm still not sure how we will make it work using a refresh token credential since we don't have the right fields that the `google-cloud` SDK provides as initialization options (see the table in "Advanced Usage" [here](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/v0.51.1/google-cloud?method=gcloud)).

I didn't do anything for multi-bucket support although it shouldn't be too bad to support.

cc/ @mcdonamp, @sphippen, @hiranya911, @depoll

### Code sample

```
var admin = require('firebase-admin');

var serviceAccount = require('./path/to/key.json');

admin.initializeApp({
  credential: admin.credential.cert(serviceAccount),
  storageBucket: 'admin-sdks-test.appspot.com',
});

admin.storage().bucket.file('firebase.png').download({
  destination: './firebase.png'
}, function(error) {
  if (error) {
    console.log('Error downloading file:', error);
  } else {
    console.log('File successfully downloaded!');
  }
});
```

