### PR TITLE
Re-implementing the HTTP Client Abstraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -318,7 +318,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1869,7 +1869,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -318,7 +318,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -731,7 +731,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.4.1",
+        "follow-redirects": "1.5.0",
         "is-buffer": "1.1.6"
       }
     },
@@ -805,9 +805,21 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
+        "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
         "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-types": {
@@ -1069,7 +1081,21 @@
       "dev": true,
       "requires": {
         "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.1",
+        "write-file-atomic": "1.3.4"
+      },
+      "dependencies": {
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        }
       }
     },
     "call-me-maybe": {
@@ -1465,7 +1491,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
     },
     "defaults": {
       "version": "1.0.3",
@@ -1829,7 +1869,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2213,9 +2253,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
         "debug": "3.1.0"
       }
@@ -2245,7 +2285,20 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
+        "cross-spawn": "4.0.2",
         "signal-exit": "3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
+          }
+        }
       }
     },
     "forever-agent": {
@@ -4693,7 +4746,15 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
       "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
       }
     },
     "minizlib": {
@@ -4846,8 +4907,19 @@
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
       "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
       "requires": {
+        "debug": "2.6.9",
         "iconv-lite": "0.4.23",
         "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "nice-try": {
@@ -5274,7 +5346,8 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "requires": {
             "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "yargs": {
@@ -5777,6 +5850,16 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
             "pinkie-promise": "2.0.1"
           }
         }
@@ -6087,7 +6170,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -6096,7 +6180,76 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
+            "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -6514,6 +6667,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snakeize": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@google-cloud/storage": "^1.6.0",
     "@types/google-cloud__storage": "^1.1.7",
     "@types/node": "^8.0.53",
+    "axios": "^0.18.0",
     "jsonwebtoken": "8.1.0",
     "node-forge": "0.7.4"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@google-cloud/storage": "^1.6.0",
     "@types/google-cloud__storage": "^1.1.7",
     "@types/node": "^8.0.53",
-    "axios": "^0.18.0",
     "jsonwebtoken": "8.1.0",
     "node-forge": "0.7.4"
   },

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -23,8 +23,8 @@ import {OutgoingHttpHeaders} from 'http';
 import http = require('http');
 import https = require('https');
 import url = require('url');
