### PR TITLE
Reading projectId from GOOGLE_CLOUD_PROJECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [changed] Admin SDK can now read the Firebase/GCP project ID from both
+  `GCLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT` environment variables.
 
 # v5.12.1
 

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -83,7 +83,7 @@ export function getFirestoreOptions(app: FirebaseApp): any {
         code: 'no-project-id',
         message: 'Failed to determine project ID for Firestore. Initialize the '
           + 'SDK with service account credentials or set project ID as an app option. '
-          + 'Alternatively set the GCLOUD_PROJECT environment variable.',
+          + 'Alternatively set the GOOGLE_CLOUD_PROJECT environment variable.',
       });
     }
     return {
@@ -96,7 +96,7 @@ export function getFirestoreOptions(app: FirebaseApp): any {
   } else if (app.options.credential instanceof ApplicationDefaultCredential) {
     // Try to use the Google application default credentials.
     // If an explicit project ID is not available, let Firestore client discover one from the
-    // environment. This prevents the users from having to set GCLOUD_PROJECT in GCP runtimes.
+    // environment. This prevents the users from having to set GOOGLE_CLOUD_PROJECT in GCP runtimes.
     return validator.isNonEmptyString(projectId) ? {projectId} : {};
   }
 

--- a/src/instance-id/instance-id.ts
+++ b/src/instance-id/instance-id.ts
@@ -62,7 +62,7 @@ export class InstanceId implements FirebaseServiceInterface {
         InstanceIdClientErrorCode.INVALID_PROJECT_ID,
         'Failed to determine project ID for InstanceId. Initialize the '
         + 'SDK with service account credentials or set project ID as an app option. '
-        + 'Alternatively set the GCLOUD_PROJECT environment variable.',
+        + 'Alternatively set the GOOGLE_CLOUD_PROJECT environment variable.',
       );
     }
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -683,7 +683,7 @@ export class Messaging implements FirebaseServiceInterface {
         MessagingClientErrorCode.INVALID_ARGUMENT,
         'Failed to determine project ID for Messaging. Initialize the '
         + 'SDK with service account credentials or set project ID as an app option. '
-        + 'Alternatively set the GCLOUD_PROJECT environment variable.',
+        + 'Alternatively set the GOOGLE_CLOUD_PROJECT environment variable.',
       );
     }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -74,7 +74,7 @@ export function getProjectId(app: FirebaseApp): string {
     return cert.projectId;
   }
 
-  const projectId = process.env.GCLOUD_PROJECT;
+  const projectId = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
   if (validator.isNonEmptyString(projectId)) {
     return projectId;
   }

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -166,6 +166,7 @@ describe('Auth', () => {
 
     oldProcessEnv = process.env;
     // Project ID not set in the environment.
+    delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GCLOUD_PROJECT;
   });
 
@@ -301,6 +302,16 @@ describe('Auth', () => {
         // Confirm getUser never called.
         expect(getUserStub).not.to.have.been.called;
         expect(result).to.deep.equal(decodedIdToken);
+        expect(stub).to.have.been.calledOnce.and.calledWith(mockIdToken);
+      });
+    });
+
+    it('should work with a non-cert credential when the GOOGLE_CLOUD_PROJECT environment variable is present', () => {
+      process.env.GOOGLE_CLOUD_PROJECT = mocks.projectId;
+
+      const mockCredentialAuth = new Auth(mocks.mockCredentialApp());
+
+      return mockCredentialAuth.verifyIdToken(mockIdToken).then(() => {
         expect(stub).to.have.been.calledOnce.and.calledWith(mockIdToken);
       });
     });
