### PR TITLE
Accept prefixed topic names

### DIFF
--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -429,9 +429,16 @@ function validateMessage(message: Message) {
   }
 
   const anyMessage = message as any;
-  if (anyMessage.topic && anyMessage.topic.startsWith('/topics/')) {
+  if (anyMessage.topic) {
     // If the topic name is prefixed, remove it.
-    anyMessage.topic = anyMessage.topic.replace(/^\/topics\//, '');
+    if (anyMessage.topic.startsWith('/topics/')) {
+      anyMessage.topic = anyMessage.topic.replace(/^\/topics\//, '');
+    }
+    // Checks for illegal characters and empty string.
+    if (!/^[a-zA-Z0-9-_.~%]+$/.test(anyMessage.topic)) {
+      throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD, 'Malformed topic name');
+    }
   }
 
   const targets = [anyMessage.token, anyMessage.topic, anyMessage.condition];

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -429,16 +429,16 @@ function validateMessage(message: Message) {
   }
 
   const anyMessage = message as any;
+  if (anyMessage.topic && anyMessage.topic.startsWith('/topics/')) {
+    // If the topic name is prefixed, remove it.
+    anyMessage.topic = anyMessage.topic.replace(/^\/topics\//, '');
+  }
+
   const targets = [anyMessage.token, anyMessage.topic, anyMessage.condition];
   if (targets.filter((v) => validator.isNonEmptyString(v)).length !== 1) {
     throw new FirebaseMessagingError(
       MessagingClientErrorCode.INVALID_PAYLOAD,
       'Exactly one of topic, token or condition is required');
-  }
-  if (anyMessage.topic && anyMessage.topic.startsWith('/topics/')) {
-    throw new FirebaseMessagingError(
-      MessagingClientErrorCode.INVALID_PAYLOAD,
-      'Topic name must be specified without the "/topics/" prefix');
   }
 
   validateStringMap(message.data, 'data');

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -374,6 +374,15 @@ describe('Messaging', () => {
       });
     });
 
+    const invalidTopics = ['/topics/', '/foo/bar', 'foo bar'];
+    invalidTopics.forEach((topic) => {
+      it(`should throw given invalid topic name: ${JSON.stringify(topic)}`, () => {
+        expect(() => {
+          messaging.send({topic});
+        }).to.throw('Malformed topic name');
+      });
+    });
+
     const targetMessages = [
       {token: 'mock-token'}, {topic: 'mock-topic'},
       {topic: '/topics/mock-topic'}, {condition: '"foo" in topics'},

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -365,12 +365,6 @@ describe('Messaging', () => {
       });
     });
 
-    it('should throw given message with invalid topic name', () => {
-      expect(() => {
-        messaging.send({topic: '/topics/foo'});
-      }).to.throw('Topic name must be specified without the "/topics/" prefix');
-    });
-
     const invalidDryRun = [null, NaN, 0, 1, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];
     invalidDryRun.forEach((dryRun) => {
       it(`should throw given invalid dryRun parameter: ${JSON.stringify(dryRun)}`, () => {
@@ -380,7 +374,10 @@ describe('Messaging', () => {
       });
     });
 
-    const targetMessages = [{token: 'mock-token'}, {topic: 'mock-topic'}, {condition: '"foo" in topics'}];
+    const targetMessages = [
+      {token: 'mock-token'}, {topic: 'mock-topic'},
+      {topic: '/topics/mock-topic'}, {condition: '"foo" in topics'},
+    ];
     targetMessages.forEach((message) => {
       it(`should be fulfilled with a message ID given a valid message: ${JSON.stringify(message)}`, () => {
         mockedRequests.push(mockSendRequest());
@@ -2306,6 +2303,21 @@ describe('Messaging', () => {
             expect(requestData.message).to.deep.equal(expectedReq);
           });
       });
+    });
+
+    it('should not throw when the message is addressed to the prefixed topic name', () => {
+      return mockApp.INTERNAL.getToken()
+        .then(() => {
+          httpsRequestStub = sinon.stub(https, 'request');
+          httpsRequestStub.callsArgWith(1, mockResponse).returns(mockRequestStream);
+          return messaging.send({topic: '/topics/mock-topic'});
+        })
+        .then(() => {
+          expect(requestWriteSpy).to.have.been.calledOnce;
+          const requestData = JSON.parse(requestWriteSpy.args[0][0]);
+          const expectedReq = {topic: 'mock-topic'};
+          expect(requestData.message).to.deep.equal(expectedReq);
+        });
     });
 
     it('should convert whitelisted camelCased properties to underscore_cased properties', () => {


### PR DESCRIPTION
The new FCM API does not accept topic names prefixed with `/topics/`. But we can easily check for this in the SDK and remove it. This results in a better and consistent dev experience since the other methods in this API accepts prefixed topic names.