### PR TITLE
fix(package): drop unused dep google-auth-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,10 @@
   ],
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@firebase/database": "^0.1.3",
     "@firebase/app": "^0.1.1",
-    "google-auth-library": "^0.10.0",
-    "@google-cloud/storage": "^1.2.1",
+    "@firebase/database": "^0.1.3",
     "@google-cloud/firestore": "^0.10.0",
+    "@google-cloud/storage": "^1.2.1",
     "@types/google-cloud__storage": "^1.1.1",
     "@types/jsonwebtoken": "^7.1.33",
     "@types/node": "^8.0.32",


### PR DESCRIPTION
I was trying to integration-test a semver major update, that includes some [breaking changes](https://github.com/google/google-auth-library-nodejs/releases/tag/1.0.0-alpha.1), being made over at [google-auth-library](https://github.com/google/google-auth-library-nodejs). To my surprise, all tests passed. It turns out the package.json is the only thing that depends on `google-auth-library`.