@@ -490,6 +501,16 @@ describe('Auth', () => {
         // Confirm getUser never called.
         expect(getUserStub).not.to.have.been.called;
         expect(result).to.deep.equal(decodedSessionCookie);
+        expect(stub).to.have.been.calledOnce.and.calledWith(mockSessionCookie);
+      });
+    });
+
+    it('should work with a non-cert credential when the GOOGLE_CLOUD_PROJECT environment variable is present', () => {
+      process.env.GOOGLE_CLOUD_PROJECT = mocks.projectId;
+
+      const mockCredentialAuth = new Auth(mocks.mockCredentialApp());
+
+      return mockCredentialAuth.verifySessionCookie(mockSessionCookie).then(() => {
         expect(stub).to.have.been.calledOnce.and.calledWith(mockSessionCookie);
       });
     });

--- a/test/unit/instance-id/instance-id.spec.ts
+++ b/test/unit/instance-id/instance-id.spec.ts
@@ -48,11 +48,12 @@ describe('InstanceId', () => {
   let malformedAccessTokenClient: InstanceId;
   let rejectedPromiseAccessTokenClient: InstanceId;
 
+  let googleCloudProject: string;
   let gcloudProject: string;
 
   const noProjectIdError = 'Failed to determine project ID for InstanceId. Initialize the SDK '
   + 'with service account credentials or set project ID as an app option. Alternatively set the '
-  + 'GCLOUD_PROJECT environment variable.';
+  + 'GOOGLE_CLOUD_PROJECT environment variable.';
 
   before(() => utils.mockFetchAccessTokenRequests());
 
@@ -63,6 +64,7 @@ describe('InstanceId', () => {
     mockCredentialApp = mocks.mockCredentialApp();
     iid = new InstanceId(mockApp);
 
+    googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
     gcloudProject = process.env.GCLOUD_PROJECT;
 
     nullAccessTokenClient = new InstanceId(mocks.appReturningNullAccessToken());
@@ -71,6 +73,7 @@ describe('InstanceId', () => {
   });
 
   afterEach(() => {
+    process.env.GOOGLE_CLOUD_PROJECT = googleCloudProject;
     process.env.GCLOUD_PROJECT = gcloudProject;
     return mockApp.delete();
   });
@@ -96,6 +99,7 @@ describe('InstanceId', () => {
 
     it('should throw given an invalid credential without project ID', () => {
       // Project ID not set in the environment.
+      delete process.env.GOOGLE_CLOUD_PROJECT;
       delete process.env.GCLOUD_PROJECT;
       expect(() => {
         return new InstanceId(mockCredentialApp);

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -64,13 +64,21 @@ describe('toWebSafeBase64()', () => {
 });
 
 describe('getProjectId()', () => {
+  let googleCloudProject: string;
   let gcloudProject: string;
 
   before(() => {
+    googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
     gcloudProject = process.env.GCLOUD_PROJECT;
   });
 
   after(() => {
+    if (isNonEmptyString(googleCloudProject)) {
+      process.env.GOOGLE_CLOUD_PROJECT = googleCloudProject;
+    } else {
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+    }
+
     if (isNonEmptyString(gcloudProject)) {
       process.env.GCLOUD_PROJECT = gcloudProject;
     } else {
@@ -92,13 +100,20 @@ describe('getProjectId()', () => {
     expect(getProjectId(app)).to.equal('project_id');
   });
 
-  it('should return the project ID set in environment', () => {
+  it('should return the project ID set in GOOGLE_CLOUD_PROJECT environment variable', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'env-var-project-id';
+    const app: FirebaseApp = mocks.mockCredentialApp();
+    expect(getProjectId(app)).to.equal('env-var-project-id');
+  });
+
+  it('should return the project ID set in GCLOUD_PROJECT environment variable', () => {
     process.env.GCLOUD_PROJECT = 'env-var-project-id';
     const app: FirebaseApp = mocks.mockCredentialApp();
     expect(getProjectId(app)).to.equal('env-var-project-id');
   });
 
   it('should return null when project ID is not set', () => {
+    delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GCLOUD_PROJECT;
     const app: FirebaseApp = mocks.mockCredentialApp();
     expect(getProjectId(app)).to.be.null;


### PR DESCRIPTION
`GCLOUD_PROJECT` is no longer supported in some managed Google runtimes. `GOOGLE_CLOUD_PROJECT` is the new recommended environment variable.