### PR TITLE
Updating the DB rules to the defaults before running integration tests

### DIFF
--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -26,6 +26,9 @@ var auth = require('./auth');
 var database = require('./database');
 var messaging = require('./messaging');
 
+var apiRequest = require('../../lib/utils/api-request');
+var url = require('url');
+
 var serviceAccount = utils.getCredential();
 var databaseURL = 'https://' + utils.getProjectId() + '.firebaseio.com';
 
@@ -75,8 +78,26 @@ utils.assert(
   'App instances do not match.'
 );
 
+function updateRules() {
+  // Update database rules to the defaults. Rest of the test suite
+  // expects it.
+  const client = new apiRequest.SignedApiRequestHandler(defaultApp);
+  const dbUrl =  url.parse(defaultApp.options.databaseURL);
+  const defaultRules = {
+    rules : {
+      '.read': 'auth != null',
+      '.write': 'auth != null',
+    }
+  }
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+  return client.sendRequest(dbUrl.host, 443, '/.settings/rules.json', 
+    'PUT', defaultRules, headers, 10000);
+}
 
 return Promise.resolve()
+  .then(updateRules)
   .then(_.partial(app.test, utils))
   .then(_.partial(auth.test, utils))
   .then(_.partial(database.test, utils))

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -87,11 +87,11 @@ function updateRules() {
     rules : {
       '.read': 'auth != null',
       '.write': 'auth != null',
-    }
-  }
+    },
+  };
   const headers = {
     'Content-Type': 'application/json',
-  }
+  };
   return client.sendRequest(dbUrl.host, 443, '/.settings/rules.json', 
     'PUT', defaultRules, headers, 10000);
 }


### PR DESCRIPTION
Integration test suite expects default security rules. Therefore it should update the rules accordingly before running tests to avoid false positives.

See #48 