### PR TITLE
Fixing a number of TS errors/warnings

### DIFF
--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -152,7 +152,7 @@ export class FirebaseTokenGenerator {
       );
     }
 
-    const fullDecodedToken = jwt.decode(idToken, {
+    const fullDecodedToken: any = jwt.decode(idToken, {
       complete: true,
     });
 
@@ -222,7 +222,7 @@ export class FirebaseTokenGenerator {
       return new Promise((resolve, reject) => {
         jwt.verify(idToken, publicKeys[header.kid], {
           algorithms: [ALGORITHM],
-        }, (error, decodedToken) => {
+        }, (error, decodedToken: any) => {
           if (error) {
             if (error.name === 'TokenExpiredError') {
               errorMessage = 'Firebase ID token has expired. Get a fresh token from your client app and try ' +
@@ -297,12 +297,12 @@ export class FirebaseTokenGenerator {
             } else {
               /* istanbul ignore else */
               if (res.headers.hasOwnProperty('cache-control')) {
-                const cacheControlHeader = res.headers['cache-control'];
+                const cacheControlHeader: string = res.headers['cache-control'] as string;
                 const parts = cacheControlHeader.split(',');
                 parts.forEach((part) => {
                   const subParts = part.trim().split('=');
                   if (subParts[0] === 'max-age') {
-                    const maxAge = subParts[1];
+                    const maxAge: number = +subParts[1];
                     this.publicKeysExpireAt_ = Date.now() + (maxAge * 1000);
                   }
                 });

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -431,10 +431,10 @@ class Messaging implements FirebaseServiceInterface {
         // See b/35394951 for more context.
         if ('multicast_id' in response) {
           if ((response as any).success === 0) {
-            return Promise.reject(new FirebaseMessagingError(
+            throw new FirebaseMessagingError(
               MessagingClientErrorCode.INVALID_RECIPIENT,
               'Notification key provided to sendToDeviceGroup() is invalid.'
-            ));
+            );
           } else {
             return mapRawResponseToDevicesResponse(response);
           }
@@ -485,7 +485,7 @@ class Messaging implements FirebaseServiceInterface {
         // Rename properties on the server response
         utils.renameProperties(response, MESSAGING_TOPIC_RESPONSE_KEYS_MAP);
 
-        return response;
+        return response as MessagingTopicResponse;
       });
   }
 
@@ -537,7 +537,7 @@ class Messaging implements FirebaseServiceInterface {
         // Rename properties on the server response
         utils.renameProperties(response, MESSAGING_CONDITION_RESPONSE_KEYS_MAP);
 
-        return response;
+        return response as MessagingConditionResponse;
       });
   }
 

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -18,6 +18,7 @@ import {deepCopy} from './deep-copy';
 import {FirebaseApp} from '../firebase-app';
 import {AppErrorCodes, FirebaseAppError} from './error';
 
+import {OutgoingHttpHeaders} from 'http';
 import https = require('https');
 
 /** Http method type definition. */
@@ -57,12 +58,12 @@ export class HttpRequestHandler {
         return Promise.reject(e);
       }
     }
-    const options = {
+    const options: https.RequestOptions = {
       method: httpMethod,
       host,
       port,
       path,
-      headers,
+      headers: headers as OutgoingHttpHeaders,
     };
     // Only https endpoints.
     return new Promise((resolve, reject) => {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -100,7 +100,7 @@ function getValidUserRecord(serverResponse: any) {
 describe('Auth', () => {
   let auth: Auth;
   let mockApp: FirebaseApp;
-  let oldProcessEnv: Object;
+  let oldProcessEnv: NodeJS.ProcessEnv;
   let nullAccessTokenAuth: Auth;
   let malformedAccessTokenAuth: Auth;
   let rejectedPromiseAccessTokenAuth: Auth;

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -84,7 +84,7 @@ const ONE_HOUR_IN_SECONDS = 60 * 60;
 describe('Credential', () => {
   let mockedRequests: nock.Scope[] = [];
   let mockCertificateObject;
-  let oldProcessEnv: Object;
+  let oldProcessEnv: NodeJS.ProcessEnv;
 
   before(() => utils.mockFetchAccessTokenRequests());
 

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -351,7 +351,7 @@ describe('FirebaseTokenGenerator', () => {
 
       return tokenGenerator.createCustomToken(mocks.uid)
         .then(token => {
-          const decoded = jwt.decode(token, {
+          const decoded: any = jwt.decode(token, {
             complete: true,
           });
 

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -1564,7 +1564,12 @@ describe('Messaging', () => {
       });
     });
 
-    const whitelistedOptionsKeys = {
+    const whitelistedOptionsKeys: {
+      [name: string]: {
+        type: string,
+        underscoreCasedKey?: string
+      }
+    } = {
       dryRun: { type: 'boolean', underscoreCasedKey: 'dry_run' },
       priority: { type: 'string' },
       timeToLive: { type: 'number', underscoreCasedKey: 'time_to_live' },

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -1579,7 +1579,7 @@ describe('Messaging', () => {
       restrictedPackageName: { type: 'string', underscoreCasedKey: 'restricted_package_name' },
     };
 
-    _.forEach(whitelistedOptionsKeys as any, ({ type, underscoreCasedKey }, camelCasedKey) => {
+    _.forEach(whitelistedOptionsKeys, ({ type, underscoreCasedKey }, camelCasedKey) => {
       let validValue;
       let invalidValues;
       if (type === 'string') {


### PR DESCRIPTION
Following errors occur when running `gulp`:

```
src/auth/token-generator.ts(159,57): error TS2339: Property 'header' does not exist on type 'string | object'.
  Property 'header' does not exist on type 'string'.
src/auth/token-generator.ts(160,58): error TS2339: Property 'payload' does not exist on type 'string | object'.
  Property 'payload' does not exist on type 'string'.
src/auth/token-generator.ts(238,26): error TS2339: Property 'uid' does not exist on type 'string | object'.
  Property 'uid' does not exist on type 'string'.
src/auth/token-generator.ts(238,45): error TS2339: Property 'sub' does not exist on type 'string | object'.
  Property 'sub' does not exist on type 'string'.
src/auth/token-generator.ts(301,50): error TS2339: Property 'split' does not exist on type 'string | string[]'.
  Property 'split' does not exist on type 'string[]'.
src/messaging/messaging.ts(423,13): error TS2345: Argument of type '(response: Object) => Promise<never> | MessagingDevicesResponse | MessagingDeviceGroupResponse' is not assignable to parameter of type '(value: Object) => PromiseLike<never>'.
  Type 'Promise<never> | MessagingDevicesResponse | MessagingDeviceGroupResponse' is not assignable to type 'PromiseLike<never>'.
    Type 'MessagingDevicesResponse' is not assignable to type 'PromiseLike<never>'.
      Property 'then' is missing in type 'MessagingDevicesResponse'.
src/messaging/messaging.ts(470,5): error TS2322: Type 'Promise<Object>' is not assignable to type 'Promise<MessagingTopicResponse>'.
  Type 'Object' is not assignable to type 'MessagingTopicResponse'.
    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
      Property 'messageId' is missing in type 'Object'.
src/messaging/messaging.ts(523,5): error TS2322: Type 'Promise<Object>' is not assignable to type 'Promise<MessagingConditionResponse>'.
  Type 'Object' is not assignable to type 'MessagingConditionResponse'.
    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
      Property 'messageId' is missing in type 'Object'.
src/utils/api-request.ts(69,33): error TS2345: Argument of type '{ method: HttpMethod; host: string; port: number; path: string; headers: Object; }' is not assignable to parameter of type 'string | URL | RequestOptions'.
  Type '{ method: HttpMethod; host: string; port: number; path: string; headers: Object; }' is not assignable to type 'RequestOptions'.
    Types of property 'headers' are incompatible.
      Type 'Object' is not assignable to type 'OutgoingHttpHeaders'.
        The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
          Index signature is missing in type 'Object'.
test/unit/auth/auth.spec.ts(124,5): error TS2322: Type 'Object' is not assignable to type 'ProcessEnv'.
  The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
    Index signature is missing in type 'Object'.
test/unit/auth/credential.spec.ts(101,5): error TS2322: Type 'Object' is not assignable to type 'ProcessEnv'.
  The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
test/unit/auth/token-generator.spec.ts(358,26): error TS2339: Property 'header' does not exist on type 'string | object'.
```

This should fix all of it.