### PR TITLE
Removed skrinkwrap File

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@ Here are some highlights of the directory structure and notable source files
 * `verifyReleaseTarball.sh` - Installs and validates the release tarballs created by
   `createReleaseTarball.sh`.
 * `gulpfile.js` - Defines the `gulp` tasks necessary for building release artifacts.
+* `package-lock.json` - A snapshot of the dependency tree for development and CI purposes.
 * `tslint.json` - TypeScript linting rules.
 * `tsconfig.json` - TypeScript configuration options.
 * `tsconfig-lint.json` - TypeScript configuration options for the linter. This simply widens

--- a/createReleaseTarball.sh
+++ b/createReleaseTarball.sh
@@ -89,13 +89,13 @@ sed -i '' -e s/"\"version\": \".*\""/"\"version\": \"${VERSION_WITHOUT_RC}\""/ p
 echo
 
 
-####################################
-#  REGENERATE npm-shrinkwrap.json  #
-####################################
-echo "[INFO] Removing lib/, node_modules/, and npm-shrinkwrap..."
-rm -rf lib/ node_modules/ npm-shrinkwrap.json
+############################
+#  REINSTALL DEPENDENCIES  #
+############################
+echo "[INFO] Removing lib/, and node_modules/..."
+rm -rf lib/ node_modules/
 if [[ $? -ne 0 ]]; then
-  echo "Error: Failed to remove lib/, node_modules/, and npm-shrinkwrap."
+  echo "Error: Failed to remove lib/, and node_modules/."
   exit 1
 fi
 echo
@@ -104,14 +104,6 @@ echo "[INFO] Installing production node modules..."
 npm install --production
 if [[ $? -ne 0 ]]; then
   echo "Error: Failed to install production node modules."
-  exit 1
-fi
-echo
-
-echo "[INFO] Regenerating npm-shrinkwrap.json file..."
-npm shrinkwrap
-if [[ $? -ne 0 ]]; then
-  echo "Error: Failed to regenerate npm-shrinkwrap.json file."
   exit 1
 fi
 echo
@@ -190,5 +182,5 @@ echo
 ##############
 
 echo "[INFO] firebase-admin-${VERSION}.tgz successfully created!"
-echo "[INFO] Create a CL for the updated package.json and npm-shrinkwrap.json if this is an actual release."
+echo "[INFO] Create a CL for the updated package.json if this is an actual release."
 echo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "5.4.4",
