### PR TITLE
Implements phone auth support for Admin node.js SDK.

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -164,6 +164,21 @@ class Auth implements FirebaseServiceInterface {
   };
 
   /**
+   * Looks up the user identified by the provided phone number and returns a promise that is
+   * fulfilled with a user record for the given user if that user is found.
+   *
+   * @param {string} phoneNumber The phone number of the user to look up.
+   * @return {Promise<UserRecord>} A promise that resolves with the corresponding user record.
+   */
+  public getUserByPhoneNumber(phoneNumber: string): Promise<UserRecord> {
+    return this.authRequestHandler.getAccountInfoByPhoneNumber(phoneNumber)
+      .then((response: any) => {
+        // Returns the user record populated with server response.
+        return new UserRecord(response.users[0]);
+      });
+  };
+
+  /**
    * Creates a new user with the properties provided.
    *
    * @param {Object} properties The properties to set on the new user record to be created.

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -80,6 +80,7 @@ export class UserInfo {
   public readonly email: string;
   public readonly photoURL: string;
   public readonly providerId: string;
+  public readonly phoneNumber: string;
 
   constructor(response: any) {
     // Provider user id and provider id are required.
@@ -94,6 +95,7 @@ export class UserInfo {
     utils.addReadonlyGetter(this, 'email', response.email);
     utils.addReadonlyGetter(this, 'photoURL', response.photoUrl);
     utils.addReadonlyGetter(this, 'providerId', response.providerId);
+    utils.addReadonlyGetter(this, 'phoneNumber', response.phoneNumber);
   }
 
   /** @return {Object} The plain object representation of the current provider data. */
@@ -104,6 +106,7 @@ export class UserInfo {
       email: this.email,
       photoURL: this.photoURL,
       providerId: this.providerId,
+      phoneNumber: this.phoneNumber,
     };
   }
 }
