### PR TITLE
Added Node 8 to the list of environments we test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "7"
   - "6"
-  - "5"
   - "4"


### PR DESCRIPTION
Node 8 is the latest stable release of Node.js. And according to #153 Node 5 is no longer supported upstream. Therefore this PR trades Node 5 for 8 in the set of environments tested in CI.