### PR TITLE
Passing Admin SDK version to RTDB client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
--
+- [changed] Upgraded Realtime Database client to v0.1.11.
+- [changed] Modified the Realtime Database client integration to report the
+  correct user agent header.
 
 # v5.9.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,19 @@
   "requires": true,
   "dependencies": {
     "@firebase/app": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.2.tgz",
-      "integrity": "sha512-H2moN0Dl5LJn1AiRsCvwJsfE7PLKYYYJc+WKqAta+qIB/ZzBAay8NTVBYHiqsteLHc7gXofoi8zEUrGjbmz4OQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.10.tgz",
+      "integrity": "sha512-2GTXt3b2QZXkmx6/5nNJq+pEN/VTjAG55MFJS1WMoLVZkwKuNpWNk65QVyPaoL88x1iHtuLqAMFgJUOnhOg+Pw==",
       "requires": {
-        "@firebase/util": "0.1.2"
+        "@firebase/app-types": "0.1.2",
+        "@firebase/util": "0.1.10",
+        "tslib": "1.9.0"
       }
+    },
+    "@firebase/app-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.1.2.tgz",
+      "integrity": "sha512-bCIZGeMtP0ibrXNNaU214/1tRNw0jHnir/cfiAao1gjUyIS7RzOTQoH+zbwPJNEwUqJ0T3ykw/Tv4/khGqbVBg=="
     },
     "@firebase/auth": {
       "version": "0.2.2",
@@ -19,12 +26,14 @@
       "dev": true
     },
     "@firebase/database": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.3.tgz",
-      "integrity": "sha512-Uk9IRPYDmpDRBvnIZhs16iQX/7GxetslWD+7N6GKgEDmO9csPC+9hHmdXkcVc6cG7xHCePdRJGvhrVt3ax7Fcw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.11.tgz",
+      "integrity": "sha512-1TX8YlL3BCjgsbe1qvgg/r0SxOvIlJdmaktXXm6fnaPCjSD0Vhm5ln2EX3xGY97ft/Lruy9AA/7TfnAKIYA/+w==",
       "requires": {
-        "@firebase/util": "0.1.2",
-        "faye-websocket": "0.11.1"
+        "@firebase/database-types": "0.1.2",
+        "@firebase/util": "0.1.10",
+        "faye-websocket": "0.11.1",
+        "tslib": "1.9.0"
       },
       "dependencies": {
         "faye-websocket": {
@@ -36,6 +45,11 @@
           }
         }
       }
+    },
+    "@firebase/database-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.1.2.tgz",
+      "integrity": "sha512-WDqyclInvbD6qNtbVlatzXW6SpsV8V1Nz7DaTM8z27CwxRtXakAXxERPnGipA0ZbZV4v+Xs1+6wC7Xc6T4EVaw=="
     },
     "@firebase/firestore": {
       "version": "0.1.4",
@@ -95,9 +109,12 @@
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.2.tgz",
-      "integrity": "sha512-XzvnxTsPIukAJmBVpBOGTLVgz27Iyoudmum6Bqy8Czu2qhWjikhkE1UlND7Gh5BwTpBVr03axjovRXgh5xgIxw=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.10.tgz",
+      "integrity": "sha512-XEogRfUQBZ4T37TMq/3ZbuiTdRAKX8hF3TgJglUZNCJf/6QnQ+jlupCuMAXBqCGfw2Mw0m2matoCUBWpsyevOA==",
+      "requires": {
+        "tslib": "1.9.0"
+      }
     },
     "@firebase/webchannel-wrapper": {
       "version": "0.2.5",
@@ -1474,9 +1491,9 @@
       "integrity": "sha512-qI4qWZNO4/tS05goNaLYaxFd2/GgWVONPcqq+H1YyLi0ybWfF7oEVhw1dz8SY+7Xc5wc3S4jGSMi3apgINz1Zg==",
       "dev": true,
       "requires": {
-        "@firebase/app": "0.1.2",
+        "@firebase/app": "0.1.10",
         "@firebase/auth": "0.2.2",
-        "@firebase/database": "0.1.3",
+        "@firebase/database": "0.1.11",
         "@firebase/firestore": "0.1.4",
         "@firebase/messaging": "0.1.6",
         "@firebase/polyfill": "0.1.3",
@@ -7824,8 +7841,7 @@
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "tslint": {
       "version": "5.9.1",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   ],
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@firebase/app": "^0.1.1",
-    "@firebase/database": "^0.1.3",
+    "@firebase/app": "^0.1.10",
+    "@firebase/database": "^0.1.11",
     "@google-cloud/firestore": "^0.11.2",
     "@google-cloud/storage": "^1.2.1",
     "@types/google-cloud__storage": "^1.1.1",

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -66,7 +66,8 @@ export class DatabaseService implements FirebaseServiceInterface {
     let db: Database = this.INTERNAL.databases[dbUrl];
     if (typeof db === 'undefined') {
       const rtdb = require('@firebase/database');
-      db = rtdb.initStandalone(this.appInternal, dbUrl).instance;
+      const { version } = require('../../package.json');
+      db = rtdb.initStandalone(this.appInternal, dbUrl, version).instance;
       this.INTERNAL.databases[dbUrl] = db;
     }
     return db;


### PR DESCRIPTION
Related change in JS SDK: https://github.com/firebase/firebase-js-sdk/pull/524

I've verified the correct user-agent header is being passed by adding some log statements to the RTDB client code:

```
{ headers: { 'User-Agent': 'Firebase/5/5.9.0/darwin/AdminNode' } }
```

Resolves #134 