### PR TITLE
Adds support for Firebase Auth session management.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "run-s lint test:unit",
     "integration": "run-s build test:integration",
     "test:unit": "mocha test/unit/*.spec.ts --compilers ts:ts-node/register",
-    "test:integration": "mocha test/integration/*.ts --slow 5000 --compilers ts:ts-node/register",
+    "test:integration": "mocha test/integration/*.ts --slow 5000 --timeout 5000 --compilers ts:ts-node/register",
     "test:coverage": "nyc npm run test:unit",
     "lint:src": "tslint --format stylish -p tsconfig.json",
     "lint:unit": "tslint -c tslint-test.json --format stylish test/unit/*.ts test/unit/**/*.ts",

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -59,6 +59,12 @@ const MAX_DOWNLOAD_ACCOUNT_PAGE_SIZE = 1000;
 /** Maximum allowed number of users to batch upload at one time. */
 const MAX_UPLOAD_ACCOUNT_BATCH_SIZE = 1000;
 
+/** Minimum allowed session cookie duration in seconds (5 minutes). */
+const MIN_SESSION_COOKIE_DURATION_SECS = 5 * 60;
+
+/** Maximum allowed session cookie duration in seconds (2 weeks). */
+const MAX_SESSION_COOKIE_DURATION_SECS = 14 * 24 * 60 * 60;
+
 
 /**
  * Validates a providerUserInfo object. All unsupported parameters
@@ -287,6 +293,31 @@ function validateCreateEditRequest(request: any, uploadAccountRequest: boolean =
 }
 
 
+/** Instantiates the createSessionCookie endpoint settings. */
+export const FIREBASE_AUTH_CREATE_SESSION_COOKIE =
+    new ApiSettings('createSessionCookie', 'POST')
+        // Set request validator.
+        .setRequestValidator((request: any) => {
+          // Validate the ID token is a non-empty string.
+          if (!validator.isNonEmptyString(request.idToken)) {
+            throw new FirebaseAuthError(AuthClientErrorCode.INVALID_ID_TOKEN);
+          }
+          // Validate the custom session cookie duration.
+          if (!validator.isNumber(request.validDuration) ||
+              request.validDuration < MIN_SESSION_COOKIE_DURATION_SECS ||
+              request.validDuration > MAX_SESSION_COOKIE_DURATION_SECS) {
+            throw new FirebaseAuthError(AuthClientErrorCode.INVALID_SESSION_COOKIE_DURATION);
+          }
+        })
+        // Set response validator.
+        .setResponseValidator((response: any) => {
+          // Response should always contain the session cookie.
+          if (!response.sessionCookie || !validator.isNonEmptyString(response.sessionCookie)) {
+            throw new FirebaseAuthError(AuthClientErrorCode.INTERNAL_ERROR);
+          }
+        });
+
+
 /** Instantiates the uploadAccount endpoint settings. */
 export const FIREBASE_AUTH_UPLOAD_ACCOUNT = new ApiSettings('uploadAccount', 'POST');
 
@@ -419,6 +450,26 @@ export class FirebaseAuthRequestHandler {
    */
   constructor(app: FirebaseApp) {
     this.signedApiRequestHandler = new SignedApiRequestHandler(app);
+  }
+
+  /**
+   * Creates a new Firebase session cookie with the specified duration that can be used for
+   * session management (set as a server side session cookie with custom cookie policy).
+   * The session cookie JWT will have the same payload claims as the provided ID token.
+   *
+   * @param {string} idToken The Firebase ID token to exchange for a session cookie.
+   * @param {number} expiresIn The session cookie duration.
+   *
+   * @return {Promise<string>} A promise that resolves on success with the created session cookie.
+   */
+  public createSessionCookie(idToken: string, expiresIn: number): Promise<string> {
+    const request = {
+      idToken,
+      // Convert to seconds.
+      validDuration: expiresIn / 1000,
+    };
+    return this.invokeRequestHandler(FIREBASE_AUTH_CREATE_SESSION_COOKIE, request)
+        .then((response: any) => response.sessionCookie);
   }
 
   /**

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -51,7 +51,7 @@ export interface ListUsersResult {
 }
 
 
-/** Inteface representing a decoded ID token. */
+/** Interface representing a decoded ID token. */
 export interface DecodedIdToken {
   aud: string;
   auth_time: number;
@@ -67,6 +67,13 @@ export interface DecodedIdToken {
   iss: string;
   sub: string;
   [key: string]: any;
+}
+
+
+/** Interface representing the session cookie options. */
+export interface SessionCookieOptions {
+  expiresIn: number;
+  refreshThreshold?: number;
 }
 
 
@@ -171,23 +178,9 @@ export class Auth implements FirebaseServiceInterface {
         if (!checkRevoked) {
           return decodedIdToken;
         }
-        // Get tokens valid after time for the corresponding user.
-        return this.getUser(decodedIdToken.sub)
-          .then((user: UserRecord) => {
-            // If no tokens valid after time available, token is not revoked.
-            if (user.tokensValidAfterTime) {
-              // Get the ID token authentication time and convert to milliseconds UTC.
-              const authTimeUtc = decodedIdToken.auth_time * 1000;
-              // Get user tokens valid after time in milliseconds UTC.
-              const validSinceUtc = new Date(user.tokensValidAfterTime).getTime();
-              // Check if authentication time is older than valid since time.
-              if (authTimeUtc < validSinceUtc) {
-                throw new FirebaseAuthError(AuthClientErrorCode.ID_TOKEN_REVOKED);
-              }
-            }
-            // All checks above passed. Return the decoded token.
-            return decodedIdToken;
-          });
+        return this.verifyDecodedJWTNotRevoked(
+          decodedIdToken,
+          new FirebaseAuthError(AuthClientErrorCode.ID_TOKEN_REVOKED));
       });
   }
 
