### PR TITLE
Fixing a TS compilation error in index.d.ts

### DIFF
--- a/createReleaseTarball.sh
+++ b/createReleaseTarball.sh
@@ -157,6 +157,18 @@ echo
 mv firebase-admin-${VERSION_WITHOUT_RC}.tgz firebase-admin-${VERSION}.tgz
 
 
+############################
+#  VERIFY RELEASE TARBALL  #
+############################
+echo "[INFO] Running release tarball verification..."
+bash verifyReleaseTarball.sh firebase-admin-${VERSION}.tgz
+if [[ $? -ne 0 ]]; then
+  echo "Error: Release tarball failed verification."
+  exit 1
+fi
+echo
+
+
 ##############
 #  EPILOGUE  #
 ##############

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
- import {Bucket} from '@google-cloud/storage';
-
 declare namespace admin {
   interface FirebaseError {
     code: string;
@@ -388,7 +386,7 @@ declare namespace admin.messaging {
 declare namespace admin.storage {
   interface Storage {
     app: admin.app.App;
-    bucket(name?: string): Bucket;
+    bucket(name?: string): any;
   }
 }
 

--- a/test/integration/typescript/package.json
+++ b/test/integration/typescript/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "firebase-admin-typescript-test",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@types/chai": "^3.4.35",
+    "@types/mocha": "^2.2.39",
+    "@types/node": "^7.0.8",
+    "chai": "^3.5.0",
+    "mocha": "^3.5.0",
+    "ts-node": "^3.3.0",
+    "typescript": "^2.4.2"
+  }
+}

--- a/test/integration/typescript/src/example.test.ts
+++ b/test/integration/typescript/src/example.test.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import initApp from './example'
+import {expect} from 'chai';
+
+const serviceAccount = require('../mock.key.json');
+
+describe('Init App', () => {
+    it('Should return an initialized App', () => {
+        const app = initApp(serviceAccount, 'TestApp');
+        expect(app.name).to.equal('TestApp');
+    });
+});

--- a/test/integration/typescript/src/example.ts
+++ b/test/integration/typescript/src/example.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firebase from 'firebase-admin';
+
+const serviceAccount = 'mock.key.json';
+
+export function initApp(serviceAcct: any, name: string) {
+    return firebase.initializeApp({
+        credential: firebase.credential.cert(serviceAcct)
+    }, name);
+}
+
+export default initApp;

--- a/test/integration/typescript/src/example.ts
+++ b/test/integration/typescript/src/example.ts
@@ -16,8 +16,6 @@
 
 import * as firebase from 'firebase-admin';
 
-const serviceAccount = 'mock.key.json';
-
 export function initApp(serviceAcct: any, name: string) {
     return firebase.initializeApp({
         credential: firebase.credential.cert(serviceAcct)

--- a/test/integration/typescript/tsconfig.json
+++ b/test/integration/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": false,
+    "lib": ["es5", "es2015.promise"],
+    "outDir": "lib",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "files": [
+    "src/example.ts"
+  ]
+}

--- a/verifyReleaseTarball.sh
+++ b/verifyReleaseTarball.sh
@@ -1,0 +1,67 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "[ERROR] No package name provided."
+    echo "[INFO] Usage: ./verifyReleaseTarball.sh <PACKAGE_NAME>"
+    exit 1
+fi
+
+# Variables
+PKG_NAME="$1"
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+GULP_CLI="$ROOT/node_modules/.bin/gulp"
+MOCHA_CLI="$ROOT/node_modules/.bin/mocha -r ts-node/register"
+DIR="$ROOT/test/integration/typescript"
+WORK_DIR=`mktemp -d`
+
+# check if tmp dir was created
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+# deletes the temp directory
+function cleanup {      
+  rm -rf "$WORK_DIR"
+  echo "Deleted temp working directory $WORK_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+# Enter work dir
+pushd "$WORK_DIR"
+
+if [ ! -d "$ROOT/lib" ]; then
+  pushd $ROOT
+  $GULP_CLI build
+  popd
+fi
+
+# Simulate env
+cp -r $DIR/* .
+cp "$ROOT/test/resources/mock.key.json" .
+npm install
+npm install "$ROOT/$PKG_NAME"
+
+echo "> tsc -p tsconfig.json"
+tsc -p tsconfig.json
+
+echo "> $MOCHA_CLI src/*.test.ts"
+$MOCHA_CLI src/*.test.ts


### PR DESCRIPTION
This provides a fix for the issue reported in #70. I've taken the easy (and probably safer) way out by dropping the offending import (`Bucket`) altogether, and declaring our API to return `any` instead. I've also added a new `verifyReleaseTarball.sh` script which will check for this type of errors in the future.

Here's the repro of the error as detected by the new verification script:

```npm WARN firebase-admin-typescript-test@1.0.0 No description
npm WARN firebase-admin-typescript-test@1.0.0 No repository field.
npm WARN firebase-admin-typescript-test@1.0.0 No license field.
> tsc -p tsconfig.json
node_modules/firebase-admin/lib/index.d.ts(397,3): error TS2666: Exports and export assignments are not permitted in module augmentations.
Deleted temp working directory /tmp/tmp.fsnUBunSgA
Error: Release tarball failed verification.
```


And with the fix...


```npm WARN firebase-admin-typescript-test@1.0.0 No description
npm WARN firebase-admin-typescript-test@1.0.0 No repository field.
npm WARN firebase-admin-typescript-test@1.0.0 No license field.
> tsc -p tsconfig.json
> /usr/local/google/home/hkj/Projects/firebase-admin-node/public/node_modules/.bin/mocha -r ts-node/register src/*.test.ts


  Init App
    ✓ Should return an initialized App


  1 passing (8ms)

Deleted temp working directory /tmp/tmp.JoeZmoqQoY

[INFO] firebase-admin-5.2.1-rc0.tgz successfully created!
[INFO] Create a CL for the updated package.json and npm-shrinkwrap.json if this is an actual release.```
