### PR TITLE
Lazy loading the Firestore implementation

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -111,5 +111,8 @@ function initFirestore(app: FirebaseApp): Firestore {
         'to use Cloud Firestore API.',
     });
   }
-  return new Firestore(options);
+
+  // Lazy-load the Firestore implementation here, which in turns loads gRPC.
+  let firestoreDatabase = require('@google-cloud/firestore');
+  return new firestoreDatabase(options);
 }

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -97,6 +97,32 @@ utils.assert(
   'admin.messaging(app).app',
   'App instances do not match.'
 );
+utils.assert(
+  _.isEqual(admin.storage(nonNullApp).app, nonNullApp),
+  'admin.storage(app).app',
+  'App instances do not match.'
+);
+
+// Firestore should not be loaded yet.
+var gcloud = require.cache[require.resolve('@google-cloud/firestore')];
+utils.assert(
+  typeof gcloud === 'undefined',
+  'require(firebase-admin)',
+  'Firestore module already loaded'
+);
+
+// Calling admin.firestore should load Firestore
+utils.assert(
+  typeof admin.firestore !== 'undefined',
+  'admin.firestore',
+  'Firestore namespace could not be loaded.'
+);
+gcloud = require.cache[require.resolve('@google-cloud/firestore')];
+utils.assert(
+  typeof gcloud !== 'undefined',
+  'admin.firestore',
+  'Firestore module not loaded'
+);
 
 /**
  * Prompts the developer whether the Database rules should be

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -112,11 +112,13 @@ utils.assert(
 );
 
 // Calling admin.firestore should load Firestore
+const firestoreNamespace = admin.firestore;
 utils.assert(
-  typeof admin.firestore !== 'undefined',
+  typeof firestoreNamespace !== 'undefined',
   'admin.firestore',
   'Firestore namespace could not be loaded.'
 );
+
 gcloud = require.cache[require.resolve('@google-cloud/firestore')];
 utils.assert(
   typeof gcloud !== 'undefined',


### PR DESCRIPTION
After this fix, we only `require` Firestore conditionally. This means, the SDK won't require `@google-cloud/firestore` until we call `admin.firestore`. In the transpiled JS code, there are 2 instances that require this module. But both of them are now in functions that need to be invoked explicitly:

```
$ grep -r -A 5 -B 5 "require('@google-cloud/firestore')" lib/
lib/firebase-namespace.js-        get: function () {
lib/firebase-namespace.js-            var ns = this;
lib/firebase-namespace.js-            var fn = function (app) {
lib/firebase-namespace.js-                return ns.ensureApp(app).firestore();
lib/firebase-namespace.js-            };
lib/firebase-namespace.js:            return Object.assign(fn, require('@google-cloud/firestore'));
lib/firebase-namespace.js-        },
lib/firebase-namespace.js-        enumerable: true,
lib/firebase-namespace.js-        configurable: true
lib/firebase-namespace.js-    });
lib/firebase-namespace.js-    /**
--
lib/firestore/firestore.js-                'Must initialize the SDK with a certificate credential or application default credentials ' +
lib/firestore/firestore.js-                'to use Cloud Firestore API.',
lib/firestore/firestore.js-        });
lib/firestore/firestore.js-    }
lib/firestore/firestore.js-    // Lazy-load the Firestore implementation here, which in turns loads gRPC.
lib/firestore/firestore.js:    var firestoreDatabase = require('@google-cloud/firestore');
lib/firestore/firestore.js-    return new firestoreDatabase(options);
lib/firestore/firestore.js-}
```

To test this, I patched the `require()` function to generate a log statement, and tried executing some Admin SDK statements. Here's everything loaded at initialization:

```
> let admin = require('firebase-admin');
Require emitted for: ./database/database
Require emitted for: ../default-namespace
Require emitted for: faye-websocket
Require emitted for: util
Require emitted for: websocket-driver
Require emitted for: ./driver/base
Require emitted for: events
Require emitted for: util
Require emitted for: ../streams
Require emitted for: stream
Require emitted for: util
Require emitted for: ./headers
Require emitted for: ./stream_reader
Require emitted for: ./driver/client
Require emitted for: crypto
Require emitted for: url
Require emitted for: util
Require emitted for: ../http_parser
Require emitted for: http-parser-js
Require emitted for: assert
Require emitted for: ./base
Require emitted for: ./hybi
Require emitted for: crypto
Require emitted for: util
Require emitted for: websocket-extensions
Require emitted for: ./parser
Require emitted for: ./pipeline
Require emitted for: ./cell
Require emitted for: ./functor
Require emitted for: ./ring_buffer
Require emitted for: ./pledge
Require emitted for: ./ring_buffer
Require emitted for: ./pledge
Require emitted for: ./base
Require emitted for: ./hybi/frame
Require emitted for: ./hybi/message
Require emitted for: ./proxy
Require emitted for: stream
Require emitted for: url
Require emitted for: util
Require emitted for: ./base
Require emitted for: ./headers
Require emitted for: ../http_parser
Require emitted for: ./driver/server
Require emitted for: util
Require emitted for: ../http_parser
Require emitted for: ./base
Require emitted for: ./draft75
Require emitted for: ./base
Require emitted for: util
Require emitted for: ./draft76
Require emitted for: ./base
Require emitted for: ./draft75
Require emitted for: crypto
Require emitted for: util
Require emitted for: ./hybi
Require emitted for: ./websocket/api
Require emitted for: stream
Require emitted for: util
Require emitted for: websocket-driver
Require emitted for: ./api/event_target
Require emitted for: ./event
Require emitted for: ./api/event
Require emitted for: ./websocket/client
Require emitted for: util
Require emitted for: net
Require emitted for: tls
Require emitted for: crypto
Require emitted for: url
Require emitted for: websocket-driver
Require emitted for: ./api
Require emitted for: ./api/event
Require emitted for: ./eventsource
Require emitted for: stream
Require emitted for: util
Require emitted for: websocket-driver
Require emitted for: websocket-driver/lib/websocket/driver/headers
Require emitted for: ./websocket/api
Require emitted for: ./websocket/api/event_target
Require emitted for: ./websocket/api/event
```

And, when we try to use Firestore...

```
admin.firestore
Require emitted for: @google-cloud/firestore
Require emitted for: bun
Require emitted for: readable-stream
Require emitted for: stream
Require emitted for: ./lib/_stream_readable.js
...truncated...
```