### PR TITLE
Lazy loading modules for faster load times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,6 +1100,12 @@
       "integrity": "sha512-1v3/dB01fkW5qTpZH5zjjBLgj97Jhpu/tjJt/g0LHMPTuj2D2a6sJhj9RcwqmXl+TtokCZQyaynxL4buN5G2WA==",
       "dev": true
     },
+    "@types/caseless": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
@@ -1177,13 +1183,15 @@
       "dev": true
     },
     "@types/request": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.6.tgz",
-      "integrity": "sha512-8/VAk8kgeWuNQTOMmhaLyYmzX7Foshcdh0f1KwkyWQPmoPCy4AIMDx4KqI/n/uO5pAw2FOCgW+76iJTyjYsIRw==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
+      "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
       "dev": true,
       "requires": {
+        "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.0",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.53",
+        "@types/tough-cookie": "2.3.3"
       }
     },
     "@types/request-promise": {
@@ -1193,7 +1201,7 @@
       "dev": true,
       "requires": {
         "@types/bluebird": "3.5.17",
-        "@types/request": "2.0.6"
+        "@types/request": "2.47.0"
       }
     },
     "@types/sinon": {
@@ -1211,6 +1219,12 @@
         "@types/chai": "3.5.2",
         "@types/sinon": "4.3.0"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,12 +1100,6 @@
       "integrity": "sha512-1v3/dB01fkW5qTpZH5zjjBLgj97Jhpu/tjJt/g0LHMPTuj2D2a6sJhj9RcwqmXl+TtokCZQyaynxL4buN5G2WA==",
       "dev": true
     },
-    "@types/caseless": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
-      "dev": true
-    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
@@ -1183,15 +1177,13 @@
       "dev": true
     },
     "@types/request": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
-      "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.6.tgz",
+      "integrity": "sha512-8/VAk8kgeWuNQTOMmhaLyYmzX7Foshcdh0f1KwkyWQPmoPCy4AIMDx4KqI/n/uO5pAw2FOCgW+76iJTyjYsIRw==",
       "dev": true,
       "requires": {
-        "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.0",
-        "@types/node": "8.0.53",
-        "@types/tough-cookie": "2.3.3"
+        "@types/node": "8.0.53"
       }
     },
     "@types/request-promise": {
@@ -1201,7 +1193,7 @@
       "dev": true,
       "requires": {
         "@types/bluebird": "3.5.17",
-        "@types/request": "2.47.0"
+        "@types/request": "2.0.6"
       }
     },
     "@types/sinon": {
@@ -1219,12 +1211,6 @@
         "@types/chai": "3.5.2",
         "@types/sinon": "4.3.0"
       }
-    },
-    "@types/tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
-      "dev": true
     },
     "abbrev": {
       "version": "1.0.9",

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-import * as jwt from 'jsonwebtoken';
-import * as forge from 'node-forge';
-
 // Use untyped import syntax for Node built-ins
 import fs = require('fs');
 import os = require('os');
-import http = require('http');
 import path = require('path');
-import https = require('https');
 
 import {AppErrorCodes, FirebaseAppError} from '../utils/error';
 
@@ -169,6 +164,7 @@ export class Certificate {
       throw new FirebaseAppError(AppErrorCodes.INVALID_CREDENTIAL, errorMessage);
     }
 
+    const forge = require('node-forge');
     try {
       forge.pki.privateKeyFromPem(this.privateKey);
     } catch (error) {
@@ -257,6 +253,7 @@ export class CertCredential implements Credential {
         'Content-Length': postData.length,
       },
     };
+    const https = require('https');
     return requestAccessToken(https, options, postData);
   }
 
@@ -275,6 +272,7 @@ export class CertCredential implements Credential {
       ].join(' '),
     };
 
+    const jwt = require('jsonwebtoken');
     // This method is actually synchronous so we can capture and return the buffer.
     return jwt.sign(claims, this.certificate_.privateKey, {
       audience: GOOGLE_TOKEN_AUDIENCE,
@@ -321,6 +319,7 @@ export class RefreshTokenCredential implements Credential {
         'Content-Length': postData.length,
       },
     };
+    const https = require('https');
     return requestAccessToken(https, options, postData);
   }
 
@@ -345,6 +344,7 @@ export class MetadataServiceCredential implements Credential {
         'Content-Length': 0,
       },
     };