-import zlib = require('zlib');
-import stream = require('stream');
+import * as stream from 'stream';
+import * as zlibmod from 'zlib';
 
 /** Http method type definition. */
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -195,6 +195,7 @@ function sendRequest(config: HttpRequestConfig): Promise<LowLevelResponse> {
       const encodings = ['gzip', 'compress', 'deflate'];
       if (encodings.indexOf(res.headers['content-encoding']) !== -1) {
         // add the unzipper to the body stream processing pipeline
+        const zlib: typeof zlibmod = require('zlib');
         respStream = respStream.pipe(zlib.createUnzip());
         // remove the content-encoding in order to not confuse downstream operations
         delete res.headers['content-encoding'];

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -45,7 +45,7 @@ export interface HttpResponse {
   readonly data: any;
 }
 
-class AxiosHttpResponse implements HttpResponse {
+class DefaultHttpResponse implements HttpResponse {
 
   public readonly status: number;
   public readonly headers: any;
@@ -89,7 +89,7 @@ export class HttpError extends Error {
 
   constructor(resp: LowLevelResponse) {
     super(`Server responded with status ${resp.status}.`);
-    this.response = new AxiosHttpResponse(resp);
+    this.response = new DefaultHttpResponse(resp);
   }
 }
 
@@ -110,7 +110,7 @@ export class HttpClient {
   private sendWithRetry(config: HttpRequestConfig, attempts: number = 0): Promise<HttpResponse> {
     return sendRequest(config)
       .then((resp) => {
-        return new AxiosHttpResponse(resp);
+        return new DefaultHttpResponse(resp);
       }).catch((err: LowLevelError) => {
         const retryCodes = ['ECONNRESET', 'ETIMEDOUT'];
         if (retryCodes.indexOf(err.code) !== -1 && attempts === 0) {

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -94,6 +94,16 @@ const identityTransform: AxiosTransformer = (data, header) => {
   return data;
 };
 
+function retryOnError(err) {
+  const retryCodes = ['ECONNRESET'];
+  if (retryCodes.indexOf(err.code) !== -1 && err.config && !err.config.__isRetryRequest) {
+    err.config.__isRetryRequest = true;
+    return axios(err.config);
+  }
+  throw err;
+}
+axios.interceptors.response.use(undefined, retryOnError);
+
 export class HttpClient {
 
   /**

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -68,6 +68,14 @@ export function generateRandomAccessToken(): string {
   return 'access_token_' + _.random(999999999);
 }
 
+/**
+ * Creates a mock HTTP response from the given data and parameters.
+ *
+ * @param data Data to be included in the response body.
+ * @param status HTTP status code (defaults to 200).
+ * @param headers HTTP headers to be included in the ersponse.
+ * @returns {HttpResponse} An HTTP response object.
+ */
 export function responseFrom(data: any, status: number = 200, headers: any = {}): HttpResponse {
   return {
     status,

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -71,9 +71,9 @@ export function generateRandomAccessToken(): string {
 /**
  * Creates a mock HTTP response from the given data and parameters.
  *
- * @param data Data to be included in the response body.
- * @param status HTTP status code (defaults to 200).
- * @param headers HTTP headers to be included in the ersponse.
+ * @param {*} data Data to be included in the response body.
+ * @param {number=} status HTTP status code (defaults to 200).
+ * @param {*=} headers HTTP headers to be included in the ersponse.
  * @returns {HttpResponse} An HTTP response object.
  */
 export function responseFrom(data: any, status: number = 200, headers: any = {}): HttpResponse {

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -21,6 +21,7 @@ import * as mocks from '../resources/mocks';
 
 import {FirebaseNamespace} from '../../src/firebase-namespace';
 import {FirebaseApp, FirebaseAppOptions} from '../../src/firebase-app';
+import { HttpResponse } from '../../src/utils/api-request';
 
 /**
  * Returns a new FirebaseApp instance with the provided options.
@@ -65,4 +66,13 @@ export function mockFetchAccessTokenRequests(
 /** @return {string} A randomly generated access token string. */
 export function generateRandomAccessToken(): string {
   return 'access_token_' + _.random(999999999);
+}
+
+export function responseFrom(data: any, status: number = 200, headers: any = {}): HttpResponse {
+  return {
+    status,
+    headers,
+    data,
+    text: JSON.stringify(data),
+  };
 }

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -148,26 +148,6 @@ describe('HttpClient', () => {
     mockedRequests = [];
   });
 
-  it('should be fulfilled for a 2xx response from an HTTP endpoint', () => {
-    const respData = {foo: 'bar'};
-    const scope = nock('http://' + mockHost)
-      .get(mockPath)
-      .reply(200, respData, {
-        'content-type': 'application/json',
-      });
-    mockedRequests.push(scope);
-    const client = new HttpClient();
-    return client.send({
-      method: 'GET',
-      url: `http://${mockHost}${mockPath}`,
-    }).then((resp) => {
-      expect(resp.status).to.equal(200);
-      expect(resp.headers['content-type']).to.equal('application/json');
-      expect(resp.text).to.equal(JSON.stringify(respData));
-      expect(resp.data).to.deep.equal(respData);
-    });
-  });
-
   it('should be fulfilled for a 2xx response with a json payload', () => {
     const respData = {foo: 'bar'};
     const scope = nock('https://' + mockHost)
@@ -212,17 +192,17 @@ describe('HttpClient', () => {
     const reqData = {request: 'data'};
     const respData = {success: true};
     const scope = nock('https://' + mockHost, {
-        reqheaders: {
-          'Authorization': 'Bearer token',
-          'Content-Type': (header) => {
-            return header.startsWith('application/json'); // auto-inserted by Axios
-          },
-          'My-Custom-Header': 'CustomValue',
+      reqheaders: {
+        'Authorization': 'Bearer token',
+        'Content-Type': (header) => {
+          return header.startsWith('application/json'); // auto-inserted by Axios
         },
-      }).post(mockPath, reqData)
-      .reply(200, respData, {
-        'content-type': 'application/json',
-      });
+        'My-Custom-Header': 'CustomValue',
+      },
+    }).post(mockPath, reqData)
+    .reply(200, respData, {
+      'content-type': 'application/json',
+    });
     mockedRequests.push(scope);
     const client = new HttpClient();
     return client.send({


### PR DESCRIPTION
The existing HTTP client abstractions (`HttpRequestHandler` and `SignedApiRequestHandler`) have a number of caveats:

1. Do not support HTTP endpoints (HTTPS only)
2. Do not expose response headers
3. Complex and often confusing error handling semantics (e.g. even low-level network errors are reported as errors with HTTP status codes)
4. Support for handling different payload types is broken (e.g. cannot handle anything other than `application/json`, `text/html` and `text/plain`)
5. Not easy to extend or test (public API takes 5 arguments already)

I ran into pretty much all the above problems while prototyping the IAM support for token minting. 

To resolve these problems I propose a new set of HTTP client abstractions (`HttpClient` and `AuthorizedHttpClient`). My original plan was to use the [`axios`](https://www.npmjs.com/package/axios) library under the hood, but its support for handling timeouts [needs a bit of work](https://github.com/axios/axios/issues/459). So I came up with an implementation which borrows from both `axios` and our already existing `HttpRequestHandler` class. The resulting implementation:

1. Supports both HTTPS and HTTP
2. Exposes response headers alongside status and payload
3. Simplifies error handling -- HTTP errors are reported by throwing an `HttpError` which provides access to the response object. All other low-level errors result in a `FirebaseAppError`.
4. Supports any payload type
5. Fairly easy to test; new arguments can be added by extending the `HttpRequestConfig` type

This PR implements the new abstractions and provides unit tests. I will update the rest of the codebase to use them in a series of future PRs (work already underway in a separate branch).