@@ -370,5 +363,86 @@ export class Auth implements FirebaseServiceInterface {
   public importUsers(
       users: UserImportRecord[], options?: UserImportOptions): Promise<UserImportResult> {
     return this.authRequestHandler.uploadAccount(users, options);
+  }
+
+  /**
+   * Creates a new Firebase session cookie with the specified options that can be used for
+   * session management (set as a server side session cookie with custom cookie policy).
+   * The session cookie JWT will have the same payload claims as the provided ID token.
+   *
+   * @param {string} idToken The Firebase ID token to exchange for a session cookie.
+   * @param {SessionCookieOptions} sessionCookieOptions The session cookie options which includes
+   *     custom session duration.
+   *
+   * @return {Promise<string>} A promise that resolves on success with the created session cookie.
+   */
+  public createSessionCookie(
+      idToken: string, sessionCookieOptions: SessionCookieOptions): Promise<string> {
+    return this.authRequestHandler.createSessionCookie(
+      idToken, sessionCookieOptions && sessionCookieOptions.expiresIn);
+  }
+
+  /**
+   * Verifies a Firebase session cookie. Returns a Promise with the tokens claims. Rejects
+   * the promise if the token could not be verified. If checkRevoked is set to true,
+   * verifies if the session corresponding to the session cookie was revoked. If the corresponding
+   * user's session was invalidated, an auth/session-cookie-revoked error is thrown. If not
+   * specified the check is not applied.
+   *
+   * @param {string} sessionCookie The session cookie to verify.
+   * @param {boolean=} checkRevoked Whether to check if the session cookie is revoked.
+   * @return {Promise<DecodedIdToken>} A Promise that will be fulfilled after a successful
+   *     verification.
+   */
+  public verifySessionCookie(
+      sessionCookie: string, checkRevoked: boolean = false): Promise<DecodedIdToken> {
+    if (typeof this.tokenGenerator_ === 'undefined') {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_CREDENTIAL,
+        'Must initialize app with a cert credential or set your Firebase project ID as the ' +
+        'GCLOUD_PROJECT environment variable to call auth().verifySessionCookie().',
+      );
+    }
+    return this.tokenGenerator_.verifySessionCookie(sessionCookie)
+      .then((decodedIdToken: DecodedIdToken) => {
+        // Whether to check if the token was revoked.
+        if (!checkRevoked) {
+          return decodedIdToken;
+        }
+        return this.verifyDecodedJWTNotRevoked(
+          decodedIdToken,
+          new FirebaseAuthError(AuthClientErrorCode.SESSION_COOKIE_REVOKED));
+      });
+  }
+
+  /**
+   * Verifies the decoded Firebase issued JWT is not revoked. Returns a promise that resolves
+   * with the decoded claims on success. Rejects the promise with revocation error if revoked.
+   *
+   * @param {DecodedIdToken} decodedIdToken The JWT's decoded claims.
+   * @param {FirebaseAuthError} revocationError The revocation error to throw on revocation
+   *     detection.
+   * @return {Promise<DecodedIdToken>} A Promise that will be fulfilled after a successful
+   *     verification.
+   */
+  private verifyDecodedJWTNotRevoked(
+      decodedIdToken: DecodedIdToken, revocationError: FirebaseAuthError): Promise<DecodedIdToken> {
+    // Get tokens valid after time for the corresponding user.
+    return this.getUser(decodedIdToken.sub)
+      .then((user: UserRecord) => {
+        // If no tokens valid after time available, token is not revoked.
+        if (user.tokensValidAfterTime) {
+          // Get the ID token authentication time and convert to milliseconds UTC.
+          const authTimeUtc = decodedIdToken.auth_time * 1000;
+          // Get user tokens valid after time in milliseconds UTC.
+          const validSinceUtc = new Date(user.tokensValidAfterTime).getTime();
+          // Check if authentication time is older than valid since time.
+          if (authTimeUtc < validSinceUtc) {
+            throw revocationError;
+          }
+        }
+        // All checks above passed. Return the decoded token.
+        return decodedIdToken;
+      });
   }
 }

--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -18,6 +18,7 @@ import {Certificate} from './credential';
 import {AuthClientErrorCode, FirebaseAuthError} from '../utils/error';
 
 import * as validator from '../utils/validator';
+import * as tokenVerify from './token-verifier';
 
 import * as jwt from 'jsonwebtoken';
 
@@ -38,6 +39,9 @@ const BLACKLISTED_CLAIMS = [
 // Auth ID tokens)
 const CLIENT_CERT_URL = 'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 
+// URL containing the public keys for Firebase session cookies. This will be updated to a different URL soon.
+const SESSION_COOKIE_CERT_URL = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys';
+
 // Audience to use for Firebase Auth Custom tokens
 const FIREBASE_AUDIENCE = 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit';
 
@@ -46,13 +50,33 @@ interface JWTPayload {
   uid?: string;
 }
 
+/** User facing token information related to the Firebase session cookie. */
+export const SESSION_COOKIE_INFO: tokenVerify.FirebaseTokenInfo = {
+  // Placeholder until documentation page is created for session cookies.
+  url: 'https://firebase.google.com/docs/auth/admin/verify-id-tokens',
+  verifyApiName: 'verifySessionCookie()',
+  jwtName: 'Firebase session cookie',
+  shortName: 'session cookie',
+  expiredErrorCode: 'auth/session-cookie-expired',
+};
+
+/** User facing token information related to the Firebase ID token. */
+export const ID_TOKEN_INFO: tokenVerify.FirebaseTokenInfo = {
+  url: 'https://firebase.google.com/docs/auth/admin/verify-id-tokens',
+  verifyApiName: 'verifyIdToken()',
+  jwtName: 'Firebase ID token',
+  shortName: 'ID token',
+  expiredErrorCode: 'auth/id-token-expired',
+};
+
+
 /**
  * Class for generating and verifying different types of Firebase Auth tokens (JWTs).
  */
 export class FirebaseTokenGenerator {
   private certificate_: Certificate;
-  private publicKeys_: object;
-  private publicKeysExpireAt_: number;
+  private sessionCookieVerifier: tokenVerify.FirebaseTokenVerifier;
+  private idTokenVerifier: tokenVerify.FirebaseTokenVerifier;
 
   constructor(certificate: Certificate) {
     if (!certificate) {
@@ -62,6 +86,20 @@ export class FirebaseTokenGenerator {
       );
     }
     this.certificate_ = certificate;
+    this.sessionCookieVerifier = new tokenVerify.FirebaseTokenVerifier(
+        SESSION_COOKIE_CERT_URL,
+        ALGORITHM,
+        'https://session.firebase.google.com/',
+        this.certificate_.projectId,
+        SESSION_COOKIE_INFO,
+    );
+    this.idTokenVerifier = new tokenVerify.FirebaseTokenVerifier(
+        CLIENT_CERT_URL,
+        ALGORITHM,
+        'https://securetoken.google.com/',
+        this.certificate_.projectId,
+        ID_TOKEN_INFO,
+    );
   }
 
   /**
@@ -138,107 +176,19 @@ export class FirebaseTokenGenerator {
    *                           token.
    */
   public verifyIdToken(idToken: string): Promise<object> {
-    if (typeof idToken !== 'string') {
-      throw new FirebaseAuthError(
-        AuthClientErrorCode.INVALID_ARGUMENT,
-        'First argument to verifyIdToken() must be a Firebase ID token string.',
-      );
-    }
-
-    if (!validator.isNonEmptyString(this.certificate_.projectId)) {
-      throw new FirebaseAuthError(
-        AuthClientErrorCode.INVALID_CREDENTIAL,
-        'verifyIdToken() requires a certificate with "project_id" set.',
-      );
-    }
-
-    const fullDecodedToken: any = jwt.decode(idToken, {
-      complete: true,
-    });
-
-    const header = fullDecodedToken && fullDecodedToken.header;
-    const payload = fullDecodedToken && fullDecodedToken.payload;
-
-    const projectIdMatchMessage = ' Make sure the ID token comes from the same Firebase project as the ' +
-      'service account used to authenticate this SDK.';
-    const verifyIdTokenDocsMessage = ' See https://firebase.google.com/docs/auth/admin/verify-id-tokens ' +
-      'for details on how to retrieve an ID token.';
-
-    let errorMessage: string;
-    if (!fullDecodedToken) {
-      errorMessage = 'Decoding Firebase ID token failed. Make sure you passed the entire string JWT ' +
-        'which represents an ID token.' + verifyIdTokenDocsMessage;
-    } else if (typeof header.kid === 'undefined') {
-      const isCustomToken = (payload.aud === FIREBASE_AUDIENCE);
-      const isLegacyCustomToken = (header.alg === 'HS256' && payload.v === 0 && 'd' in payload && 'uid' in payload.d);
-
-      if (isCustomToken) {
-        errorMessage = 'verifyIdToken() expects an ID token, but was given a custom token.';
-      } else if (isLegacyCustomToken) {
-        errorMessage = 'verifyIdToken() expects an ID token, but was given a legacy custom token.';
-      } else {
-        errorMessage = 'Firebase ID token has no "kid" claim.';
-      }
-
-      errorMessage += verifyIdTokenDocsMessage;
-    } else if (header.alg !== ALGORITHM) {
-      errorMessage = 'Firebase ID token has incorrect algorithm. Expected "' + ALGORITHM + '" but got ' +
-        '"' + header.alg + '".' + verifyIdTokenDocsMessage;
-    } else if (payload.aud !== this.certificate_.projectId) {
-      errorMessage = 'Firebase ID token has incorrect "aud" (audience) claim. Expected "' +
-        this.certificate_.projectId + '" but got "' + payload.aud + '".' + projectIdMatchMessage +
-        verifyIdTokenDocsMessage;
-    } else if (payload.iss !== 'https://securetoken.google.com/' + this.certificate_.projectId) {
-      errorMessage = 'Firebase ID token has incorrect "iss" (issuer) claim. Expected ' +
-        '"https://securetoken.google.com/' + this.certificate_.projectId + '" but got "' +
-        payload.iss + '".' + projectIdMatchMessage + verifyIdTokenDocsMessage;
-    } else if (typeof payload.sub !== 'string') {
-      errorMessage = 'Firebase ID token has no "sub" (subject) claim.' + verifyIdTokenDocsMessage;
-    } else if (payload.sub === '') {
-      errorMessage = 'Firebase ID token has an empty string "sub" (subject) claim.' + verifyIdTokenDocsMessage;
-    } else if (payload.sub.length > 128) {
-      errorMessage = 'Firebase ID token has "sub" (subject) claim longer than 128 characters.' +
-        verifyIdTokenDocsMessage;
-    }
-
-    if (typeof errorMessage !== 'undefined') {
-      return Promise.reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_ARGUMENT, errorMessage));
-    }
-
-    return this.fetchPublicKeys_().then((publicKeys) => {
-      if (!publicKeys.hasOwnProperty(header.kid)) {
-        return Promise.reject(
-          new FirebaseAuthError(
-            AuthClientErrorCode.INVALID_ARGUMENT,
-            'Firebase ID token has "kid" claim which does not correspond to a known public key. ' +
-            'Most likely the ID token is expired, so get a fresh token from your client app and ' +
-            'try again.' + verifyIdTokenDocsMessage,
-          ),
-        );
-      }
-
-      return new Promise((resolve, reject) => {
-        jwt.verify(idToken, publicKeys[header.kid], {
-          algorithms: [ALGORITHM],
-        }, (error, decodedToken: any) => {
-          if (error) {
-            if (error.name === 'TokenExpiredError') {
-              errorMessage = 'Firebase ID token has expired. Get a fresh token from your client app and try ' +
-                'again (auth/id-token-expired).' + verifyIdTokenDocsMessage;
-            } else if (error.name === 'JsonWebTokenError') {
-              errorMessage = 'Firebase ID token has invalid signature.' + verifyIdTokenDocsMessage;
-            }
-
-            return reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_ARGUMENT, errorMessage));
-          } else {
-            decodedToken.uid = decodedToken.sub;
-            resolve(decodedToken);
-          }
-        });
-      });
-    });
+    return this.idTokenVerifier.verifyJWT(idToken);
   }
 