+    const http = require('http');
     return requestAccessToken(http, options);
   }
 

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -286,7 +286,8 @@ export class FirebaseApp {
    */
   public auth(): Auth {
     return this.ensureService_('auth', () => {
-      return new Auth(this);
+      const authService: typeof Auth = require('./auth/auth').Auth;
+      return new authService(this);
     });
   }
 
@@ -297,7 +298,8 @@ export class FirebaseApp {
    */
   public database(url?: string): Database {
     const service: DatabaseService = this.ensureService_('database', () => {
-      return new DatabaseService(this);
+      const dbService: typeof DatabaseService = require('./database/database').DatabaseService;
+      return new dbService(this);
     });
     return service.getDatabase(url);
   }
@@ -309,7 +311,8 @@ export class FirebaseApp {
    */
   public messaging(): Messaging {
     return this.ensureService_('messaging', () => {
-      return new Messaging(this);
+      const messagingService: typeof Messaging = require('./messaging/messaging').Messaging;
+      return new messagingService(this);
     });
   }
 
@@ -320,13 +323,15 @@ export class FirebaseApp {
    */
   public storage(): Storage {
     return this.ensureService_('storage', () => {
-      return new Storage(this);
+      const storageService: typeof Storage = require('./storage/storage').Storage;
+      return new storageService(this);
     });
   }
 
   public firestore(): Firestore {
     const service: FirestoreService = this.ensureService_('firestore', () => {
-      return new FirestoreService(this);
+      const firestoreService: typeof FirestoreService = require('./firestore/firestore').FirestoreService;
+      return new firestoreService(this);
     });
     return service.client;
   }
@@ -338,7 +343,8 @@ export class FirebaseApp {
    */
   public instanceId(): InstanceId {
     return this.ensureService_('iid', () => {
-      return new InstanceId(this);
+      const iidService: typeof InstanceId = require('./instance-id/instance-id').InstanceId;
+      return new iidService(this);
     });
   }
 

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -325,7 +325,8 @@ export class FirebaseNamespace {
     const fn: FirebaseServiceNamespace<Auth> = (app?: FirebaseApp) => {
       return this.ensureApp(app).auth();
     };
-    return Object.assign(fn, {Auth});
+    const auth = require('./auth/auth').Auth;
+    return Object.assign(fn, {Auth: auth});
   }
 
   /**
@@ -347,7 +348,8 @@ export class FirebaseNamespace {
     const fn: FirebaseServiceNamespace<Messaging> = (app?: FirebaseApp) => {
       return this.ensureApp(app).messaging();
     };
-    return Object.assign(fn, {Messaging});
+    const messaging = require('./messaging/messaging').Messaging;
+    return Object.assign(fn, {Messaging: messaging});
   }
 
   /**
@@ -358,7 +360,8 @@ export class FirebaseNamespace {
     const fn: FirebaseServiceNamespace<Storage> = (app?: FirebaseApp) => {
       return this.ensureApp(app).storage();
     };
-    return Object.assign(fn, {Storage});
+    const storage = require('./storage/storage').Storage;
+    return Object.assign(fn, {Storage: storage});
   }
 
   /**
@@ -380,7 +383,8 @@ export class FirebaseNamespace {
     const fn: FirebaseServiceNamespace<InstanceId> = (app?: FirebaseApp) => {
       return this.ensureApp(app).instanceId();
     };
-    return Object.assign(fn, {InstanceId});
+    const instanceId = require('./instance-id/instance-id').InstanceId;
+    return Object.assign(fn, {InstanceId: instanceId});
   }
 
   /**


### PR DESCRIPTION
Lazy loading internal modules and some dependencies for faster load times. This essentially defers loading child modules until they are explicitly required (using the technique described [here](http://www.typescriptlang.org/docs/handbook/modules.html#optional-module-loading-and-other-advanced-loading-scenarios)). For example none of the `auth/*` sources will be loaded until `admin.auth()` is invoked. This also ensures that only the child modules used by the developers get loaded into the Node.js process.

## Experimental results

Test code:
```
const start = Date.now();
require('firebase-admin');
const end = Date.now();
console.log('Load time:', (end-start), 'ms');
```

### MacBook Pro (Core i7 2.2 GHz, 16GB RAM)

Before (ms): 154, 151, 151, 153, 153 (mean = 152.4ms)
After (ms): 18, 18, 17, 18, 18 (mean = 17.8ms)
Speed up of initial load: 88.32%

### Ubuntu 16.04 (Core i7 2.8GHz, 16GB RAM)

Before (ms): 61, 59, 59, 59, 59 (mean = 59.4 ms)
After (ms): 4, 5, 5, 4, 5 (mean = 4.6 ms)
Speed up of initial load: 92.25%

