### PR TITLE
Send email verification

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -287,6 +287,19 @@ export const FIREBASE_AUTH_SIGN_UP_NEW_USER = new ApiSettings('signupNewUser', '
         'INTERNAL ASSERT FAILED: Unable to create new user');
     }
   });
+/**
+ * Instantiates the getOobConfirmationCode endpoint settings for sending a verification email.
+ */
+export const FIREBASE_AUTH_GET_OOB_CONFIRMATION_CODE = new ApiSettings('getOobConfirmationCode', 'POST')
+  // Set request validator.
+  .setRequestValidator((request: any) => {
+    // requestType is required
+    if (typeof request.requestType === 'undefined') {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INTERNAL_ERROR,
+        'INTERNAL ASSERT FAILED: Server request is missing request type');
+    }
+  });
 
 /**
  * Class that provides mechanism to send requests to the Firebase Auth backend endpoints.

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -319,6 +319,15 @@ export class Auth implements FirebaseServiceInterface {
       });
   }
 
+  public async sendEmailVerification(uid: string): Promise<void> {
+    const customToken = await this.createCustomToken(uid);
+    const { idToken } = await this.authRequestHandler.verifyCustomToken(customToken);
+
+    await this.authRequestHandler.sendEmailVerification(idToken);
+
+    return;
+  }
+
   /**
    * Sets additional developer claims on an existing user identified by the provided UID.
    *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -163,6 +163,7 @@ declare namespace admin.auth {
     getUserByPhoneNumber(phoneNumber: string): Promise<admin.auth.UserRecord>;
     listUsers(maxResults?: number, pageToken?: string): Promise<admin.auth.ListUsersResult>;
     updateUser(uid: string, properties: admin.auth.UpdateRequest): Promise<admin.auth.UserRecord>;
+    sendEmailVerification(uid: string): Promise<void>;
     verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<admin.auth.DecodedIdToken>;
     setCustomUserClaims(uid: string, customUserClaims: Object): Promise<void>;
     revokeRefreshTokens(uid: string): Promise<void>;


### PR DESCRIPTION
Fixes #46 

Adds `admin.auth().sendEmailVerification(uid)`. Tested it locally and it works great.

This could be made much nicer if the `/getOobConfirmationCode` endpoint was changed to optionally accept a `localId` (uid) instead of an `idToken`. This is how the other endpoints work. This would make the process use one less REST call and not require the use of `createCustomToken` which isn't supported by all environments. 

Let me know if this is going in the right direction and I'll clean it up a bit and add tests (or you can).