+  /**
+   * Verifies the format and signature of a Firebase session cookie JWT.
+   *
+   * @param {string} sessionCookie The Firebase session cookie to verify.
+   * @return {Promise<object>} A promise fulfilled with the decoded claims of the Firebase session
+   *                           cookie.
+   */
+  public verifySessionCookie(sessionCookie: string): Promise<object> {
+    return this.sessionCookieVerifier.verifyJWT(sessionCookie);
+  }
 
   /**
    * Returns whether or not the provided developer claims are valid.
@@ -257,62 +207,5 @@ export class FirebaseTokenGenerator {
 
     return false;
   }
-
-
-  /**
-   * Fetches the public keys for the Google certs.
-   *
-   * @return {Promise<object>} A promise fulfilled with public keys for the Google certs.
-   */
-  private fetchPublicKeys_(): Promise<object> {
-    const publicKeysExist = (typeof this.publicKeys_ !== 'undefined');
-    const publicKeysExpiredExists = (typeof this.publicKeysExpireAt_ !== 'undefined');
-    const publicKeysStillValid = (publicKeysExpiredExists && Date.now() < this.publicKeysExpireAt_);
-    if (publicKeysExist && publicKeysStillValid) {
-      return Promise.resolve(this.publicKeys_);
-    }
-
-    return new Promise((resolve, reject) => {
-      https.get(CLIENT_CERT_URL, (res) => {
-        const buffers: Buffer[] = [];
-
-        res.on('data', (buffer) => buffers.push(buffer as Buffer));
-
-        res.on('end', () => {
-          try {
-            const response = JSON.parse(Buffer.concat(buffers).toString());
-
-            if (response.error) {
-              let errorMessage = 'Error fetching public keys for Google certs: ' + response.error;
-              /* istanbul ignore else */
-              if (response.error_description) {
-                errorMessage += ' (' + response.error_description + ')';
-              }
-
-              reject(new FirebaseAuthError(AuthClientErrorCode.INTERNAL_ERROR, errorMessage));
-            } else {
-              /* istanbul ignore else */
-              if (res.headers.hasOwnProperty('cache-control')) {
-                const cacheControlHeader: string = res.headers['cache-control'] as string;
-                const parts = cacheControlHeader.split(',');
-                parts.forEach((part) => {
-                  const subParts = part.trim().split('=');
-                  if (subParts[0] === 'max-age') {
-                    const maxAge: number = +subParts[1];
-                    this.publicKeysExpireAt_ = Date.now() + (maxAge * 1000);
-                  }
-                });
-              }
-
-              this.publicKeys_ = response;
-              resolve(response);
-            }
-          } catch (e) {
-            /* istanbul ignore next */
-            reject(e);
-          }
-        });
-      }).on('error', reject);
-    });
-  }
 }
