### PR TITLE
Supporting % characters in the URL path

### DIFF
--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -161,8 +161,8 @@ export function isURL(urlStr: any): boolean {
       return false;
     }
     // Allow for pathnames: (/chars+)*
-    // Where chars can be a combination of: a-z A-Z 0-9 - _ . ~ ! $ & ' ( ) * + , ; = : @
-    let pathnameRe = /^(\/[\w\-\.\~\!\$\'\(\)\*\+\,\;\=\:\@]+)*$/;
+    // Where chars can be a combination of: a-z A-Z 0-9 - _ . ~ ! $ & ' ( ) * + , ; = : @ %
+    let pathnameRe = /^(\/[\w\-\.\~\!\$\'\(\)\*\+\,\;\=\:\@\%]+)*$/;
     // Validate pathname.
     if (pathname &&
         pathname !== '/' &&

--- a/test/unit/utils/validator.spec.ts
+++ b/test/unit/utils/validator.spec.ts
@@ -356,6 +356,13 @@ describe('isURL()', () => {
     expect(isURL('http://localhost/path/name/index.php?a=1&b=2&c=3#abcd')).to.be.true;
     expect(isURL('http://127.0.0.1/path/name/index.php?a=1&b=2&c=3#abcd')).to.be.true;
     expect(isURL('http://a--b.c-c.co-uk/')).to.be.true;
+    expect(isURL('https://storage.googleapis.com/example-bucket/cat%20pic.jpeg?GoogleAccessId=e@' +
+      'example-project.iam.gserviceaccount.com&Expires=1458238630&Signature=VVUgfqviDCov%2B%2BKn' +
+      'mVOkwBR2olSbId51kSibuQeiH8ucGFyOfAVbH5J%2B5V0gDYIioO2dDGH9Fsj6YdwxWv65HE71VEOEsVPuS8CVb%2' +
+      'BVeeIzmEe8z7X7o1d%2BcWbPEo4exILQbj3ROM3T2OrkNBU9sbHq0mLbDMhiiQZ3xCaiCQdsrMEdYVvAFggPuPq%2' +
+      'FEQyQZmyJK3ty%2Bmr7kAFW16I9pD11jfBSD1XXjKTJzgd%2FMGSde4Va4J1RtHoX7r5i7YR7Mvf%2Fb17zlAuGlz' +
+      'VUf%2FzmhLPqtfKinVrcqdlmamMcmLoW8eLG%2B1yYW%2F7tlS2hvqSfCW8eMUUjiHiSWgZLEVIG4Lw%3D%3D'))
+      .to.be.true;
   });
 
   it('should return false with an invalid web URL string', () => {


### PR DESCRIPTION
Support for handling URLs with `%` signs in path. For example:

`https://test.com/foo%20bar`

Fix for #40 