+  "version": "5.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -141,9 +141,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@types/bluebird": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.16.tgz",
-      "integrity": "sha512-957wyvA86h7pv69cIGUQ1s5RKWFFuU4EyRQCV33TvL0oeJxM9L4hIKW9iomOf+HSEeKysG4RkNnPlhUvOtbHPg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.17.tgz",
+      "integrity": "sha512-1v3/dB01fkW5qTpZH5zjjBLgj97Jhpu/tjJt/g0LHMPTuj2D2a6sJhj9RcwqmXl+TtokCZQyaynxL4buN5G2WA==",
       "dev": true
     },
     "@types/chai": {
@@ -174,7 +174,7 @@
       "integrity": "sha512-vm5OGsKc61Sx/GTRMQ9d0H0PYCDebT78/bdIBPCoPEHdgp0etaH1RzMmkDygymUmyXTj3rdWQn0sRUpYKZzljA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.46"
+        "@types/node": "8.0.47"
       }
     },
     "@types/google-cloud__storage": {
@@ -182,7 +182,7 @@
       "resolved": "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.6.tgz",
       "integrity": "sha512-X/hXFBpcnrfUjm6Q+9wTqVOlxKY5vC5aFMB4AIOnpuIhWmksJ5uVwry9Tr60buoYmeWbBGtx5JRWACJK9MhC+Q==",
       "requires": {
-        "@types/node": "8.0.46"
+        "@types/node": "8.0.47"
       }
     },
     "@types/jsonwebtoken": {
@@ -190,13 +190,13 @@
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz",
       "integrity": "sha512-cVhxZfVCyTZd1P+2a+xXSR9to7hZTulNRLLCQMVfAevUqx2Ee+EgsiD/7pX8qvdXWP3nWgSoTjKRLMrIpdPVjQ==",
       "requires": {
-        "@types/node": "8.0.46"
+        "@types/node": "8.0.47"
       }
     },
     "@types/lodash": {
-      "version": "4.14.78",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.78.tgz",
-      "integrity": "sha512-AflcpYyLyf/VIgSJbG/WMx7Bk00UejtSjYUW176K7erXChVcZENFdgOKOKfOXX9MmcXKoZW1QVFbqYapkhn1rA==",
+      "version": "4.14.80",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.80.tgz",
+      "integrity": "sha512-FumgRtCaxilKUcgMnZCzH6K3gntIwLiLLIaR+UBGNZpT/N3ne2dKrDSGoGIxSHYpAjnq6kIVV0r51U+kLXX59A==",
       "dev": true
     },
     "@types/long": {
@@ -205,9 +205,9 @@
       "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/mocha": {
-      "version": "2.2.43",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
-      "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
+      "version": "2.2.44",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
       "dev": true
     },
     "@types/nock": {
@@ -216,13 +216,13 @@
       "integrity": "sha1-H75b3suUPBCad4VT+k0kAcuTlLQ=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.46"
+        "@types/node": "8.0.47"
       }
     },
     "@types/node": {
-      "version": "8.0.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.46.tgz",
-      "integrity": "sha512-rRkP4kb5JYIfAoRKaDbcdPZBcTNOgzSApyzhPN9e6rhViSJAWQGlSXIX5gc75iR02jikhpzy3usu31wMHllfFw=="
+      "version": "8.0.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
+      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ=="
     },
     "@types/promises-a-plus": {
       "version": "0.0.27",
@@ -237,16 +237,16 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.0",
-        "@types/node": "8.0.46"
+        "@types/node": "8.0.47"
       }
     },
     "@types/request-promise": {
-      "version": "4.1.38",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.38.tgz",
-      "integrity": "sha512-12eHLNHR3dQ0m9it2TKA6bGK5gni3f39lPsaI1/8goOwRxLbJFoAgX9zuSYatXSQ8OpC6eTbjACGu34jCYBm4Q==",
+      "version": "4.1.39",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.39.tgz",
+      "integrity": "sha512-q9/VlE0osQ+EJ/UCF/MzH/xiF+wahQ4LG2i7lKkJuuWeRaM0GlhG29d11HUEFTKSL0gh3T1sJIpbYE7bwku9aQ==",
       "dev": true,
       "requires": {
-        "@types/bluebird": "3.5.16",
+        "@types/bluebird": "3.5.17",
         "@types/request": "2.0.6"
       }
     },
@@ -273,14 +273,14 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-      "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -1222,6 +1222,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3021,7 +3026,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -3074,7 +3079,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -3182,9 +3187,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -3550,6 +3555,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -3568,7 +3574,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "7.4.3",
@@ -3620,7 +3627,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -3671,7 +3678,7 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "load-json-file": {
@@ -4211,7 +4218,7 @@
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "cross-spawn": "5.1.0",
         "memory-streams": "0.1.2",
         "minimatch": "3.0.4",
@@ -4231,9 +4238,9 @@
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6319,7 +6326,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6330,7 +6337,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6366,7 +6373,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "regex-cache": {
@@ -6482,9 +6489,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -6629,9 +6636,9 @@
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
       }
@@ -6949,7 +6956,7 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "diff": "3.2.0",
         "make-error": "1.3.0",
         "minimist": "1.2.0",
@@ -6970,9 +6977,9 @@
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7035,7 +7042,7 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "underscore.string": "3.3.4"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "lib/",
     "LICENSE",
     "README.md",
-    "package.json",
-    "npm-shrinkwrap.json"
+    "package.json"
   ],
   "types": "./lib/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
Migrating from `npm-shrinkwrap.json` to `package-lock.json`. This file is far more stable than the shrinkwrap, and it cannot be published with releases. Users who install `firebase-admin` will get the dependencies as stated in our `package.json` file. Package lock also gets automatically updated when we update the `package.json` file.