+

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -1,0 +1,283 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AuthClientErrorCode, FirebaseAuthError} from '../utils/error';
+
+import * as validator from '../utils/validator';
+
+import * as jwt from 'jsonwebtoken';
+
+// Use untyped import syntax for Node built-ins
+import https = require('https');
+
+// Audience to use for Firebase Auth Custom tokens
+const FIREBASE_AUDIENCE = 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit';
+
+/** Interface that defines token related user facing information. */
+export interface FirebaseTokenInfo {
+  /** Documentation URL. */
+  url: string;
+  /** verify API name. */
+  verifyApiName: string;
+  /** The JWT full name. */
+  jwtName: string;
+  /** The JWT short name. */
+  shortName: string;
+  /** JWT Expiration error code. */
+  expiredErrorCode: string;
+}
+
+/**
+ * Class for verifying general purpose Firebase JWTs. This verifies ID tokens and session cookies.
+ */
+export class FirebaseTokenVerifier {
+  private publicKeys: object;
+  private publicKeysExpireAt: number;
+
+  constructor(private clientCertUrl: string, private algorithm: string,
+              private issuer: string, private projectId: string,
+              private tokenInfo: FirebaseTokenInfo) {
+    if (!validator.isURL(clientCertUrl)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The provided public client certificate URL is an invalid URL.`,
+      );
+    } else if (!validator.isNonEmptyString(algorithm)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The provided JWT algorithm is an empty string.`,
+      );
+    } else if (!validator.isURL(issuer)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The provided JWT issuer is an invalid URL.`,
+      );
+    } else if (!validator.isNonNullObject(tokenInfo)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The provided JWT information is not an object or null.`,
+      );
+    } else if (!validator.isURL(tokenInfo.url)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The provided JWT verification documentation URL is invalid.`,
+      );
+    } else if (!validator.isNonEmptyString(tokenInfo.verifyApiName)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The JWT verify API name must be a non-empty string.`,
+      );
+    } else if (!validator.isNonEmptyString(tokenInfo.jwtName)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The JWT public full name must be a non-empty string.`,
+      );
+    } else if (!validator.isNonEmptyString(tokenInfo.shortName)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The JWT public short name must be a non-empty string.`,
+      );
+    } else if (!validator.isNonEmptyString(tokenInfo.expiredErrorCode)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `The JWT expiration error code must be a non-empty string.`,
+      );
+    }
+    // For backward compatibility, the project ID is validated in the verification call.
+  }
+
+  /**
+   * Verifies the format and signature of a Firebase Auth JWT token.
+   *
+   * @param {string} jwtToken The Firebase Auth JWT token to verify.
+   * @return {Promise<object>} A promise fulfilled with the decoded claims of the Firebase Auth ID
+   *                           token.
+   */
+  public verifyJWT(jwtToken: string): Promise<object> {
+    if (typeof jwtToken !== 'string') {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_ARGUMENT,
+        `First argument to ${this.tokenInfo.verifyApiName} must be a ${this.tokenInfo.jwtName} string.`,
+      );
+    }
+
+    if (!validator.isNonEmptyString(this.projectId)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_CREDENTIAL,
+        `${this.tokenInfo.verifyApiName} requires a certificate with "project_id" set.`,
+      );
+    }
+
+    const fullDecodedToken: any = jwt.decode(jwtToken, {
+      complete: true,
+    });
+
+    const header = fullDecodedToken && fullDecodedToken.header;
+    const payload = fullDecodedToken && fullDecodedToken.payload;
+
+    const projectIdMatchMessage = ` Make sure the ${this.tokenInfo.shortName} comes from the same ` +
+      `Firebase project as the service account used to authenticate this SDK.`;
+    const verifyJwtTokenDocsMessage = ` See ${this.tokenInfo.url} ` +
+      `for details on how to retrieve an ${this.tokenInfo.shortName}.`;
+
+    let errorMessage: string;
+    if (!fullDecodedToken) {
+      errorMessage = `Decoding ${this.tokenInfo.jwtName} failed. Make sure you passed the entire string JWT ` +
+        `which represents an ${this.tokenInfo.shortName}.` + verifyJwtTokenDocsMessage;
+    } else if (typeof header.kid === 'undefined') {
+      const isCustomToken = (payload.aud === FIREBASE_AUDIENCE);
+      const isLegacyCustomToken = (header.alg === 'HS256' && payload.v === 0 && 'd' in payload && 'uid' in payload.d);
+
+      if (isCustomToken) {
+        errorMessage = `${this.tokenInfo.verifyApiName} expects an ${this.tokenInfo.shortName}, but ` +
+          `was given a custom token.`;
+      } else if (isLegacyCustomToken) {
+        errorMessage = `${this.tokenInfo.verifyApiName} expects an ${this.tokenInfo.shortName}, but ` +
+          `was given a legacy custom token.`;
+      } else {
+        errorMessage = 'Firebase ID token has no "kid" claim.';
+      }
+
+      errorMessage += verifyJwtTokenDocsMessage;
+    } else if (header.alg !== this.algorithm) {
+      errorMessage = `${this.tokenInfo.jwtName} has incorrect algorithm. Expected "` + this.algorithm + `" but got ` +
+        `"` + header.alg + `".` + verifyJwtTokenDocsMessage;
+    } else if (payload.aud !== this.projectId) {
+      errorMessage = `${this.tokenInfo.jwtName} has incorrect "aud" (audience) claim. Expected "` +
+        this.projectId + `" but got "` + payload.aud + `".` + projectIdMatchMessage +
+        verifyJwtTokenDocsMessage;
+    } else if (payload.iss !== this.issuer + this.projectId) {
+      errorMessage = `${this.tokenInfo.jwtName} has incorrect "iss" (issuer) claim. Expected ` +
+        `"${this.issuer}"` + this.projectId + `" but got "` +
+        payload.iss + `".` + projectIdMatchMessage + verifyJwtTokenDocsMessage;
+    } else if (typeof payload.sub !== 'string') {
+      errorMessage = `${this.tokenInfo.jwtName} has no "sub" (subject) claim.` + verifyJwtTokenDocsMessage;
+    } else if (payload.sub === '') {
+      errorMessage = `${this.tokenInfo.jwtName} has an empty string "sub" (subject) claim.` + verifyJwtTokenDocsMessage;
+    } else if (payload.sub.length > 128) {
+      errorMessage = `${this.tokenInfo.jwtName} has "sub" (subject) claim longer than 128 characters.` +
+        verifyJwtTokenDocsMessage;
+    }
+    if (typeof errorMessage !== 'undefined') {
+      return Promise.reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_ARGUMENT, errorMessage));
+    }
+
+    return this.fetchPublicKeys().then((publicKeys) => {
+      if (!publicKeys.hasOwnProperty(header.kid)) {
+        return Promise.reject(
+          new FirebaseAuthError(
+            AuthClientErrorCode.INVALID_ARGUMENT,
+            `${this.tokenInfo.jwtName} has "kid" claim which does not correspond to a known public key. ` +
+            `Most likely the ${this.tokenInfo.shortName} is expired, so get a fresh token from your ` +
+            `client app and try again.`,
+          ),
+        );
+      } else {
+        return this.verifyJwtSignatureWithKey(jwtToken, publicKeys[header.kid]);
+      }
+
+    });
+  }
+
+  /**
+   * Verifies the JWT signature using the provided public key.
+   * @param {string} jwtToken The JWT token to verify.
+   * @param {string} publicKey The public key certificate.
+   * @return {Promise<object>} A promise that resolves with the decoded JWT claims on successful
+   *     verification.
+   */
+  private verifyJwtSignatureWithKey(jwtToken: string, publicKey: string): Promise<object> {
+    let errorMessage: string;
+    const verifyJwtTokenDocsMessage = ` See ${this.tokenInfo.url} ` +
+      `for details on how to retrieve an ${this.tokenInfo.shortName}.`;
+    return new Promise((resolve, reject) => {
+      jwt.verify(jwtToken, publicKey, {
+        algorithms: [this.algorithm],
+      }, (error, decodedToken: any) => {
+        if (error) {
+          if (error.name === 'TokenExpiredError') {
+            errorMessage = `${this.tokenInfo.jwtName} has expired. Get a fresh token from your client ` +
+              `app and try again (${this.tokenInfo.expiredErrorCode}).` + verifyJwtTokenDocsMessage;
+          } else if (error.name === 'JsonWebTokenError') {
+            errorMessage = `${this.tokenInfo.jwtName} has invalid signature.` + verifyJwtTokenDocsMessage;
+          }
+
+          return reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_ARGUMENT, errorMessage));
+        } else {
+          decodedToken.uid = decodedToken.sub;
+          resolve(decodedToken);
+        }
+      });
+    });
+  }
+
+  /**
+   * Fetches the public keys for the Google certs.
+   *
+   * @return {Promise<object>} A promise fulfilled with public keys for the Google certs.
+   */
+  private fetchPublicKeys(): Promise<object> {
+    const publicKeysExist = (typeof this.publicKeys !== 'undefined');
+    const publicKeysExpiredExists = (typeof this.publicKeysExpireAt !== 'undefined');
+    const publicKeysStillValid = (publicKeysExpiredExists && Date.now() < this.publicKeysExpireAt);
+    if (publicKeysExist && publicKeysStillValid) {
+      return Promise.resolve(this.publicKeys);
+    }
+
+    return new Promise((resolve, reject) => {
+      https.get(this.clientCertUrl, (res) => {
+        const buffers: Buffer[] = [];
+
+        res.on('data', (buffer) => buffers.push(buffer as Buffer));
+
+        res.on('end', () => {
+          try {
+            const response = JSON.parse(Buffer.concat(buffers).toString());
+
+            if (response.error) {
+              let errorMessage = 'Error fetching public keys for Google certs: ' + response.error;
+              /* istanbul ignore else */
+              if (response.error_description) {
+                errorMessage += ' (' + response.error_description + ')';
+              }
+
+              reject(new FirebaseAuthError(AuthClientErrorCode.INTERNAL_ERROR, errorMessage));
+            } else {
+              /* istanbul ignore else */
+              if (res.headers.hasOwnProperty('cache-control')) {
+                const cacheControlHeader: string = res.headers['cache-control'] as string;
+                const parts = cacheControlHeader.split(',');
+                parts.forEach((part) => {
+                  const subParts = part.trim().split('=');
+                  if (subParts[0] === 'max-age') {
+                    const maxAge: number = +subParts[1];
+                    this.publicKeysExpireAt = Date.now() + (maxAge * 1000);
+                  }
+                });
+              }
+
+              this.publicKeys = response;
+              resolve(response);
+            }
+          } catch (e) {
+            /* istanbul ignore next */
+            reject(e);
+          }
+        });
+      }).on('error', reject);
+    });
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -200,6 +200,11 @@ declare namespace admin.auth {
     passwordSalt?: Buffer;
   }
 
+  interface SessionCookieOptions {
+    expiresIn: number;
+    refreshThreshold?: number;
+  }
+
   interface Auth {
     app: admin.app.App;
 
@@ -218,6 +223,14 @@ declare namespace admin.auth {
       users: admin.auth.UserImportRecord[],
       options?: admin.auth.UserImportOptions,
     ): Promise<admin.auth.UserImportResult>
+    createSessionCookie(
+      idToken: string,
+      sessionCookieOptions: admin.auth.SessionCookieOptions,
+    ): Promise<string>;
+    verifySessionCookie(
+      sessionCookie: string,
+      checkForRevocation?: boolean,
+    ): Promise<admin.auth.DecodedIdToken>;
   }
 }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -318,6 +318,10 @@ export class AuthClientErrorCode {
     code: 'claims-too-large',
     message: 'Developer claims maximum payload size exceeded.',
   };
