### PR TITLE
Removing calls to some deprecated Sinon APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1035,11 +1035,17 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
+        "arr-union": "3.1.0",
         "define-property": "0.2.5",
         "isobject": "3.0.1",
         "static-extend": "0.1.2"
       },
       "dependencies": {
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -2270,15 +2276,6 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      }
-    },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
       }
     },
     "fragment-cache": {
@@ -5000,9 +4997,9 @@
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
     },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
     },
     "long": {
@@ -5311,24 +5308,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
+      "integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
+        "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "1.6.0",
+        "lolex": "2.3.2",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        }
       }
     },
     "nock": {
@@ -8255,17 +8244,17 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
-      "integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.5.tgz",
+      "integrity": "sha512-vsg06IyB4gM5ry1qq13cQQk2U5ZqbL40ygDRNklYx2kokZktakyfinPDJP00WY0WjizRg2p0yhKLuTsCRpwCUA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "5.2.0",
+        "lolex": "2.3.2",
+        "nise": "1.3.0",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {
@@ -8276,9 +8265,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -9228,11 +9217,17 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
+        "arr-union": "3.1.0",
         "get-value": "2.0.6",
         "is-extendable": "0.1.1",
         "set-value": "0.4.3"
       },
       "dependencies": {
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "request-promise": "^4.1.1",
     "run-sequence": "^1.1.5",
     "scrypt": "^6.0.3",
-    "sinon": "^4.3.0",
+    "sinon": "^4.4.5",
     "sinon-chai": "^2.8.0",
     "ts-node": "^3.3.0",
     "tslint": "^5.9.0",

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -92,7 +92,7 @@ describe('FirebaseApp', () => {
       delete process.env[FIREBASE_CONFIG_VAR];
     }
 
-    deleteSpy.reset();
+    deleteSpy.resetHistory();
     (firebaseNamespaceInternals.removeApp as any).restore();
 
     _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
@@ -907,7 +907,7 @@ describe('FirebaseApp', () => {
     });
 
     afterEach(() => {
-      addAuthTokenListenerSpy.reset();
+      addAuthTokenListenerSpy.resetHistory();
     });
 
     it('is notified when the token changes', () => {
@@ -964,7 +964,7 @@ describe('FirebaseApp', () => {
     });
 
     afterEach(() => {
-      addAuthTokenListenerSpies.forEach((spy) => spy.reset());
+      addAuthTokenListenerSpies.forEach((spy) => spy.resetHistory());
     });
 
     it('removes the listener', () => {

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -309,7 +309,7 @@ describe('FirebaseNamespace', () => {
 
       const app = firebaseNamespace.initializeApp(mocks.appOptions, mocks.appName);
 
-      appHook.reset();
+      appHook.resetHistory();
 
       firebaseNamespace.INTERNAL.removeApp(mocks.appName);
 


### PR DESCRIPTION
Addressing the deprecation warnings:

```
FirebaseApp
    #name
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return the app's name
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should be case sensitive
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should respect leading and trailing whitespace
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should be read-only
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
    #options
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return the app's options
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should be read-only
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should not return an object which can mutate the underlying options
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should ignore the config file when options is not null
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should throw when the environment variable points to non existing file
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should throw when the environment variable contains bad json
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should throw when the environment variable points to an empty file
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should throw when the environment variable points to bad json
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should ignore a bad config key in the config file
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should ignore a bad config key in the json string
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should not throw when the config file has a bad key and the config file is unused
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should not throw when the config json has a bad key and the config json is unused
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should use explicitly specified options when available and ignore the config file
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should not throw if some fields are missing
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should not throw when the config environment variable is not set, and some options are present
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should init with application default creds when no options provided and env variable is not set
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should init with application default creds when no options provided and env variable is an empty json
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should init when no init arguments are provided and config var points to a file
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should init when no init arguments are provided and config var is json
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
    #delete()
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should call removeApp() on the Firebase namespace internals
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should call delete() on each service's internals
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
    auth()
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return the Auth namespace
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return a cached version of Auth on subsequent calls
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
    messaging()
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return the Messaging namespace
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return a cached version of Messaging on subsequent calls
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
    database()
      ✓ should throw if the app has already been deleted
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ should return the Database

```