### PR TITLE
Updated types to include potential for other keys in AppOptions.

### DIFF
--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -45,6 +45,7 @@ export type FirebaseAppOptions = {
   databaseURL?: string,
   storageBucket?: string,
   projectId?: string,
+  authDomain?: string,
 };
 
 /**

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -45,7 +45,6 @@ export type FirebaseAppOptions = {
   databaseURL?: string,
   storageBucket?: string,
   projectId?: string,
-  authDomain?: string,
 };
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,6 +47,8 @@ declare namespace admin {
     databaseAuthVariableOverride?: Object;
     databaseURL?: string;
     storageBucket?: string;
+    projectId?: string;
+    authDomain?: string;
   }
 
   var SDK_VERSION: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,6 @@ declare namespace admin {
     databaseURL?: string;
     storageBucket?: string;
     projectId?: string;
-    authDomain?: string;
   }
 
   var SDK_VERSION: string;


### PR DESCRIPTION
### Discussion

Since the updates to Firebase Functions (firebase/firebase-functions#127, firebase/firebase-functions#138) ```config()``` function, it seems the ```AppOptions``` type needs to be updated to correctly reflect what keys might be present on the object. I might be missing some (not sure exactly what keys might be present), but I added those that I've used previously (worked previously because ```config().firebase``` used to be of type ```any```).

### API Changes

Only changes to the type definitions.
