### PR TITLE
Update Webpush types in Messaging

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -438,18 +438,17 @@ declare namespace admin.messaging {
     title?: string;
     body?: string;
   };
-  
+
   type WebpushConfig = {
     headers?: {[key: string]: string};
     data?: {[key: string]: string};
     notification?: WebpushNotification;
   };
-  
-  type WebpushNotification = {
+
+  interface WebpushNotification extends NotificationOptions {
     title?: string;
-    body?: string;
-    icon?: string;
-  };
+    [key: string]: any;
+  }
 
   type DataMessagePayload = {
     [key: string]: string;

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -129,10 +129,9 @@ export interface WebpushConfig {
   notification?: WebpushNotification;
 }
 
-export interface WebpushNotification {
+export interface WebpushNotification extends NotificationOptions {
   title?: string;
-  body?: string;
-  icon?: string;
+  [key: string]: any;
 }
 
 export interface ApnsConfig {

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -2236,6 +2236,22 @@ describe('Messaging', () => {
               title: 'test.title',
               body: 'test.body',
               icon: 'test.icon',
+              actions: [{
+                action: 'test.action.1',
+                title: 'test.action.1.title',
+                icon: 'test.action.1.icon',
+              }, {
+                action: 'test.action.2',
+                title: 'test.action.2.title',
+                icon: 'test.action.2.icon',
+              }],
+              badge: 'test.badge',
+              data: {
+                key: 'value',
+              },
+              dir: 'auto',
+              image: 'test.image',
+              requireInteraction: true,
             },
           },
         },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": false,
-    "lib": ["es5", "es2015.promise", "es2015"],
+    "lib": ["es5", "es2015.promise", "es2015", "dom"],
     "outDir": "lib",
     // We manually craft typings in src/index.d.ts instead of auto-generating them.
     // "declaration": true,


### PR DESCRIPTION
Webpush Notification is a struct now: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig