### PR TITLE
Declaring the Bucket return type in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Bucket} from '@google-cloud/storage';
+
 declare namespace admin {
   interface FirebaseError {
     code: string;
@@ -386,10 +388,11 @@ declare namespace admin.messaging {
 declare namespace admin.storage {
   interface Storage {
     app: admin.app.App;
-    bucket(name?: string): any;
+    bucket(name?: string): Bucket;
   }
 }
 
 declare module 'firebase-admin' {
-  export = admin;
 }
+
+export = admin;


### PR DESCRIPTION
Up until now we have been declaring the return type of `admin.storage().bucket()` to be `any`. We wanted to make it `Bucket`, but ran into issues with it (see #70).

This PR brings the `Bucket` type back into `index.d.ts`, but to avoid errors in downstream applications, we have to also slightly change how we export modules in the type definition file. I'm not sure what the implications of this change are, but at least nothing seems broken (unit tests, integration tests and release verification script are all passing). Feedback welcome.