### PR TITLE
Removing '# Unreleased' with sed instead of replacing

### DIFF
--- a/createReleaseTarball.sh
+++ b/createReleaseTarball.sh
@@ -92,7 +92,7 @@ echo
 #  UPDATE CHANGELOG.md  #
 #########################
 echo "[INFO] Updating version number in CHANGELOG.md to ${VERSION_WITHOUT_RC}..."
-sed -i '' -e "1 s/# Unreleased//" CHANGELOG.md
+sed -i '' -e "/^# Unreleased$/d" CHANGELOG.md
 echo -e "# Unrelased\n\n-\n\n# v${VERSION_WITHOUT_RC}" | cat - CHANGELOG.md > TEMP_CHANGELOG.md
 mv TEMP_CHANGELOG.md CHANGELOG.md
 


### PR DESCRIPTION
Replacing the pattern leaves an extra newline character around which has to be removed manually. I'm using a stricter pattern match here (with line delimiters), and then deleting the matched line with sed altogether.