@@ -122,6 +125,7 @@ export class UserRecord {
   public readonly emailVerified: boolean;
   public readonly displayName: string;
   public readonly photoURL: string;
+  public readonly phoneNumber: string;
   public readonly disabled: boolean;
   public readonly metadata: UserMetadata;
   public readonly providerData: UserInfo[];
@@ -139,6 +143,7 @@ export class UserRecord {
     utils.addReadonlyGetter(this, 'emailVerified', !!response.emailVerified);
     utils.addReadonlyGetter(this, 'displayName', response.displayName);
     utils.addReadonlyGetter(this, 'photoURL', response.photoUrl);
+    utils.addReadonlyGetter(this, 'phoneNumber', response.phoneNumber);
     // If disabled is not provided, the account is enabled by default.
     utils.addReadonlyGetter(this, 'disabled', response.disabled || false);
     utils.addReadonlyGetter(this, 'metadata', new UserMetadata(response));
@@ -157,6 +162,7 @@ export class UserRecord {
       emailVerified: this.emailVerified,
       displayName: this.displayName,
       photoURL: this.photoURL,
+      phoneNumber: this.phoneNumber,
       disabled: this.disabled,
       // Convert metadata to json.
       metadata: this.metadata.toJSON(),

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -80,6 +80,7 @@ declare namespace admin.auth {
     uid: string;
     displayName: string;
     email: string;
+    phoneNumber: string;
     photoURL: string;
     providerId: string;
 
@@ -91,6 +92,7 @@ declare namespace admin.auth {
     email: string;
     emailVerified: boolean;
     displayName: string;
+    phoneNumber: string;
     photoURL: string;
     disabled: boolean;
     metadata: admin.auth.UserMetadata;
@@ -125,6 +127,7 @@ declare namespace admin.auth {
     deleteUser(uid: string): Promise<void>;
     getUser(uid: string): Promise<admin.auth.UserRecord>;
     getUserByEmail(email: string): Promise<admin.auth.UserRecord>;
+    getUserByPhoneNumber(phoneNumber: string): Promise<admin.auth.UserRecord>;
     updateUser(uid: string, properties: Object): Promise<admin.auth.UserRecord>;
     verifyIdToken(idToken: string): Promise<admin.auth.DecodedIdToken>;
   }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -235,6 +235,11 @@ export class AuthClientErrorCode {
     code: 'invalid-password',
     message: 'The password must be a string with at least 6 characters.',
   };
+  public static INVALID_PHONE_NUMBER = {
+    code: 'invalid-phone-number',
+    message: 'The phone number must be a non-empty E.164 standard compliant identifier ' +
+      'string.',
+  };
   public static INVALID_PHOTO_URL = {
     code: 'invalid-photo-url',
     message: 'The photoURL field must be a valid URL.',
@@ -252,6 +257,10 @@ export class AuthClientErrorCode {
     message: 'The given sign-in provider is disabled for this Firebase project. ' +
         'Enable it in the Firebase console, under the sign-in method tab of the ' +
         'Auth section.',
+  };
+  public static PHONE_NUMBER_ALREADY_EXISTS = {
+    code: 'phone-number-already-exists',
+    message: 'The user with the provided phone number already exists.',
   };
   public static PROJECT_NOT_FOUND = {
     code: 'project-not-found',
@@ -382,6 +391,8 @@ const AUTH_SERVER_TO_CLIENT_CODE: ServerToClientCode = {
   EMAIL_EXISTS: 'EMAIL_ALREADY_EXISTS',
   // Invalid email provided.
   INVALID_EMAIL: 'INVALID_EMAIL',
+  // Invalid phone number.
+  INVALID_PHONE_NUMBER: 'INVALID_PHONE_NUMBER',
   // Invalid service account.
   INVALID_SERVICE_ACCOUNT: 'INVALID_SERVICE_ACCOUNT',
   // No localId provided (deleteAccount missing localId).
@@ -390,6 +401,8 @@ const AUTH_SERVER_TO_CLIENT_CODE: ServerToClientCode = {
   MISSING_USER_ACCOUNT: 'MISSING_UID',
   // Password auth disabled in console.
   OPERATION_NOT_ALLOWED: 'OPERATION_NOT_ALLOWED',
+  // Phone number already exists.
+  PHONE_NUMBER_EXISTS: 'PHONE_NUMBER_ALREADY_EXISTS',
   // Project not found.
   PROJECT_NOT_FOUND: 'PROJECT_NOT_FOUND',
   // User on which action is to be performed is not found.

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -132,6 +132,27 @@ export function isEmail(email: any): boolean {
 
 
 /**
+ * Validates that a string is a valid phone number.
+ *
+ * @param {any} phoneNumber The string to validate.
+ * @return {boolean} Whether the string is a valid phone number or not.
+ */
+export function isPhoneNumber(phoneNumber: any): boolean {
+  if (typeof phoneNumber !== 'string') {
+    return false;
+  }
+  // Phone number validation is very lax here. Backend will enforce E.164
+  // spec compliance and will normalize accordingly.
+  // The phone number string must be non-empty and starts with a plus sign.
+  let re1 = /^\+/;
+  // The phone number string must contain at least one alphanumeric character.
+  let re2 = /[\da-zA-Z]+/;
+  return re1.test(phoneNumber) && re2.test(phoneNumber);
+}
+
+
+
+/**
  * Validates that a string is a valid web URL.
  *
  * @param {any} urlStr The string to validate.

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -82,7 +82,7 @@ function test(utils) {
     ];
     return Promise.all(promises)
       .catch(function(error) {
-        utils.logFailure('setUp()', error);
+        utils.logFailure('before()', error);
       });
   }
 

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -33,23 +33,75 @@ function test(utils) {
 
   var newUserUid = utils.generateRandomString(20);
   var nonexistentUid = utils.generateRandomString(20);
+  var testPhoneNumber = '+11234567890';
+  var testPhoneNumber2 = '+16505550101';
+  var nonexistentPhoneNumber = '+18888888888';
+  var updatedEmail = utils.generateRandomString(20) + '@example.com';
+  var updatedPhone = '+16505550102';
 
   var mockUserData = {
     email: newUserUid + '@example.com',
     emailVerified: false,
+    phoneNumber: testPhoneNumber,
     password: 'password',
     displayName: 'Random User ' + newUserUid,
     photoURL: 'http://www.example.com/' + newUserUid + '/photo.png',
     disabled: false,
   };
 
+  /**
+   * Helper function that deletes the user with the specified phone number
+   * if it exists.
+   * @param {string} phoneNumber The phone number of the user to delete.
+   * @return {Promise} A promise that resolves when the user is deleted
+   *     or is found not to exist.
+   */
+  function deletePhoneNumberUser(phoneNumber) {
+    return admin.auth().getUserByPhoneNumber(phoneNumber)
+      .then(function(userRecord) {
+        return admin.auth().deleteUser(userRecord.uid);
+      })
+      .catch(function(error) {
+        // Suppress user not found error.
+        if (error.code !== 'auth/user-not-found') {
+          throw error;
+        }
+      });
+  }
+
+  /**
+   * @return {Promise} A promise that resolves when test preparations are ready.
+   */
+  function before() {
+    // Delete any existing users that could affect the test outcome.
+    var promises = [
+      deletePhoneNumberUser(testPhoneNumber),
+      deletePhoneNumberUser(testPhoneNumber2),
+      deletePhoneNumberUser(nonexistentPhoneNumber),
+      deletePhoneNumberUser(updatedPhone)
+    ];
+    return Promise.all(promises)
+      .catch(function(error) {
+        utils.logFailure('setUp()', error);
+      });
+  }
+
   function testCreateUserWithoutUid() {
     var newUserData = _.clone(mockUserData);
     newUserData.email = utils.generateRandomString(20) + '@example.com';
+    newUserData.phoneNumber = testPhoneNumber2;
     return admin.auth().createUser(newUserData)
       .then(function(userRecord) {
         uidFromCreateUserWithoutUid = userRecord.uid;
         utils.assert(typeof userRecord.uid === 'string', 'auth().createUser(noUid)', 'Incorrect uid type.');
+        // Confirm expected email.
+        utils.assert(
+          userRecord.email === newUserData.email.toLowerCase(),
+          'auth().createUser(noUid)', 'Incorrect email.');
+        // Confirm expected phone number.
+        utils.assert(
+          userRecord.phoneNumber === newUserData.phoneNumber,
+          'auth().createUser(noUid)', 'Incorrect phone.');
       })
       .catch(function(error) {
         utils.logFailure('auth().createUser(noUid)', error);
@@ -62,6 +114,14 @@ function test(utils) {
     return admin.auth().createUser(newUserData)
       .then(function(userRecord) {
         utils.assert(userRecord.uid === newUserUid, 'auth().createUser(withUid)', 'Incorrect uid.');
+        // Confirm expected email.
+        utils.assert(
+          userRecord.email === newUserData.email.toLowerCase(),
+          'auth().createUser(withUid)', 'Incorrect email.');
+        // Confirm expected phone number.
+        utils.assert(
+          userRecord.phoneNumber === newUserData.phoneNumber,
+          'auth().createUser(withUid)', 'Incorrect phone.');
       })
       .catch(function(error) {
         utils.logFailure('auth().createUser(withUid)', error);
@@ -104,10 +164,22 @@ function test(utils) {
       });
   }
 
+  function testGetUserByPhoneNumber() {
+    return admin.auth().getUserByPhoneNumber(mockUserData.phoneNumber)
+      .then(function(userRecord) {
+        utils.assert(userRecord.uid === newUserUid, 'auth().getUserByPhoneNumber()', 'Incorrect uid.');
+      })
+      .catch(function(error) {
+        utils.logFailure('auth().getUserByPhoneNumber()', error);
+      });
+  }
+
   function testUpdateUser() {
     var updatedDisplayName = 'Updated User ' + newUserUid;
 
     return admin.auth().updateUser(newUserUid, {
+      email: updatedEmail,
+      phoneNumber: updatedPhone,
       emailVerified: true,
       displayName: updatedDisplayName,
     })
@@ -117,6 +189,13 @@ function test(utils) {
           'auth().updateUser()',
           'Incorrect emailVerified or displayName.'
         );
+        // Confirm expected email.
+        utils.assert(
+          userRecord.email === updatedEmail.toLowerCase(),
+          'auth().updateUser()', 'Incorrect email.');
+        // Confirm expected phone number.
+        utils.assert(
+          userRecord.phoneNumber === updatedPhone, 'auth().updateUser()', 'Incorrect phone.');
       })
       .catch(function(error) {
         utils.logFailure('auth().updateUser()', error);
@@ -159,6 +238,21 @@ function test(utils) {
         utils.assert(
           error.code === 'auth/user-not-found',
           'auth().getUserEmail(nonexistentEmail)',
+          'Incorrect error code: ' + error.code
+        );
+      });
+  }
+
+  function testGetNonexistentUserByPhoneNumberWithError() {
+    return admin.auth().getUserByPhoneNumber(nonexistentPhoneNumber)
+      .then(function() {
+        utils.logFailure(
+          'auth().getUserByPhoneNumber(nonexistentPhoneNumber)', 'User unexpectedly returned.');
+      })
+      .catch(function(error) {
+        utils.assert(
+          error.code === 'auth/user-not-found',
+          'auth().getUserByPhoneNumber(nonexistentPhoneNumber)',
           'Incorrect error code: ' + error.code
         );
       });
@@ -234,15 +328,17 @@ function test(utils) {
   }
 
 
-  return Promise.resolve()
+  return before()
     .then(testCreateUserWithoutUid)
     .then(testCreateUserWithUid)
     .then(testCreateDuplicateUserWithError)
     .then(testGetUser)
     .then(testGetUserByEmail)
+    .then(testGetUserByPhoneNumber)
     .then(testUpdateUser)
     .then(testGetNonexistentUserWithError)
     .then(testGetNonexistentUserByEmailWithError)
+    .then(testGetNonexistentUserByPhoneNumberWithError)
     .then(testUpdateNonexistentUserWithError)
     .then(testDeleteNonexistentUserWithError)
     .then(testCreateCustomToken)

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -64,7 +64,13 @@ describe('FIREBASE_AUTH_GET_ACCOUNT_INFO', () => {
         return requestValidator(validRequest);
       }).not.to.throw();
     });
-    it('should fail when localId and email not passed', () => {
+    it('should succeed with phoneNumber passed', () => {
+      const validRequest = {phoneNumber: ['+11234567890']};
+      expect(() => {
+        return requestValidator(validRequest);
+      }).not.to.throw();
+    });
+    it('should fail when neither localId, email or phoneNumber are passed', () => {
       const invalidRequest = {bla: ['1234']};
       expect(() => {
         return requestValidator(invalidRequest);
@@ -126,18 +132,21 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
   let isEmailSpy: sinon.SinonSpy;
   let isPasswordSpy: sinon.SinonSpy;
   let isUrlSpy: sinon.SinonSpy;
+  let isPhoneNumberSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     isUidSpy = sinon.spy(validator, 'isUid');
     isEmailSpy = sinon.spy(validator, 'isEmail');
     isPasswordSpy = sinon.spy(validator, 'isPassword');
     isUrlSpy = sinon.spy(validator, 'isURL');
+    isPhoneNumberSpy = sinon.spy(validator, 'isPhoneNumber');
   });
   afterEach(() => {
     isUidSpy.restore();
     isEmailSpy.restore();
     isPasswordSpy.restore();
     isUrlSpy.restore();
+    isPhoneNumberSpy.restore();
   });
 
   it('should return the correct endpoint', () => {
@@ -164,6 +173,7 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
         emailVerified: true,
         photoUrl: 'http://www.example.com/1234/photo.png',
         disableUser: false,
+        phoneNumber: '+11234567890',
         // Pass an unsupported parameter which should be ignored.
         ignoreMe: 'bla',
       };
@@ -175,6 +185,7 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
       expect(isPasswordSpy).to.have.been.calledOnce.and.calledWith('password');
       expect(isUrlSpy).to.have.been.calledOnce.and
         .calledWith('http://www.example.com/1234/photo.png');
+      expect(isPhoneNumberSpy).to.have.been.calledOnce.and.calledWith('+11234567890');
     });
     it('should fail when localId not passed', () => {
       const invalidRequest = {};
@@ -223,6 +234,12 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
           return requestValidator({localId: '1234', disableUser: 'no'});
         }).to.throw();
       });
+      it('should fail with invalid phoneNumber', () => {
+        expect(() => {
+          return requestValidator({localId: '1234', phoneNumber: 'invalid'});
+        }).to.throw();
+        expect(isPhoneNumberSpy).to.have.been.calledOnce.and.calledWith('invalid');
+      });
     });
   });
   describe('responseValidator', () => {
@@ -248,18 +265,21 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
   let isEmailSpy: sinon.SinonSpy;
   let isPasswordSpy: sinon.SinonSpy;
   let isUrlSpy: sinon.SinonSpy;
+  let isPhoneNumberSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     isUidSpy = sinon.spy(validator, 'isUid');
     isEmailSpy = sinon.spy(validator, 'isEmail');
     isPasswordSpy = sinon.spy(validator, 'isPassword');
     isUrlSpy = sinon.spy(validator, 'isURL');
+    isPhoneNumberSpy = sinon.spy(validator, 'isPhoneNumber');
   });
   afterEach(() => {
     isUidSpy.restore();
     isEmailSpy.restore();
     isPasswordSpy.restore();
     isUrlSpy.restore();
+    isPhoneNumberSpy.restore();
   });
 
   it('should return the correct endpoint', () => {
@@ -278,6 +298,7 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
         emailVerified: true,
         photoUrl: 'http://www.example.com/1234/photo.png',
         disabled: false,
+        phoneNumber: '+11234567890',
         // Pass an unsupported parameter which should be ignored.
         ignoreMe: 'bla',
       };
@@ -289,6 +310,7 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
       expect(isPasswordSpy).to.have.been.calledOnce.and.calledWith('password');
       expect(isUrlSpy).to.have.been.calledOnce.and
         .calledWith('http://www.example.com/1234/photo.png');
+      expect(isPhoneNumberSpy).to.have.been.calledOnce.and.calledWith('+11234567890');
     });
     it('should succeed with valid parameters including uid', () => {
       const validRequest = {
@@ -299,6 +321,7 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
         emailVerified: true,
         photoUrl: 'http://www.example.com/1234/photo.png',
         disabled: false,
+        phoneNumber: '+11234567890',
         // Pass an unsupported parameter which should be ignored.
         ignoreMe: 'bla',
       };
@@ -310,6 +333,7 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
       expect(isPasswordSpy).to.have.been.calledOnce.and.calledWith('password');
       expect(isUrlSpy).to.have.been.calledOnce.and
         .calledWith('http://www.example.com/1234/photo.png');
+      expect(isPhoneNumberSpy).to.have.been.calledOnce.and.calledWith('+11234567890');
     });
     it('should succeed with no parameters', () => {
       expect(() => {
@@ -355,6 +379,12 @@ describe('FIREBASE_AUTH_SIGN_UP_NEW_USER', () => {
         expect(() => {
           return requestValidator({disabled: 'no'});
         }).to.throw();
+      });
+      it('should fail with invalid phoneNumber', () => {
+        expect(() => {
+          return requestValidator({phoneNumber: 'invalid'});
+        }).to.throw();
+        expect(isPhoneNumberSpy).to.have.been.calledOnce.and.calledWith('invalid');
       });
     });
   });
@@ -674,6 +704,7 @@ describe('FirebaseAuthRequestHandler', () => {
       disabled: false,
       photoURL: 'http://localhost/1234/photo.png',
       password: 'password',
+      phoneNumber: '+11234567890',
       ignoredProperty: 'value',
     };
     const expectedValidData = {
@@ -684,6 +715,7 @@ describe('FirebaseAuthRequestHandler', () => {
       disableUser: false,
       photoUrl: 'http://localhost/1234/photo.png',
       password: 'password',
+      phoneNumber: '+11234567890',
     };
     // Valid request to delete photoURL and displayName.
     const validDeleteData = deepCopy(validData);
@@ -695,11 +727,29 @@ describe('FirebaseAuthRequestHandler', () => {
       emailVerified: true,
       disableUser: false,
       password: 'password',
+      phoneNumber: '+11234567890',
       deleteAttribute: ['DISPLAY_NAME', 'PHOTO_URL'],
+    };
+    // Valid request to delete phoneNumber.
+    const validDeletePhoneNumberData = deepCopy(validData);
+    validDeletePhoneNumberData.phoneNumber = null;
+    const expectedValidDeletePhoneNumberData = {
+      localId: uid,
+      displayName: 'John Doe',
+      email: 'user@example.com',
+      emailVerified: true,
+      disableUser: false,
+      photoUrl: 'http://localhost/1234/photo.png',
+      password: 'password',
+      deleteProvider: ['phone'],
     };
     const invalidData = {
       uid,
       email: 'user@invalid@',
+    };
+    const invalidPhoneNumberData = {
+      uid,
+      phoneNumber: 'invalid',
     };
 
     it('should be fulfilled given a valid localId', () => {
@@ -748,7 +798,7 @@ describe('FirebaseAuthRequestHandler', () => {
         });
     });
 
-    it('should be fulfilled given valid paramaters to delete', () => {
+    it('should be fulfilled given valid profile paramaters to delete', () => {
       // Successful result server response.
       const expectedResult = {
         kind: 'identitytoolkit#SetAccountInfoResponse',
@@ -772,7 +822,32 @@ describe('FirebaseAuthRequestHandler', () => {
         });
     });
 
-    it('should be rejected given invalid parameters', () => {
+    it('should be fulfilled given phone number to delete', () => {
+      // Successful result server response.
+      const expectedResult = {
+        kind: 'identitytoolkit#SetAccountInfoResponse',
+        localId: uid,
+      };
+
+      let stub = sinon.stub(HttpRequestHandler.prototype, 'sendRequest')
+        .returns(Promise.resolve(expectedResult));
+      stubs.push(stub);
+
+      const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+      // Send update request to delete phone number.
+      return requestHandler.updateExistingAccount(uid, validDeletePhoneNumberData)
+        .then((returnedUid: string) => {
+          // uid should be returned.
+          expect(returnedUid).to.be.equal(uid);
+          // Confirm expected rpc request parameters sent. In this case, phoneNumber
+          // removed from request and deleteProvider added.
+          expect(stub).to.have.been.calledOnce.and.calledWith(
+              host, port, path, httpMethod, expectedValidDeletePhoneNumberData, expectedHeaders,
+              timeout);
+        });
+    });
+
+    it('should be rejected given invalid parameters such as email', () => {
       // Expected error when an invalid email is provided.
       const expectedError = new FirebaseAuthError(AuthClientErrorCode.INVALID_EMAIL);
       const requestHandler = new FirebaseAuthRequestHandler(mockApp);
@@ -782,6 +857,20 @@ describe('FirebaseAuthRequestHandler', () => {
           throw new Error('Unexpected success');
         }, (error) => {
           // Invalid email error should be thrown.
+          expect(error).to.deep.equal(expectedError);
+        });
+    });
+
+    it('should be rejected given invalid parameters such as phoneNumber', () => {
+      // Expected error when an invalid phone number is provided.
+      const expectedError = new FirebaseAuthError(AuthClientErrorCode.INVALID_PHONE_NUMBER);
+      const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+      // Send update request with invalid phone number.
+      return requestHandler.updateExistingAccount(uid, invalidPhoneNumberData)
+        .then((returnedUid: string) => {
+          throw new Error('Unexpected success');
+        }, (error) => {
+          // Invalid phone number error should be thrown.
           expect(error).to.deep.equal(expectedError);
         });
     });
@@ -827,6 +916,7 @@ describe('FirebaseAuthRequestHandler', () => {
         disabled: false,
         photoURL: 'http://localhost/1234/photo.png',
         password: 'password',
+        phoneNumber: '+11234567890',
         ignoredProperty: 'value',
       };
       const expectedValidData = {
@@ -837,10 +927,15 @@ describe('FirebaseAuthRequestHandler', () => {
         disabled: false,
         photoUrl: 'http://localhost/1234/photo.png',
         password: 'password',
+        phoneNumber: '+11234567890',
       };
       const invalidData = {
         uid,
         email: 'user@invalid@',
+      };
+      const invalidPhoneNumberData = {
+        uid,
+        phoneNumber: 'invalid',
       };
       const emptyRequest = {
         localId: uid,
@@ -890,7 +985,7 @@ describe('FirebaseAuthRequestHandler', () => {
           });
       });
 
-      it('should be rejected given invalid parameters', () => {
+      it('should be rejected given invalid parameters such as email', () => {
         // Expected error when an invalid email is provided.
         const expectedError = new FirebaseAuthError(AuthClientErrorCode.INVALID_EMAIL);
         const requestHandler = new FirebaseAuthRequestHandler(mockApp);
@@ -900,6 +995,20 @@ describe('FirebaseAuthRequestHandler', () => {
             throw new Error('Unexpected success');
           }, (error) => {
             // Expected invalid email error should be thrown.
+            expect(error).to.deep.equal(expectedError);
+          });
+      });
+
+      it('should be rejected given invalid parameters such as phoneNumber', () => {
+        // Expected error when an invalid phone number is provided.
+        const expectedError = new FirebaseAuthError(AuthClientErrorCode.INVALID_PHONE_NUMBER);
+        const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+        // Create new account with invalid phone number.
+        return requestHandler.createNewAccount(invalidPhoneNumberData)
+          .then((returnedUid: string) => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            // Expected invalid phone number error should be thrown.
             expect(error).to.deep.equal(expectedError);
           });
       });
@@ -996,6 +1105,7 @@ describe('FirebaseAuthRequestHandler', () => {
         disabled: false,
         photoURL: 'http://localhost/1234/photo.png',
         password: 'password',
+        phoneNumber: '+11234567890',
         ignoredProperty: 'value',
       };
       const expectedValidData = {
@@ -1005,9 +1115,14 @@ describe('FirebaseAuthRequestHandler', () => {
         disabled: false,
         photoUrl: 'http://localhost/1234/photo.png',
         password: 'password',
+        phoneNumber: '+11234567890',
       };
       const invalidData = {
         email: 'user@invalid@',
+      };
+      const invalidPhoneNumberData = {
+        uid,
+        phoneNumber: 'invalid',
       };
 
       it('should be fulfilled given valid parameters', () => {
@@ -1033,13 +1148,27 @@ describe('FirebaseAuthRequestHandler', () => {
           });
       });
 
-      it('should be rejected given invalid parameters', () => {
+      it('should be rejected given invalid parameters such as email', () => {
         // Expected error when an invalid email is provided.
         const expectedError =
           new FirebaseAuthError(AuthClientErrorCode.INVALID_EMAIL);
         const requestHandler = new FirebaseAuthRequestHandler(mockApp);
         // Send create new account request with invalid data.
         return requestHandler.createNewAccount(invalidData)
+          .then((returnedUid: string) => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            expect(error).to.deep.equal(expectedError);
+          });
+      });
+
+      it('should be rejected given invalid parameters such as phone number', () => {
+        // Expected error when an invalid phone number is provided.
+        const expectedError =
+          new FirebaseAuthError(AuthClientErrorCode.INVALID_PHONE_NUMBER);
+        const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+        // Send create new account request with invalid data.
+        return requestHandler.createNewAccount(invalidPhoneNumberData)
           .then((returnedUid: string) => {
             throw new Error('Unexpected success');
           }, (error) => {

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -534,6 +534,85 @@ describe('FirebaseAuthRequestHandler', () => {
     });
   });
 
+  describe('getAccountInfoByPhoneNumber', () => {
+    const httpMethod = 'POST';
+    const host = 'www.googleapis.com';
+    const port = 443;
+    const path = '/identitytoolkit/v3/relyingparty/getAccountInfo';
+    const timeout = 10000;
+    it('should be fulfilled given a valid phoneNumber', () => {
+      const expectedResult = {
+        users : [
+          {
+            localId: 'uid',
+            phoneNumber: '+11234567890',
+            providerUserInfo: [
+              {
+                providerId: 'phone',
+                rawId: '+11234567890',
+                phoneNumber: '+11234567890',
+              },
+            ],
+          },
+        ],
+      };
+      const data = {
+        phoneNumber: ['+11234567890'],
+      };
+
+      let stub = sinon.stub(HttpRequestHandler.prototype, 'sendRequest')
+        .returns(Promise.resolve(expectedResult));
+      stubs.push(stub);
+
+      const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+      return requestHandler.getAccountInfoByPhoneNumber('+11234567890')
+        .then((result) => {
+          expect(result).to.deep.equal(expectedResult);
+          expect(stub).to.have.been.calledOnce.and.calledWith(
+              host, port, path, httpMethod, data, expectedHeaders, timeout);
+        });
+    });
+    it('should be rejected given an invalid phoneNumber', () => {
+      const expectedError = new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_PHONE_NUMBER);
+
+      let stub = sinon.stub(HttpRequestHandler.prototype, 'sendRequest');
+      stubs.push(stub);
+      const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+      return requestHandler.getAccountInfoByPhoneNumber('invalid')
+        .then((resp) => {
+          throw new Error('Unexpected success');
+        }, (error) => {
+          expect(error).to.deep.equal(expectedError);
+          expect(stub).to.have.not.been.called;
+        });
+
+    });
+    it('should be rejected when the backend returns an error', () => {
+      const expectedResult = {
+        kind: 'identitytoolkit#GetAccountInfoResponse',
+      };
+      const expectedError = new FirebaseAuthError(AuthClientErrorCode.USER_NOT_FOUND);
+      const data = {
+        phoneNumber: ['+11234567890'],
+      };
+
+      let stub = sinon.stub(HttpRequestHandler.prototype, 'sendRequest')
+        .returns(Promise.resolve(expectedResult));
+      stubs.push(stub);
+
+      const requestHandler = new FirebaseAuthRequestHandler(mockApp);
+      return requestHandler.getAccountInfoByPhoneNumber('+11234567890')
+        .then((resp) => {
+          throw new Error('Unexpected success');
+        }, (error) => {
+          expect(error).to.deep.equal(expectedError);
+          expect(stub).to.have.been.calledOnce.and.calledWith(
+              host, port, path, httpMethod, data, expectedHeaders, timeout);
+        });
+    });
+  });
+
   describe('deleteAccount', () => {
     const httpMethod = 'POST';
     const host = 'www.googleapis.com';

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -36,6 +36,7 @@ function getValidUserResponse(): Object {
     email: 'user@gmail.com',
     emailVerified: true,
     displayName: 'John Doe',
+    phoneNumber: '+11234567890',
     providerUserInfo: [
       {
         providerId: 'google.com',
@@ -53,6 +54,11 @@ function getValidUserResponse(): Object {
         email: 'user@facebook.com',
         rawId: '0987654321',
       },
+      {
+        providerId: 'phone',
+        rawId: '+11234567890',
+        phoneNumber: '+11234567890',
+      },
     ],
     photoUrl: 'https://lh3.googleusercontent.com/1234567890/photo.jpg',
     validSince: '1476136676',
@@ -69,6 +75,7 @@ function getUserJSON(): Object {
   return {
     uid: 'abcdefghijklmnopqrstuvwxyz',
     email: 'user@gmail.com',
+    phoneNumber: '+11234567890',
     emailVerified: true,
     disabled: false,
     displayName: 'John Doe',
@@ -79,6 +86,7 @@ function getUserJSON(): Object {
         photoURL: 'https://lh3.googleusercontent.com/1234567890/photo.jpg',
         email: 'user@gmail.com',
         uid: '1234567890',
+        phoneNumber: undefined,
       },
       {
         providerId: 'facebook.com',
@@ -86,6 +94,15 @@ function getUserJSON(): Object {
         photoURL: 'https://facebook.com/0987654321/photo.jpg',
         email: 'user@facebook.com',
         uid: '0987654321',
+        phoneNumber: undefined,
+      },
+      {
+        providerId: 'phone',
+        displayName: undefined,
+        photoURL: undefined,
+        email: undefined,
+        uid: '+11234567890',
+        phoneNumber: '+11234567890',
       },
     ],
     photoURL: 'https://lh3.googleusercontent.com/1234567890/photo.jpg',
@@ -121,6 +138,34 @@ function getUserInfoJSON(): Object {
     photoURL: 'https://lh3.googleusercontent.com/1234567890/photo.jpg',
     uid: '1234567890',
     email: 'user@gmail.com',
+    phoneNumber: undefined,
+  };
+}
+
+/**
+ * @return {Object} A sample user info response with phone number as returned
+ *     from getAccountInfo endpoint.
+ */
+function getUserInfoWithPhoneNumberResponse(): Object {
+  return {
+    providerId: 'phone',
+    phoneNumber: '+11234567890',
+    rawId: '+11234567890',
+  };
+}
+
+/**
+ * @return {Object} The JSON representation of the above user info response
+ *     with a phone number.
+ */
+function getUserInfoWithPhoneNumberJSON(): Object {
+  return {
+    providerId: 'phone',
+    displayName: undefined,
+    photoURL: undefined,
+    uid: '+11234567890',
+    email: undefined,
+    phoneNumber: '+11234567890',
   };
 }
 
@@ -153,7 +198,9 @@ describe('UserInfo', () => {
 
   describe('getters', () => {
     const userInfoResponse: any = getUserInfoResponse();
-    const userInfo = new UserInfo(getUserInfoResponse());
+    const userInfo = new UserInfo(userInfoResponse);
+    const userInfoWithPhoneNumberResponse: any = getUserInfoWithPhoneNumberResponse();
+    const userInfoWithPhoneNumber = new UserInfo(userInfoWithPhoneNumberResponse);
     it('should return expected providerId', () => {
       expect(userInfo.providerId).to.equal(userInfoResponse.providerId);
     });
@@ -203,12 +250,29 @@ describe('UserInfo', () => {
         (userInfo as any).uid = '00000000';
       }).to.throw(Error);
     });
+
+    it('should return expected phoneNumber', () => {
+      expect(userInfoWithPhoneNumber.phoneNumber)
+        .to.equal(userInfoWithPhoneNumberResponse.phoneNumber);
+    });
+
+    it('should throw when modifying readonly phoneNumber property', () => {
+      expect(() => {
+        (userInfoWithPhoneNumber as any).phoneNumber = '+10987654321';
+      }).to.throw(Error);
+    });
   });
 
   describe('toJSON', () => {
     const userInfo = new UserInfo(getUserInfoResponse());
+    const userInfoWithPhoneNumber =
+        new UserInfo(getUserInfoWithPhoneNumberResponse());
     it('should return expected JSON object', () => {
       expect(userInfo.toJSON()).to.deep.equal(getUserInfoJSON());
+    });
+    it('should return expected JSON object with phone number', () => {
+      expect(userInfoWithPhoneNumber.toJSON())
+        .to.deep.equal(getUserInfoWithPhoneNumberJSON());
     });
   });
 });
@@ -362,6 +426,16 @@ describe('UserRecord', () => {
       }).to.throw(Error);
     });
 
+    it('should return expected phoneNumber', () => {
+      expect(userRecord.phoneNumber).to.equal('+11234567890');
+    });
+
+    it('should throw when modifying readonly phoneNumber property', () => {
+      expect(() => {
+        (userRecord as any).phoneNumber = '+10987654321';
+      }).to.throw(Error);
+    });
+
     it('should return expected metadata', () => {
       let metadata = new UserMetadata({
         createdAt: '1476136676000',
@@ -402,6 +476,11 @@ describe('UserRecord', () => {
           federatedId: '0987654321',
           email: 'user@facebook.com',
           rawId: '0987654321',
+        }),
+        new UserInfo({
+          providerId: 'phone',
+          phoneNumber: '+11234567890',
+          rawId: '+11234567890',
         }),
       ];
       expect(userRecord.providerData).to.deep.equal(providerData);

--- a/test/unit/utils/validator.spec.ts
+++ b/test/unit/utils/validator.spec.ts
@@ -22,7 +22,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 
 import {
   isArray, isNonEmptyArray, isBoolean, isNumber, isString, isNonEmptyString, isNonNullObject,
-  isEmail, isPassword, isURL, isUid,
+  isEmail, isPassword, isURL, isUid, isPhoneNumber,
 } from '../../../src/utils/validator';
 
 
@@ -376,5 +376,46 @@ describe('isURL()', () => {
     expect(isURL('http://abc.com.')).to.be.false;
     expect(isURL('http://-abc.com')).to.be.false;
     expect(isURL('http://www._abc.com')).to.be.false;
+  });
+});
+
+describe('isPhoneNumber()', () => {
+  it('should return false given no argument', () => {
+    expect(isPhoneNumber(undefined as any)).to.be.false;
+  });
+
+  const nonStrings = [null, NaN, 0, 1, true, false, [], ['a'], {}, { a: 1 }, _.noop];
+  nonStrings.forEach((nonString) => {
+    it('should return false given a non-string argument: ' + JSON.stringify(nonString), () => {
+      expect(isPhoneNumber(nonString as any)).to.be.false;
+    });
+  });
+
+  it('should return false given an empty string', () => {
+    expect(isPhoneNumber('')).to.be.false;
+  });
+
+  it('should return false given a string with only whitespace', () => {
+    expect(isPhoneNumber(' ')).to.be.false;
+  });
+
+  it('should return false given a string with only a plus sign', () => {
+    expect(isPhoneNumber('+')).to.be.false;
+  });
+
+  it('should return false given a string with a plus sign and no alphanumeric char', () => {
+    expect(isPhoneNumber('+ ()-')).to.be.false;
+  });
+
+  it('should return true given a valid phone number', () => {
+    expect(isPhoneNumber('+11234567890')).to.be.true;
+  });
+
+  it('should return true given a valid phone number that is formatted', () => {
+    expect(isPhoneNumber('+1 (123) 456-7890')).to.be.true;
+  });
+
+  it('should return true given a valid phone number with alphabetical chars', () => {
+    expect(isPhoneNumber('+1 800 FLOwerS')).to.be.true;
   });
 });


### PR DESCRIPTION
Adds phoneNumber to UserRecord and UserInfo.
Implements new API for looking up users by phone number: getUserByPhoneNumber
Adds the ability to pass the phoneNumber property when creating a new user,
or updating an existing one via createUser and updateUser.
This includes the ability to delete the phone number for a specified user.
Defines the new related auth errors:
auth/invalid-phone-number and auth/phone-number-already-exists.
