### PR TITLE
Fixing some Firestore test warnings, caused by failure to find ADC

### DIFF
--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -16,6 +16,7 @@
 
 'use strict';
 
+import path = require('path');
 import * as _ from 'lodash';
 import {expect} from 'chai';
 
@@ -37,6 +38,8 @@ describe('Firestore', () => {
   const invalidCredError = 'Failed to initialize Google Cloud Firestore client with the available '
     + 'credentials. Must initialize the SDK with a certificate credential or application default '
     + 'credentials to use Cloud Firestore API.';
+
+  const mockServiceAccount = path.resolve(__dirname, '../../resources/mock.key.json');
 
   beforeEach(() => {
     appCredentials = process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -104,6 +107,7 @@ describe('Firestore', () => {
     it('should not throw given application default credentials without project ID', () => {
       // Project ID not set in the environment.
       delete process.env.GCLOUD_PROJECT;
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = mockServiceAccount;
       expect(() => {
         return new FirestoreService(defaultCredentialApp);
       }).not.to.throw();
@@ -147,6 +151,7 @@ describe('Firestore', () => {
 
     it('should return a string when project ID is present in environment', () => {
       process.env.GCLOUD_PROJECT = 'env-project-id';
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = mockServiceAccount;
       expect((new FirestoreService(defaultCredentialApp).client as any).projectId).to.equal('env-project-id');
     });
   });


### PR DESCRIPTION
This is to fix some warnings observed in the Travis CI environment (which does not have application default credentials set up).

Before the fix:

```
Firestore
    Initializer
      ✓ should throw given invalid app: null
      ✓ should throw given invalid app: null
      ✓ should throw given invalid app: 0
      ✓ should throw given invalid app: 1
      ✓ should throw given invalid app: true
      ✓ should throw given invalid app: false
      ✓ should throw given invalid app: ""
      ✓ should throw given invalid app: "a"
      ✓ should throw given invalid app: []
      ✓ should throw given invalid app: [1,"a"]
      ✓ should throw given invalid app: {}
      ✓ should throw given invalid app: {"a":1}
      ✓ should throw given invalid app: undefined
      ✓ should throw given no app
      ✓ should throw given an invalid credential with project ID
      ✓ should throw given an invalid credential without project ID
      ✓ should not throw given a valid app
      ✓ should not throw given application default credentials without project ID
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 143): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 144): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 145): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 146): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 147): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 148): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 149): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 150): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 151): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 152): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 153): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 154): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
(node:3248) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 155): Error: Could not load the default credentials. Browse to https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

After the fix:

```
 Firestore
    Initializer
      ✓ should throw given invalid app: null
      ✓ should throw given invalid app: null
      ✓ should throw given invalid app: 0
      ✓ should throw given invalid app: 1
      ✓ should throw given invalid app: true
      ✓ should throw given invalid app: false
      ✓ should throw given invalid app: ""
      ✓ should throw given invalid app: "a"
      ✓ should throw given invalid app: []
      ✓ should throw given invalid app: [1,"a"]
      ✓ should throw given invalid app: {}
      ✓ should throw given invalid app: {"a":1}
      ✓ should throw given invalid app: undefined
      ✓ should throw given no app
      ✓ should throw given an invalid credential with project ID
      ✓ should throw given an invalid credential without project ID
      ✓ should not throw given a valid app
      ✓ should not throw given application default credentials without project ID
    app
      ✓ returns the app from the constructor
      ✓ is read-only
    client
      ✓ returns the client from the constructor
      ✓ is read-only
    client.projectId
      ✓ should return a string when project ID is present in credential
      ✓ should return a string when project ID is present in app options
      ✓ should return a string when project ID is present in environment
```