### PR TITLE
Updating the build/test/lint scripts to use npm instead of gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib/
 typings/
 coverage/
 node_modules/
+.nyc_output/
 
 # Real key file should not be checked in
 test/resources/key.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,37 +104,31 @@ follow the prompts:
 $ gcloud beta auth application-default login
 ```
 
-### Lint, Build, and Test
+### Running the Linter
 
 Source files are written in [TypeScript](https://www.typescriptlang.org/) and linted using
-[TSLint](https://palantir.github.io/tslint/). Tests are run on the compiled JavaScript files.
-
-The lint, build, and test process is kicked off via the default `gulp` task, although you can also
-run each task individually:
+[TSLint](https://palantir.github.io/tslint/). Run the following command to kick off the linter:
 
 ```bash
-$ gulp         # Lint, build, and test
-$ gulp lint    # Just lint
-$ gulp build   # Just build
-$ gulp test    # Just test
+$ npm run lint
 ```
 
 ### Running Tests
 
 There are two test suites: unit and integration. The unit test suite is intended to be run during
-development and the integration test suite is intended to be run before packaging up release
+development, and the integration test suite is intended to be run before packaging up release
 candidates.
 
 To run the unit test suite:
 
-```
-$ gulp   # Lint, build, and run unit test suite
+```bash
+$ npm test   # Lint and run unit test suite
 ```
 
-To run the integration test suite:
+If you wish to skip the linter, and only run the unit tests:
 