+  public static ID_TOKEN_EXPIRED = {
+    code: 'id-token-expired',
+    message: 'The provided Firebase ID token is expired.',
+  };
   public static INVALID_ARGUMENT = {
     code: 'argument-error',
     message: 'Invalid argument provided.',
@@ -329,6 +333,10 @@ export class AuthClientErrorCode {
   public static FORBIDDEN_CLAIM = {
     code: 'reserved-claim',
     message: 'The specified developer claim is reserved and cannot be specified.',
+  };
+  public static INVALID_ID_TOKEN = {
+    code: 'invalid-id-token',
+    message: 'The provided ID token is not a valid Firebase ID token.',
   };
   public static ID_TOKEN_REVOKED = {
     code: 'id-token-revoked',
@@ -436,6 +444,11 @@ export class AuthClientErrorCode {
     code: 'invalid-provider-id',
     message: 'The providerId must be a valid supported provider identifier string.',
   };
+  public static INVALID_SESSION_COOKIE_DURATION = {
+    code: 'invalid-session-cookie-duration',
+    message: 'The session cookie duration must be a valid number in milliseconds ' +
+      'between 5 minutes and 2 weeks.',
+  };
   public static INVALID_UID = {
     code: 'invalid-uid',
     message: 'The uid must be a non-empty string with at most 128 characters.',
@@ -481,6 +494,10 @@ export class AuthClientErrorCode {
       'has insufficient permission to access the requested resource. See ' +
       'https://firebase.google.com/docs/admin/setup for details on how to authenticate this SDK ' +
       'with appropriate permissions.',
+  };
+  public static SESSION_COOKIE_REVOKED = {
+    code: 'session-cookie-revoked',
+    message: 'The Firebase session cookie has been revoked.',
   };
   public static UID_ALREADY_EXISTS = {
     code: 'uid-already-exists',
@@ -627,8 +644,12 @@ const AUTH_SERVER_TO_CLIENT_CODE: ServerToClientCode = {
   FORBIDDEN_CLAIM: 'FORBIDDEN_CLAIM',
   // Invalid claims provided.
   INVALID_CLAIMS: 'INVALID_CLAIMS',
+  // Invalid session cookie duration.
+  INVALID_DURATION: 'INVALID_SESSION_COOKIE_DURATION',
   // Invalid email provided.
   INVALID_EMAIL: 'INVALID_EMAIL',
+  // Invalid ID token provided.
+  INVALID_ID_TOKEN: 'INVALID_ID_TOKEN',
   // Invalid page token.
   INVALID_PAGE_SELECTION: 'INVALID_PAGE_TOKEN',
   // Invalid phone number.
@@ -645,6 +666,8 @@ const AUTH_SERVER_TO_CLIENT_CODE: ServerToClientCode = {
   PHONE_NUMBER_EXISTS: 'PHONE_NUMBER_ALREADY_EXISTS',
   // Project not found.
   PROJECT_NOT_FOUND: 'PROJECT_NOT_FOUND',
+  // Token expired error.
+  TOKEN_EXPIRED: 'ID_TOKEN_EXPIRED',
   // User on which action is to be performed is not found.
   USER_NOT_FOUND: 'USER_NOT_FOUND',
   // Password provided is too weak.

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -202,9 +202,9 @@ export function isURL(urlStr: any): boolean {
     if (!/^[a-zA-Z0-9]+[\w\-]*([\.]?[a-zA-Z0-9]+[\w\-]*)*$/.test(hostname)) {
       return false;
     }
-    // Allow for pathnames: (/chars+)*
+    // Allow for pathnames: (/chars+)*/?
     // Where chars can be a combination of: a-z A-Z 0-9 - _ . ~ ! $ & ' ( ) * + , ; = : @ %
-    const pathnameRe = /^(\/[\w\-\.\~\!\$\'\(\)\*\+\,\;\=\:\@\%]+)*$/;
+    const pathnameRe = /^(\/[\w\-\.\~\!\$\'\(\)\*\+\,\;\=\:\@\%]+)*\/?$/;
     // Validate pathname.
     if (pathname &&
         pathname !== '/' &&

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -185,6 +185,28 @@ export function generateIdToken(overrides?: object): string {
   return jwt.sign(developerClaims, certificateObject.private_key, options);
 }
 
+/**
+ * Generates a mocked Firebase session cookie.
+ *
+ * @param {object=} overrides Overrides for the generated token's attributes.
+ * @param {number=} expiresIn Optional custom session cookie expiration in seconds.
+ * @return {string} A mocked Firebase session cookie with any provided overrides included.
+ */
+export function generateSessionCookie(overrides?: object, expiresIn?: number): string {
+  const options = _.assign({
+    audience: projectId,
+    expiresIn: expiresIn || ONE_HOUR_IN_SECONDS,
+    issuer: 'https://session.firebase.google.com/' + projectId,
+    subject: uid,
+    algorithm: ALGORITHM,
+    header: {
+      kid: certificateObject.private_key_id,
+    },
+  }, overrides);
+
+  return jwt.sign(developerClaims, certificateObject.private_key, options);
+}
+
 export function firebaseServiceFactory(
   firebaseApp: FirebaseApp,
   extendApp: (props: object) => void,

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -1,0 +1,546 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Use untyped import syntax for Node built-ins
+import https = require('https');
+
+import * as _ from 'lodash';
+import * as jwt from 'jsonwebtoken';
+import * as chai from 'chai';
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import LegacyFirebaseTokenGenerator = require('firebase-token-generator');
+
+import * as mocks from '../../resources/mocks';
+import {
+  FirebaseTokenGenerator, SESSION_COOKIE_INFO, ID_TOKEN_INFO,
+} from '../../../src/auth/token-generator';
+import {FirebaseTokenVerifier, FirebaseTokenInfo} from '../../../src/auth/token-verifier';
+
+import {Certificate} from '../../../src/auth/credential';
+
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
+
+const ONE_HOUR_IN_SECONDS = 60 * 60;
+
+
+/**
+ * Returns a mocked out success response from the URL containing the public keys for the Google certs.
+ *
+ * @return {Object} A nock response object.
+ */
+function mockFetchPublicKeys(): nock.Scope {
+  const mockedResponse = {};
+  mockedResponse[mocks.certificateObject.private_key_id] = mocks.keyPairs[0].public;
+  return nock('https://www.googleapis.com')
+    .get('/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com')
+    .reply(200, mockedResponse, {
+      'cache-control': 'public, max-age=1, must-revalidate, no-transform',
+    });
+}
+
+/**
+ * Returns a mocked out success response from the URL containing the public keys for the Google certs
+ * which contains a public key which won't match the mocked token.
+ *
+ * @return {Object} A nock response object.
+ */
+function mockFetchWrongPublicKeys(): nock.Scope {
+  const mockedResponse = {};
+  mockedResponse[mocks.certificateObject.private_key_id] = mocks.keyPairs[1].public;
+  return nock('https://www.googleapis.com')
+    .get('/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com')
+    .reply(200, mockedResponse, {
+      'cache-control': 'public, max-age=1, must-revalidate, no-transform',
+    });
+}
+
+/**
+ * Returns a mocked out error response from the URL containing the public keys for the Google certs.
+ * The status code is 200 but the response itself will contain an 'error' key.
+ *
+ * @return {Object} A nock response object.
+ */
+function mockFetchPublicKeysWithErrorResponse(): nock.Scope {
+  return nock('https://www.googleapis.com')
+    .get('/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com')
+    .reply(200, {
+      error: 'message',
+      error_description: 'description',
+    });
+}
+
+/**
+ * Returns a mocked out failed response from the URL containing the public keys for the Google certs.
+ * The status code is non-200 and the response itself will fail.
+ *
+ * @return {Object} A nock response object.
+ */
+function mockFailedFetchPublicKeys(): nock.Scope {
+  return nock('https://www.googleapis.com')
+    .get('/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com')
+    .replyWithError('message');
+}
+
+
+describe('FirebaseTokenVerifier', () => {
+  let tokenVerifier: FirebaseTokenVerifier;
+  let tokenGenerator: FirebaseTokenGenerator;
+  let clock: sinon.SinonFakeTimers;
+  let httpsSpy: sinon.SinonSpy;
+  beforeEach(() => {
+    // Needed to generate custom token for testing.
+    tokenGenerator = new FirebaseTokenGenerator(new Certificate(mocks.certificateObject));
+    tokenVerifier = new FirebaseTokenVerifier(
+      'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
+      'RS256',
+      'https://securetoken.google.com/',
+      'project_id',
+      ID_TOKEN_INFO,
+    );
+    httpsSpy = sinon.spy(https, 'get');
+  });
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+      clock = undefined;
+    }
+    httpsSpy.restore();
+  });
+
+  after(() => {
+    nock.cleanAll();
+  });
+
+  describe('Constructor', () => {
+    it('should not throw when valid arguments are provided', () =>  {
+      expect(() => {
+        tokenVerifier = new FirebaseTokenVerifier(
+          'https://www.example.com/publicKeys',
+          'RS256',
+          'https://www.example.com/issuer/',
+          'project_id',
+          {
+            url: 'https://docs.example.com/verify-tokens',
+            verifyApiName: 'verifyToken()',
+            jwtName: 'Important Token',
+            shortName: 'token',
+            expiredErrorCode: 'auth/important-token-expired',
+          },
+       );
+      }).not.to.throw();
+    });
+
+    const invalidCertURLs = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, 'file://invalid'];
+    invalidCertURLs.forEach((invalidCertUrl) => {
+      it('should throw given a non-URL public cert: ' + JSON.stringify(invalidCertUrl), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            invalidCertUrl as any,
+            'RS256',
+            'https://www.example.com/issuer/',
+            'project_id',
+            ID_TOKEN_INFO);
+        }).to.throw('The provided public client certificate URL is an invalid URL.');
+      });
+    });
+
+    const invalidAlgorithms = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, ''];
+    invalidAlgorithms.forEach((invalidAlgorithm) => {
+      it('should throw given an invalid algorithm: ' + JSON.stringify(invalidAlgorithm), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            invalidAlgorithm as any,
+            'https://www.example.com/issuer/',
+            'project_id',
+            ID_TOKEN_INFO);
+        }).to.throw('The provided JWT algorithm is an empty string.');
+      });
+    });
+
+    const invalidIssuers = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, 'file://invalid'];
+    invalidIssuers.forEach((invalidIssuer) => {
+      it('should throw given a non-URL issuer: ' + JSON.stringify(invalidIssuer), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            'RS256',
+            invalidIssuer as any,
+            'project_id',
+            ID_TOKEN_INFO);
+        }).to.throw('The provided JWT issuer is an invalid URL.');
+      });
+    });
+
+    const invalidVerifyApiNames = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, ''];
+    invalidVerifyApiNames.forEach((invalidVerifyApiName) => {
+      it('should throw given an invalid verify API name: ' + JSON.stringify(invalidVerifyApiName), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            'RS256',
+            'https://www.example.com/issuer/',
+            'project_id',
+            {
+              url: 'https://docs.example.com/verify-tokens',
+              verifyApiName: invalidVerifyApiName as any,
+              jwtName: 'Important Token',
+              shortName: 'token',
+              expiredErrorCode: 'auth/important-token-expired',
+            });
+        }).to.throw('The JWT verify API name must be a non-empty string.');
+      });
+    });
+
+    const invalidJwtNames = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, ''];
+    invalidJwtNames.forEach((invalidJwtName) => {
+      it('should throw given an invalid JWT full name: ' + JSON.stringify(invalidJwtName), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            'RS256',
+            'https://www.example.com/issuer/',
+            'project_id',
+            {
+              url: 'https://docs.example.com/verify-tokens',
+              verifyApiName: 'verifyToken()',
+              jwtName: invalidJwtName as any,
+              shortName: 'token',
+              expiredErrorCode: 'auth/important-token-expired',
+            });
+        }).to.throw('The JWT public full name must be a non-empty string.');
+      });
+    });
+
+    const invalidShortNames = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, ''];
+    invalidShortNames.forEach((invalidShortName) => {
+      it('should throw given an invalid JWT short name: ' + JSON.stringify(invalidShortName), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            'RS256',
+            'https://www.example.com/issuer/',
+            'project_id',
+            {
+              url: 'https://docs.example.com/verify-tokens',
+              verifyApiName: 'verifyToken()',
+              jwtName: 'Important Token',
+              shortName: invalidShortName as any,
+              expiredErrorCode: 'auth/important-token-expired',
+            });
+        }).to.throw('The JWT public short name must be a non-empty string.');
+      });
+    });
+
+    const invalidExpiredErrorCodes = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop, ''];
+    invalidExpiredErrorCodes.forEach((invalidExpiredErrorCode) => {
+      it('should throw given an invalid expiration error code: ' + JSON.stringify(invalidExpiredErrorCode), () => {
+        expect(() => {
+          new FirebaseTokenVerifier(
+            'https://www.example.com/publicKeys',
+            'RS256',
+            'https://www.example.com/issuer/',
+            'project_id',
+            {
+              url: 'https://docs.example.com/verify-tokens',
+              verifyApiName: 'verifyToken()',
+              jwtName: 'Important Token',
+              shortName: 'token',
+              expiredErrorCode: invalidExpiredErrorCode as any,
+            });
+        }).to.throw('The JWT expiration error code must be a non-empty string.');
+      });
+    });
+  });
+
+  describe('verifyJWT()', () => {
+    let mockedRequests: nock.Scope[] = [];
+
+    afterEach(() => {
+      _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
+      mockedRequests = [];
+    });
+
+    it('should throw given no Firebase JWT token', () => {
+      expect(() => {
+        (tokenVerifier as any).verifyJWT();
+      }).to.throw('First argument to verifyIdToken() must be a Firebase ID token');
+    });
+
+    const invalidIdTokens = [null, NaN, 0, 1, true, false, [], {}, { a: 1 }, _.noop];
+    invalidIdTokens.forEach((invalidIdToken) => {
+      it('should throw given a non-string Firebase JWT token: ' + JSON.stringify(invalidIdToken), () => {
+        expect(() => {
+          tokenVerifier.verifyJWT(invalidIdToken as any);
+        }).to.throw('First argument to verifyIdToken() must be a Firebase ID token');
+      });
+    });
+
+    it('should throw given an empty string Firebase JWT token', () => {
+      return tokenVerifier.verifyJWT('')
+        .should.eventually.be.rejectedWith('Decoding Firebase ID token failed');
+    });
+
+    it('should be rejected given an invalid Firebase JWT token', () => {
+      return tokenVerifier.verifyJWT('invalid-token')
+        .should.eventually.be.rejectedWith('Decoding Firebase ID token failed');
+    });
+
+    it('should throw if the token verifier was initialized with no "project_id"', () => {
+      const tokenVerifierWithNoProjectId = new FirebaseTokenVerifier(
+        'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
+        'RS256',
+        'https://securetoken.google.com/',
+        undefined as any,
+        ID_TOKEN_INFO,
+      );
+      const mockIdToken = mocks.generateIdToken();
+
+      expect(() => {
+        tokenVerifierWithNoProjectId.verifyJWT(mockIdToken);
+      }).to.throw('verifyIdToken() requires a certificate with "project_id" set');
+    });
+
+    it('should be rejected given a Firebase JWT token with no kid', () => {
+      const mockIdToken = mocks.generateIdToken({
+        header: {foo: 'bar'},
+      });
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has no "kid" claim');
+    });
+
+    it('should be rejected given a Firebase JWT token with a kid which does not match any of the ' +
+        'actual public keys', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      const mockIdToken = mocks.generateIdToken({
+        header: {
+          kid: 'wrongkid',
+        },
+      });
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has "kid" claim which does not ' +
+          'correspond to a known public key');
+    });
+
+    it('should be rejected given a Firebase JWT token with an incorrect algorithm', () => {
+      const mockIdToken = mocks.generateIdToken({
+        algorithm: 'HS256',
+      });
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has incorrect algorithm');
+    });
+
+    it('should be rejected given a Firebase JWT token with an incorrect audience', () => {
+      const mockIdToken = mocks.generateIdToken({
+        audience: 'incorrectAudience',
+      });
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has incorrect "aud" (audience) claim');
+    });
+
+    it('should be rejected given a Firebase JWT token with an incorrect issuer', () => {
+      const mockIdToken = mocks.generateIdToken({
+        issuer: 'incorrectIssuer',
+      });
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has incorrect "iss" (issuer) claim');
+    });
+
+    it('should be rejected given a Firebase JWT token with a subject with greater than 128 characters', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      // uid of length 128 should be fulfilled
+      let uid = Array(129).join('a');
+      expect(uid).to.have.length(128);
+      let mockIdToken = mocks.generateIdToken({
+        subject: uid,
+      });
+      return tokenVerifier.verifyJWT(mockIdToken).then(() => {
+        // uid of length 129 should be rejected
+        uid = Array(130).join('a');
+        expect(uid).to.have.length(129);
+        mockIdToken = mocks.generateIdToken({
+          subject: uid,
+        });
+
+        return tokenVerifier.verifyJWT(mockIdToken)
+          .should.eventually.be.rejectedWith('Firebase ID token has "sub" (subject) claim longer than 128 characters');
+      });
+    });
+
+    it('should be rejected given an expired Firebase JWT token', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      clock = sinon.useFakeTimers(1000);
+
+      const mockIdToken = mocks.generateIdToken();
+
+      clock.tick((ONE_HOUR_IN_SECONDS * 1000) - 1);
+
+      // Token should still be valid
+      return tokenVerifier.verifyJWT(mockIdToken).then(() => {
+        clock.tick(1);
+
+        // Token should now be invalid
+        return tokenVerifier.verifyJWT(mockIdToken)
+          .should.eventually.be.rejectedWith('Firebase ID token has expired. Get a fresh token from your client ' +
+            'app and try again (auth/id-token-expired)');
+      });
+    });
+
+    it('should be rejected given a Firebase JWT token which was not signed with the kid it specifies', () => {
+      mockedRequests.push(mockFetchWrongPublicKeys());
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Firebase ID token has invalid signature');
+    });
+
+    it('should be rejected given a custom token', () => {
+      return tokenGenerator.createCustomToken(mocks.uid)
+        .then((customToken) => {
+          return tokenVerifier.verifyJWT(customToken)
+            .should.eventually.be.rejectedWith('verifyIdToken() expects an ID token, but was given a custom token');
+        });
+    });
+
+    it('should be rejected given a legacy custom token', () => {
+      const legacyTokenGenerator = new LegacyFirebaseTokenGenerator('foo');
+      const legacyCustomToken = legacyTokenGenerator.createToken({
+        uid: mocks.uid,
+      });
+
+      return tokenVerifier.verifyJWT(legacyCustomToken)
+        .should.eventually.be.rejectedWith('verifyIdToken() expects an ID token, but was given a legacy custom token');
+    });
+
+    it('should be fulfilled with decoded claims given a valid Firebase JWT token', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      clock = sinon.useFakeTimers(1000);
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.fulfilled.and.deep.equal({
+          one: 'uno',
+          two: 'dos',
+          iat: 1,
+          exp: ONE_HOUR_IN_SECONDS + 1,
+          aud: mocks.projectId,
+          iss: 'https://securetoken.google.com/' + mocks.projectId,
+          sub: mocks.uid,
+          uid: mocks.uid,
+        });
+    });
+
+    it('should not fetch the Google cert public keys until the first time verifyJWT() is called', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      const testTokenVerifier = new FirebaseTokenVerifier(
+        'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
+        'RS256',
+        'https://securetoken.google.com/',
+        'project_id',
+        ID_TOKEN_INFO,
+      );
+      expect(https.get).not.to.have.been.called;
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return testTokenVerifier.verifyJWT(mockIdToken)
+        .then(() => expect(https.get).to.have.been.calledOnce);
+    });
+
+    it('should not re-fetch the Google cert public keys every time verifyJWT() is called', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken).then(() => {
+        expect(https.get).to.have.been.calledOnce;
+        return tokenVerifier.verifyJWT(mockIdToken);
+      }).then(() => expect(https.get).to.have.been.calledOnce);
+    });
+
+    it('should refresh the Google cert public keys after the "max-age" on the request expires', () => {
+      mockedRequests.push(mockFetchPublicKeys());
+      mockedRequests.push(mockFetchPublicKeys());
+      mockedRequests.push(mockFetchPublicKeys());
+
+      clock = sinon.useFakeTimers(1000);
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken).then(() => {
+        expect(https.get).to.have.been.calledOnce;
+        clock.tick(999);
+        return tokenVerifier.verifyJWT(mockIdToken);
+      }).then(() => {
+        expect(https.get).to.have.been.calledOnce;
+        clock.tick(1);
+        return tokenVerifier.verifyJWT(mockIdToken);
+      }).then(() => {
+        // One second has passed
+        expect(https.get).to.have.been.calledTwice;
+        clock.tick(999);
+        return tokenVerifier.verifyJWT(mockIdToken);
+      }).then(() => {
+        expect(https.get).to.have.been.calledTwice;
+        clock.tick(1);
+        return tokenVerifier.verifyJWT(mockIdToken);
+      }).then(() => {
+        // Two seconds have passed
+        expect(https.get).to.have.been.calledThrice;
+      });
+    });
+
+    it('should be rejected if fetching the Google public keys fails', () => {
+      mockedRequests.push(mockFailedFetchPublicKeys());
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('message');
+    });
+
+    it('should be rejected if fetching the Google public keys returns a response with an error message', () => {
+      mockedRequests.push(mockFetchPublicKeysWithErrorResponse());
+
+      const mockIdToken = mocks.generateIdToken();
+
+      return tokenVerifier.verifyJWT(mockIdToken)
+        .should.eventually.be.rejectedWith('Error fetching public keys for Google certs: message (description)');
+    });
+  });
+});
+

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -30,6 +30,7 @@ import './auth/auth.spec';
 import './auth/credential.spec';
 import './auth/user-record.spec';
 import './auth/token-generator.spec';
