### PR TITLE
Type definitions for createUser() and updateUser() parameters

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -23,6 +23,7 @@ import {AuthClientErrorCode, FirebaseAuthError} from '../utils/error';
 import {
   HttpMethod, SignedApiRequestHandler, ApiSettings,
 } from '../utils/api-request';
+import {CreateRequest, UpdateRequest} from './user-record';
 
 
 /** Firebase Auth backend host. */
@@ -300,7 +301,7 @@ export class FirebaseAuthRequestHandler {
    * @return {Promise<string>} A promise that resolves when the operation completes
    *     with the user id that was edited.
    */
-  public updateExistingAccount(uid: string, properties: Object): Promise<string> {
+  public updateExistingAccount(uid: string, properties: UpdateRequest): Promise<string> {
     if (!validator.isUid(uid)) {
       return Promise.reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_UID));
     } else if (!validator.isNonNullObject(properties)) {
@@ -376,7 +377,7 @@ export class FirebaseAuthRequestHandler {
    * @return {Promise<string>} A promise that resolves when the operation completes
    *     with the user id that was created.
    */
-  public createNewAccount(properties: Object): Promise<string> {
+  public createNewAccount(properties: CreateRequest): Promise<string> {
     if (!validator.isNonNullObject(properties)) {
       return Promise.reject(
         new FirebaseAuthError(

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {UserRecord} from './user-record';
+import {UserRecord, CreateRequest, UpdateRequest} from './user-record';
 import {Certificate} from './credential';
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseTokenGenerator} from './token-generator';
@@ -181,10 +181,10 @@ class Auth implements FirebaseServiceInterface {
   /**
    * Creates a new user with the properties provided.
    *
-   * @param {Object} properties The properties to set on the new user record to be created.
+   * @param {CreateRequest} properties The properties to set on the new user record to be created.
    * @return {Promise<UserRecord>} A promise that resolves with the newly created user record.
    */
-  public createUser(properties: Object): Promise<UserRecord> {
+  public createUser(properties: CreateRequest): Promise<UserRecord> {
     return this.authRequestHandler.createNewAccount(properties)
       .then((uid) => {
         // Return the corresponding user record.
@@ -219,10 +219,10 @@ class Auth implements FirebaseServiceInterface {
    * Updates an existing user with the properties provided.
    *
    * @param {string} uid The uid identifier of the user to update.
-   * @param {Object} properties The properties to update on the existing user.
+   * @param {UpdateRequest} properties The properties to update on the existing user.
    * @return {Promise<UserRecord>} A promise that resolves with the modified user record.
    */
-  public updateUser(uid: string, properties: Object): Promise<UserRecord> {
+  public updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord> {
     return this.authRequestHandler.updateExistingAccount(uid, properties)
       .then((existingUid) => {
         // Return the corresponding user record.

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -35,6 +35,29 @@ function parseDate(time: any): string {
   return null;
 }
 
+/** Parameters for create user operation */
+export type CreateRequest = {
+  uid?: string;
+  displayName?: string;
+  email?: string;
+  emailVerified?: boolean;
+  phoneNumber?: string;
+  photoURL?: string;
+  disabled?: boolean;
+  password?: string;
+}
+
+/** Parameters for update user operation */
+export type UpdateRequest = {
+  displayName?: string;
+  email?: string;
+  emailVerified?: boolean;
+  phoneNumber?: string;
+  photoURL?: string;
+  disabled?: boolean;
+  password?: string;
+}
+
 
 /**
  * User metadata class that provides metadata information like user account creation

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -35,20 +35,8 @@ function parseDate(time: any): string {
   return null;
 }
 
-/** Parameters for create user operation */
-export type CreateRequest = {
-  uid?: string;
-  displayName?: string;
-  email?: string;
-  emailVerified?: boolean;
-  phoneNumber?: string;
-  photoURL?: string;
-  disabled?: boolean;
-  password?: string;
-}
-
 /** Parameters for update user operation */
-export type UpdateRequest = {
+export interface UpdateRequest {
   displayName?: string;
   email?: string;
   emailVerified?: boolean;
@@ -58,6 +46,10 @@ export type UpdateRequest = {
   password?: string;
 }
 
+/** Parameters for create user operation */
+export interface CreateRequest extends UpdateRequest {
+  uid?: string;
+}
 
 /**
  * User metadata class that provides metadata information like user account creation

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,6 +101,20 @@ declare namespace admin.auth {
     toJSON(): Object;
   }
 
+  interface UpdateRequest {
+    displayName?: string;
+    email?: string;
+    emailVerified?: boolean;
+    phoneNumber?: string;
+    photoURL?: string;
+    disabled?: boolean;
+    password?: string;
+  }
+
+  interface CreateRequest extends UpdateRequest {
+    uid?: string;
+  }
+
   interface DecodedIdToken {
     aud: string;
     auth_time: number;
@@ -123,12 +137,12 @@ declare namespace admin.auth {
     app: admin.app.App;
 
     createCustomToken(uid: string, developerClaims?: Object): Promise<string>;
-    createUser(properties: Object): Promise<admin.auth.UserRecord>;
+    createUser(properties: admin.auth.CreateRequest): Promise<admin.auth.UserRecord>;
     deleteUser(uid: string): Promise<void>;
     getUser(uid: string): Promise<admin.auth.UserRecord>;
     getUserByEmail(email: string): Promise<admin.auth.UserRecord>;
     getUserByPhoneNumber(phoneNumber: string): Promise<admin.auth.UserRecord>;
-    updateUser(uid: string, properties: Object): Promise<admin.auth.UserRecord>;
+    updateUser(uid: string, properties: admin.auth.UpdateRequest): Promise<admin.auth.UserRecord>;
     verifyIdToken(idToken: string): Promise<admin.auth.DecodedIdToken>;
   }
 }


### PR DESCRIPTION
Implementing type definitions for arguments of `createUser()` and `updateUser()` methods in `auth`. This improvement was suggested for the Node SDK during a recent API review discussion. 

@bojeil-google Do we need to send this through the API review process?

See #62.