### PR TITLE
Supporting APNS mutable-content option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
--
+- [added] Added the `mutableContent` optional field to the `Aps` type of
+  the FCM API.
+- [added] Added the support for specifying arbitrary custom key-value
+  fields in the `Aps` type.
 
 # v5.11.0
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -405,8 +405,10 @@ declare namespace admin.messaging {
     badge?: number;
     sound?: string;
     contentAvailable?: boolean;
+    mutableContent?: boolean;
     category?: string;
     threadId?: string;
+    [customField: string]: any;
   };
 
   type ApsAlert = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -408,7 +408,7 @@ declare namespace admin.messaging {
     mutableContent?: boolean;
     category?: string;
     threadId?: string;
-    [customField: string]: any;
+    [customData: string]: any;
   };
 
   type ApsAlert = {

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -153,7 +153,7 @@ export interface Aps {
   category?: string;
   threadId?: string;
   mutableContent?: boolean;
-  [customField: string]: any;
+  [customData: string]: any;
 }
 
 export interface ApsAlert {

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -152,6 +152,8 @@ export interface Aps {
   contentAvailable?: boolean;
   category?: string;
   threadId?: string;
+  mutableContent?: boolean;
+  [customField: string]: any;
 }
 
 export interface ApsAlert {
@@ -274,15 +276,32 @@ function validateAps(aps: Aps) {
 
   const propertyMappings = {
     contentAvailable: 'content-available',
+    mutableContent: 'mutable-content',
     threadId: 'thread-id',
   };
+  Object.keys(propertyMappings).forEach((key) => {
+    if (key in aps && propertyMappings[key] in aps) {
+      throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD, `Multiple specifications for ${key} in Aps`);
+    }
+  });
   renameProperties(aps, propertyMappings);
 
-  if (typeof aps['content-available'] !== 'undefined') {
-    if (aps['content-available'] === true) {
+  const contentAvailable = aps['content-available'];
+  if (typeof contentAvailable !== 'undefined' && contentAvailable !== 1) {
+    if (contentAvailable === true) {
       aps['content-available'] = 1;
     } else {
       delete aps['content-available'];
+    }
+  }
+
+  const mutableContent = aps['mutable-content'];
+  if (typeof mutableContent !== 'undefined' && mutableContent !== 1) {
+    if (mutableContent === true) {
+      aps['mutable-content'] = 1;
+    } else {
+      delete aps['mutable-content'];
     }
   }
 }

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -1827,6 +1827,18 @@ describe('Messaging', () => {
         }).to.throw('apns.payload.aps must be a non-null object');
       });
     });
+    it(`should throw given APNS payload with duplicate fields`, () => {
+      expect(() => {
+        messaging.send({
+          apns: {
+            payload: {
+              aps: {'mutableContent': true, 'mutable-content': 1},
+            },
+          },
+          token: 'token',
+        });
+      }).to.throw('Multiple specifications for mutableContent in Aps');
+    });
 
     const invalidApnsAlerts: any = [null, [], true, 1.23];
     invalidApnsAlerts.forEach((alert) => {
@@ -2252,6 +2264,7 @@ describe('Messaging', () => {
                 sound: 'test.sound',
                 category: 'test.category',
                 contentAvailable: true,
+                mutableContent: true,
                 threadId: 'thread.id',
               },
               customKey1: 'custom.value',
@@ -2278,6 +2291,7 @@ describe('Messaging', () => {
                 'sound': 'test.sound',
                 'category': 'test.category',
                 'content-available': 1,
+                'mutable-content': 1,
                 'thread-id': 'thread.id',
               },
               customKey1: 'custom.value',
@@ -2301,6 +2315,67 @@ describe('Messaging', () => {
           apns: {
             payload: {
               aps: {},
+            },
+          },
+        },
+      },
+      {
+        label: 'APNS content-available set explicitly',
+        req: {
+          apns: {
+            payload: {
+              aps: {
+                'content-available': 1,
+              },
+            },
+          },
+        },
+        expectedReq: {
+          apns: {
+            payload: {
+              aps: {'content-available': 1},
+            },
+          },
+        },
+      },
+      {
+        label: 'APNS mutableContent explicitly false',
+        req: {
+          apns: {
+            payload: {
+              aps: {
+                mutableContent: false,
+              },
+            },
+          },
+        },
+        expectedReq: {
+          apns: {
+            payload: {
+              aps: {},
+            },
+          },
+        },
+      },
+      {
+        label: 'APNS custom fields',
+        req: {
+          apns: {
+            payload: {
+              aps: {
+                k1: 'v1',
+                k2: true,
+              },
+            },
+          },
+        },
+        expectedReq: {
+          apns: {
+            payload: {
+              aps: {
+                k1: 'v1',
+                k2: true,
+              },
             },
           },
         },


### PR DESCRIPTION
Explicitly supporting the `mutable-content` option for APNS messages.

```
type Aps = {
  mutableContent?: boolean;
  [customData]: any;
}
```