### PR TITLE
Exporting DocumentReference and DocumentSnapshot types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -413,6 +413,8 @@ declare namespace admin.storage {
 }
 
 declare namespace admin.firestore {
+  export import DocumentReference = _firestore.DocumentReference;
+  export import DocumentSnapshot = _firestore.DocumentSnapshot;
   export import FieldPath = _firestore.FieldPath;
   export import FieldValue = _firestore.FieldValue;
   export import Firestore = _firestore.Firestore;

--- a/test/integration/typescript/src/example.test.ts
+++ b/test/integration/typescript/src/example.test.ts
@@ -64,4 +64,9 @@ describe('Init App', () => {
         const fieldValue = admin.firestore.FieldValue;
         expect(fieldValue).to.not.be.null;
     });
+
+    it('Should return a DocumentReference', () => {
+        const ref: admin.firestore.DocumentReference = admin.firestore(app).collection('test').doc();
+        expect(ref).to.not.be.null;
+    });
 });


### PR DESCRIPTION
Enables TypeScript developers to reference above Firestore types via Admin SDK namespace.