### PR TITLE
Trims API key to remove any trailing space or new lines.

### DIFF
--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -50,7 +50,7 @@ before(() => {
   }
 
   try {
-    apiKey = fs.readFileSync(path.join(__dirname, '../resources/apikey.txt')).toString();
+    apiKey = fs.readFileSync(path.join(__dirname, '../resources/apikey.txt')).toString().trim();
   } catch (error) {
     console.log(chalk.red(
       'The integration test suite requires an API key for a ' +


### PR DESCRIPTION
newline appended at end of API key was causing Auth integration tests to fail with invalid API key error.