+import './auth/token-verifier.spec';
 import './auth/auth-api-request.spec';
 import './auth/user-import-builder.spec';
 

--- a/test/unit/utils/validator.spec.ts
+++ b/test/unit/utils/validator.spec.ts
@@ -382,6 +382,7 @@ describe('isURL()', () => {
   it('show return true with a valid web URL string', () => {
     expect(isURL('https://www.example.com:8080')).to.be.true;
     expect(isURL('https://www.example.com')).to.be.true;
+    expect(isURL('http://localhost/path/name/')).to.be.true;
     expect(isURL('https://www.example.com:8080/path/name/index.php?a=1&b=2&c=3#abcd'))
       .to.be.true;
     expect(isURL('http://www.example.com:8080/path/name/index.php?a=1&b=2&c=3#abcd'))


### PR DESCRIPTION
This adds 2 new APIs:
admin.auth().createSessionCookie(idToken: string, sessionCookieOptions:
SessionCookieOptions): Promise<string>
admin.auth().verifySessionCookie(sessionCookie: string, checkRevoked?:
boolean): Promise<DecodedIdToken>

Refactored token generator and split token verification to a new class
FirebaseTokenVerifier so it can be used to also verify session cookies.
Kept the same error handling for backward compatibility.
In the process, ported the same tests to token verifier.
Updated token generator ID token and session cookie verification to
check token verifier is called underneath with the expected parameters.

Added integration tests to test all common flows for session cookie
creation and verification.
Added mocks for session cookie JWTs.
Fixed error in URL validator.
Increased integration test timeout to 5 seconds from the default 2 seconds to accommodate user deletion throttling.