-```
-$ node test/integration   # Run integration test suite
+```bash
+$ npm run test:unit
 ```
 
 The integration test suite requires a service account JSON key file, and an API key for a Firebase
@@ -143,7 +137,22 @@ you do not already have one. Use a separate, dedicated project for integration t
 test suite makes a large number of writes to the Firebase realtime database. Download the service
 account key file from the "Settings > Service Accounts" page of the project, and copy it to
 `test/resources/key.json`. Also obtain the API key for the same project from "Settings > General",
-and save it to `test/resource/apikey.txt`.
+and save it to `test/resource/apikey.txt`. Finally, to run the integration test suite:
+
+```bash
+$ npm run integration   # Build and run integration test suite
+```
+
+The integration test suite overwrites the security rules present in your Firebase project. You
+will be prompted before the overwrite takes place:
+
+```
+Warning: This test will overwrite your project's existing Database rules.
+Overwrite Database rules for tests?
+* 'yes' to agree
+* 'skip' to continue without the overwrite
+* 'no' to cancel
+```
 
 ### Repo Organization
 
@@ -173,6 +182,10 @@ Here are some highlights of the directory structure and notable source files
   * `resources/` - Provides mocks for several variables as well as mock service account keys.
 * `.github/` - Contribution instructions as well as issue and pull request templates.
 * `createReleaseTarball.sh` - Generates a new release tarball and ensures it passes all tests.
-* `gulpfile.js` - Defines the `gulp` tasks.
+* `verifyReleaseTarball.sh` - Installs and validates the release tarballs created by
+  `createReleaseTarball.sh`.
+* `gulpfile.js` - Defines the `gulp` tasks necessary for building release artifacts.
 * `tslint.json` - TypeScript linting rules.
 * `tsconfig.json` - TypeScript configuration options.
+* `tsconfig-lint.json` - TypeScript configuration options for the linter. This simple widens
+  the scope of `tsconfig.json` by including some test source files in the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,5 +187,5 @@ Here are some highlights of the directory structure and notable source files
 * `gulpfile.js` - Defines the `gulp` tasks necessary for building release artifacts.
 * `tslint.json` - TypeScript linting rules.
 * `tsconfig.json` - TypeScript configuration options.
-* `tsconfig-lint.json` - TypeScript configuration options for the linter. This simple widens
+* `tsconfig-lint.json` - TypeScript configuration options for the linter. This simply widens
   the scope of `tsconfig.json` by including some test source files in the project.

--- a/createReleaseTarball.sh
+++ b/createReleaseTarball.sh
@@ -128,18 +128,34 @@ if [[ $? -ne 0 ]]; then
 fi
 echo
 
-echo "[INFO] Linting, building, and running unit tests..."
-gulp
+echo "[INFO] Running linter..."
+npm run lint
 if [[ $? -ne 0 ]]; then
-  echo "Error: Failed to lint, build, and run unit tests."
+  echo "Error: Linter failed."
   exit 1
 fi
 echo
 
-echo "[INFO] Running integration test suite..."
-node test/integration
+echo "[INFO] Running unit tests..."
+npm run test:unit
 if [[ $? -ne 0 ]]; then
-  echo "Error: Integration test suite failed."
+  echo "Error: Unit tests failed."
+  exit 1
+fi
+echo
+
+echo "[INFO] Building the release package contents..."
+npm run build
+if [[ $? -ne 0 ]]; then
+  echo "Error: Failed to build release package contents."
+  exit 1
+fi
+echo
+
+echo "[INFO] Running integration tests..."
+npm run test:integration -- --overwrite yes
+if [[ $? -ne 0 ]]; then
+  echo "Error: Integration tests failed."
   exit 1
 fi
 echo

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('copyTypings', function() {
     .pipe(gulp.dest(paths.build))
 });
 
-// Re-runs the linter and regenerates js every time a source file changes
+// Regenerates js every time a source file changes
 gulp.task('watch', function() {
   gulp.watch(paths.src, ['compile']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,16 +28,11 @@ var runSequence = require('run-sequence');
 // File I/O
 var fs = require('fs');
 var exit = require('gulp-exit');
-var tslint = require('gulp-tslint');
 var ts = require('gulp-typescript');
 var del = require('del');
 var merge = require('merge2');
 var header = require('gulp-header');
 var replace = require('gulp-replace');
-
-// Testing
-var mocha = require('gulp-mocha');
-var istanbul = require('gulp-istanbul');
 
 
 /****************/
@@ -52,28 +47,13 @@ var paths = {
     'src/**/*.js'
   ],
 
-  tests: [
-    'test/unit/utils.ts',
-    'test/unit/**/*.spec.ts',
-    'test/resources/mocks.ts'
-  ],
-
-  resources: [
-    'test/resources/*.json'
-  ],
-
   build: 'lib/',
-
-  testBuild: '.tmp/',
-
-  testRunner: ['.tmp/test/unit/index.spec.js']
 };
 
 // Create a separate project for buildProject that overrides the rootDir
 // This ensures that the generated production files are in their own root
 // rather than including both src and test in the lib dir.
 var buildProject = ts.createProject('tsconfig.json', {rootDir: 'src'});
-var testProject = ts.createProject('tsconfig.json');
 
 var banner = `/*! firebase-admin v${pkg.version} */\n`;
 
@@ -84,7 +64,6 @@ var banner = `/*! firebase-admin v${pkg.version} */\n`;
 gulp.task('cleanup', function() {
   return del([
     paths.build,
-    paths.testBuild
   ]);
 });
 
@@ -122,54 +101,9 @@ gulp.task('copyTypings', function() {
     .pipe(gulp.dest(paths.build))
 });
 
-// Lints the source and test files
-gulp.task('lint', function() {
-  let filesToLint = _.clone(paths.src.concat(paths.tests));
-
-  // Don't lint the hand-crafted TypeScript typings file
-  filesToLint.push('!src/index.d.ts');
-
-  return gulp.src(filesToLint)
-    .pipe(tslint())
-    .pipe(tslint.report({
-      summarizeFailureOutput: true
-    }));
-});
-
-// Runs the test suite
-gulp.task('test', function() {
-  merge(
-    // Copy compiled source and test files
-    gulp.src(paths.tests.concat(paths.src), {base: '.'})
-      .pipe(testProject())
-      .pipe(gulp.dest(paths.testBuild)),
-    // Copy compiled database files
-    gulp.src(paths.build + 'database/**/*')
-      .pipe(gulp.dest(paths.testBuild + 'src/database/')),
-    // Copy test resources
-    gulp.src(paths.resources, {base: '.'})
-      .pipe(gulp.dest(paths.testBuild))
-  ).on('finish', function() {
-    return gulp.src([paths.testBuild + 'src/**/*.js', '!' + paths.testBuild + 'src/database/**/*'])
-      .pipe(istanbul())
-      .pipe(istanbul.hookRequire())
-      .on('finish', function() {
-        return gulp.src(paths.testRunner)
-          .pipe(mocha({
-            reporter: 'spec',
-            timeout: 5000
-          }))
-          .pipe(istanbul.writeReports())
-          .on('finish', function() {
-            return del(paths.testBuild).then(exit);
-          });
-      });
-  })
-});
-
 // Re-runs the linter and regenerates js every time a source file changes
 gulp.task('watch', function() {
-  gulp.watch(paths.src, ['lint', 'compile']);
+  gulp.watch(paths.src, ['compile']);
 });
 
 // Build task
@@ -181,7 +115,7 @@ gulp.task('build', function(done) {
 
 // Default task
 gulp.task('default', function(done) {
-  runSequence('lint', 'build', 'test', function(error) {
+  runSequence('build', function(error) {
     done(error && error.err);
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,24 @@
   "license": "Apache-2.0",
   "homepage": "https://firebase.google.com/",
   "scripts": {
-    "test": "gulp"
+    "build": "gulp build",
+    "lint": "tslint --project tsconfig-lint.json --format stylish",
+    "test": "run-s lint test:run",
+    "test:run": "mocha test/**/*.spec.ts --compilers ts:ts-node/register",
+    "test:coverage": "nyc npm run test:run"
+  },
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "src"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "**/database.js"
+    ],
+    "all": true
   },
   "keywords": [
     "admin",
@@ -63,13 +80,17 @@
     "gulp-typescript": "^3.1.2",
     "lodash": "^4.6.1",
     "merge2": "^1.0.2",
+    "mocha": "^3.5.0",
     "nock": "^8.0.0",
+    "npm-run-all": "^4.1.1",
+    "nyc": "^11.1.0",
     "request": "^2.75.0",
     "request-promise": "^4.1.1",
     "run-sequence": "^1.1.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "tslint": "^3.5.0",
+    "ts-node": "^3.3.0",
     "typescript": "^2.0.3",
     "typings": "^1.0.4"
   }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   "scripts": {
     "build": "gulp build",
     "lint": "tslint --project tsconfig-lint.json --format stylish",
-    "test": "run-s lint test:run",
-    "test:run": "mocha test/**/*.spec.ts --compilers ts:ts-node/register",
-    "test:coverage": "nyc npm run test:run"
+    "test": "run-s lint test:unit",
+    "integration": "run-s build test:integration",
+    "test:unit": "mocha test/**/*.spec.ts --compilers ts:ts-node/register",
+    "test:integration": "node test/integration",
+    "test:coverage": "nyc npm run test:unit"
   },
   "nyc": {
     "extension": [

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -79,6 +79,7 @@ const skipAndLogWarningIfNoGcloud = () => {
 };
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
+const FIVE_MINUTES_IN_SECONDS = 5 * 60;
 
 
 describe('Credential', () => {
@@ -256,7 +257,7 @@ describe('Credential', () => {
       const c = new RefreshTokenCredential(new RefreshToken(TEST_GCLOUD_CREDENTIALS));
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.be.a('string').and.to.not.be.empty;
-        expect(token.expires_in).to.equal(ONE_HOUR_IN_SECONDS);
+        expect(token.expires_in).to.greaterThan(FIVE_MINUTES_IN_SECONDS);
       });
     });
   });

--- a/tsconfig-lint.json
+++ b/tsconfig-lint.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "target": "es5",
+      "noImplicitAny": false,
+      "lib": ["es5", "es2015.promise"],
+      "outDir": "lib",
+      // We manually craft typings in src/index.d.ts instead of auto-generating them.
+      // "declaration": true,
+      "rootDir": "."
+    },
+    "files": [
+      "src/index.ts",
+      "test/unit/utils.ts",
+      "test/unit/**/*.spec.ts",
+      "test/resources/mocks.ts"
+    ]
+  }
+  


### PR DESCRIPTION
This PR changes how we lint, test and build the SDK.

* Linting: `npm run lint`
* Linting and unit tests: `npm test`
* Unit tests with code coverage: `npm run test:coverage`
* Integration tests: `npm run integration`

With this we will only use gulp when building release packages. Even in that case we can invoke it via npm as `npm run build`. The `createReleaseTarball.sh` script has been updated to use the new npm build targets.

There are couple of advantages to this move:
* The old gulp script was very complicated. This simplifies it down to bare bones.
* Stack traces of failed tests are impossible to comprehend when invoked via gulp (due to compilation and in-memory evaluation of gulp). With this we run mocha directly over TypeScript files, so the line numbers directly map to source code. For example:

```
1) Messaging sendToDevice() should be rejected given an array containing more than 1,000 registration tokens:
     Error: An unknown server error was returned.
      at FirebaseMessagingError.Error (native)
      at FirebaseMessagingError.FirebaseError [as constructor] (src/utils/error.ts:47:5)
      at new FirebaseMessagingError (src/utils/error.ts:177:5)
      at Function.FirebaseMessagingError.fromServerError (src/utils/error.ts:172:12)
      at src/messaging/messaging-api-request.ts:142:36
      at process._tickCallback (internal/process/next_tick.js:109:7)
```

* Unit tests no longer require an explicit build step (i.e. no need to copy compiled files into a lib directory). This speeds up the tests slightly. 

Huge thank you to @jshcrowthe who was instrumental in figuring out most of the things needed to make this work.