### PR TITLE
Using the new HttpClient in messaging module

### DIFF
--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -15,17 +15,15 @@
  */
 
 import {FirebaseApp} from '../firebase-app';
-import {HttpMethod, SignedApiRequestHandler} from '../utils/api-request';
-import {FirebaseError, FirebaseMessagingError, MessagingClientErrorCode} from '../utils/error';
+import {HttpMethod, AuthorizedHttpClient, HttpRequestConfig, HttpError} from '../utils/api-request';
+import {FirebaseMessagingError, MessagingClientErrorCode} from '../utils/error';
 
 import * as validator from '../utils/validator';
 
 // FCM backend constants
-const FIREBASE_MESSAGING_PORT = 443;
 const FIREBASE_MESSAGING_TIMEOUT = 10000;
 const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {
-  'Content-Type': 'application/json',
   'Sdk-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
   'access_token_auth': 'true',
 };
@@ -35,7 +33,7 @@ const FIREBASE_MESSAGING_HEADERS = {
  * Class that provides a mechanism to send requests to the Firebase Cloud Messaging backend.
  */
 export class FirebaseMessagingRequestHandler {
-  private signedApiRequestHandler: SignedApiRequestHandler;
+  private readonly httpClient: AuthorizedHttpClient;
 
   /**
    * @param {object} response The response to check for errors.
@@ -84,7 +82,7 @@ export class FirebaseMessagingRequestHandler {
    * @constructor
    */
   constructor(app: FirebaseApp) {
-    this.signedApiRequestHandler = new SignedApiRequestHandler(app);
+    this.httpClient = new AuthorizedHttpClient(app);
   }
 
   /**
@@ -96,76 +94,78 @@ export class FirebaseMessagingRequestHandler {
    * @return {Promise<object>} A promise that resolves with the response.
    */
   public invokeRequestHandler(host: string, path: string, requestData: object): Promise<object> {
-    return this.signedApiRequestHandler.sendRequest(
-      host,
-      FIREBASE_MESSAGING_PORT,
-      path,
-      FIREBASE_MESSAGING_HTTP_METHOD,
-      requestData,
-      FIREBASE_MESSAGING_HEADERS,
-      FIREBASE_MESSAGING_TIMEOUT,
-    ).then((response) => {
+    const request: HttpRequestConfig = {
+      method: FIREBASE_MESSAGING_HTTP_METHOD,
+      url: `https://${host}${path}`,
+      data: requestData,
+      headers: FIREBASE_MESSAGING_HEADERS,
+      timeout: FIREBASE_MESSAGING_TIMEOUT,
+    };
+    return this.httpClient.send(request).then((response) => {
       // Send non-JSON responses to the catch() below where they will be treated as errors.
-      if (typeof response === 'string') {
-        return Promise.reject({
-          error: response,
-          statusCode: 200,
-        });
+      let json;
+      try {
+        json = response.data;
+      } catch {
+        throw new HttpError(response);
       }
 
       // Check for backend errors in the response.
-      const errorCode = FirebaseMessagingRequestHandler.getErrorCode(response);
+      const errorCode = FirebaseMessagingRequestHandler.getErrorCode(json);
       if (errorCode) {
-        return Promise.reject({
-          error: response,
-          statusCode: 200,
-        });
+        throw new HttpError(response);
       }
 
       // Return entire response.
-      return response;
+      return json;
     })
-    .catch((response: { statusCode: number, error: string | object }) => {
+    .catch((err) => {
+      if (err instanceof HttpError) {
+        this.handleHttpError(err);
+      }
       // Re-throw the error if it already has the proper format.
-      if (response instanceof FirebaseError) {
-        throw response;
-      } else if (response.error instanceof FirebaseError) {
-        throw response.error;
-      }
+      throw err;
+    });
+  }
 
-      // Add special handling for non-JSON responses.
-      if (typeof response.error === 'string') {
-        let error;
-        switch (response.statusCode) {
-          case 400:
-            error = MessagingClientErrorCode.INVALID_ARGUMENT;
-            break;
-          case 401:
-          case 403:
-            error = MessagingClientErrorCode.AUTHENTICATION_ERROR;
-            break;
-          case 500:
-            error = MessagingClientErrorCode.INTERNAL_ERROR;
-            break;
-          case 503:
-            error = MessagingClientErrorCode.SERVER_UNAVAILABLE;
-            break;
-          default:
-            // Treat non-JSON responses with unexpected status codes as unknown errors.
-            error = MessagingClientErrorCode.UNKNOWN_ERROR;
-        }
-
-        throw new FirebaseMessagingError({
-          code: error.code,
-          message: `${ error.message } Raw server response: "${ response.error }". Status code: ` +
-            `${ response.statusCode }.`,
-        });
-      }
-
+  private handleHttpError(err: HttpError) {
+    let json;
+    try {
+      json = err.response.data;
+    } catch {
+      json = null;
+    }
+    if (json) {
       // For JSON responses, map the server response to a client-side error.
-      const errorCode = FirebaseMessagingRequestHandler.getErrorCode(response.error);
-      const errorMessage = FirebaseMessagingRequestHandler.getErrorMessage(response.error);
-      throw FirebaseMessagingError.fromServerError(errorCode, errorMessage, response.error);
+      const errorCode = FirebaseMessagingRequestHandler.getErrorCode(json);
+      const errorMessage = FirebaseMessagingRequestHandler.getErrorMessage(json);
+      throw FirebaseMessagingError.fromServerError(errorCode, errorMessage, json);
+    }
+
+    // Non-JSON response
+    let error: {code: string, message: string};
+    switch (err.response.status) {
+      case 400:
+        error = MessagingClientErrorCode.INVALID_ARGUMENT;
+        break;
+      case 401:
+      case 403:
+        error = MessagingClientErrorCode.AUTHENTICATION_ERROR;
+        break;
+      case 500:
+        error = MessagingClientErrorCode.INTERNAL_ERROR;
+        break;
+      case 503:
+        error = MessagingClientErrorCode.SERVER_UNAVAILABLE;
+        break;
+      default:
+        // Treat non-JSON responses with unexpected status codes as unknown errors.
+        error = MessagingClientErrorCode.UNKNOWN_ERROR;
+    }
+    throw new FirebaseMessagingError({
+      code: error.code,
+      message: `${ error.message } Raw server response: "${ err.response.text }". Status code: ` +
+        `${ err.response.status }.`,
     });
   }
 }

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -103,7 +103,7 @@ export class FirebaseMessagingRequestHandler {
     };
     return this.httpClient.send(request).then((response) => {
       // Send non-JSON responses to the catch() below where they will be treated as errors.
-      if (!response.contentJson) {
+      if (!response.isJson()) {
         throw new HttpError(response);
       }
 
@@ -126,7 +126,7 @@ export class FirebaseMessagingRequestHandler {
   }
 
   private handleHttpError(err: HttpError) {
-    if (err.response.contentJson) {
+    if (err.response.isJson()) {
       // For JSON responses, map the server response to a client-side error.
       const json = err.response.data;
       const errorCode = FirebaseMessagingRequestHandler.getErrorCode(json);

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -103,7 +103,7 @@ export class FirebaseMessagingRequestHandler {
     };
     return this.httpClient.send(request).then((response) => {
       // Send non-JSON responses to the catch() below where they will be treated as errors.
-      if (!response.isJson) {
+      if (!response.contentJson) {
         throw new HttpError(response);
       }
 
@@ -126,7 +126,7 @@ export class FirebaseMessagingRequestHandler {
   }
 
   private handleHttpError(err: HttpError) {
-    if (err.response.isJson) {
+    if (err.response.contentJson) {
       // For JSON responses, map the server response to a client-side error.
       const json = err.response.data;
       const errorCode = FirebaseMessagingRequestHandler.getErrorCode(json);

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -54,6 +54,7 @@ export interface HttpResponse {
   readonly text: string;
   /** Response data as a parsed JSON object. */
   readonly data: any;
+  readonly isJson: boolean;
 }
 
 interface LowLevelResponse {
@@ -98,7 +99,7 @@ class DefaultHttpResponse implements HttpResponse {
   }
 
   get data(): any {
-    if (typeof this.parsedData !== 'undefined') {
+    if (this.isJson) {
       return this.parsedData;
     }
     throw new FirebaseAppError(
@@ -107,6 +108,10 @@ class DefaultHttpResponse implements HttpResponse {
       `response: "${ this.text }". Status code: "${ this.status }". Outgoing ` +
       `request: "${ this.request }."`,
     );
+  }
+
+  get isJson(): boolean {
+    return typeof this.parsedData !== 'undefined';
   }
 }
 

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -54,7 +54,11 @@ export interface HttpResponse {
   readonly text: string;
   /** Response data as a parsed JSON object. */
   readonly data: any;
-  readonly isJson: boolean;
+  /**
+   * Indicates if the response content is JSON-formatted or not. If true, data field can be used
+   * to retrieve the content as a parsed JSON object.
+   */
+  readonly contentJson: boolean;
 }
 
 interface LowLevelResponse {
@@ -99,7 +103,7 @@ class DefaultHttpResponse implements HttpResponse {
   }
 
   get data(): any {
-    if (this.isJson) {
+    if (this.contentJson) {
       return this.parsedData;
     }
     throw new FirebaseAppError(
@@ -110,7 +114,7 @@ class DefaultHttpResponse implements HttpResponse {
     );
   }
 
-  get isJson(): boolean {
+  get contentJson(): boolean {
     return typeof this.parsedData !== 'undefined';
   }
 }

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -58,7 +58,7 @@ export interface HttpResponse {
    * Indicates if the response content is JSON-formatted or not. If true, data field can be used
    * to retrieve the content as a parsed JSON object.
    */
-  readonly contentJson: boolean;
+  isJson(): boolean;
 }
 
 interface LowLevelResponse {
@@ -103,7 +103,7 @@ class DefaultHttpResponse implements HttpResponse {
   }
 
   get data(): any {
-    if (this.contentJson) {
+    if (this.isJson()) {
       return this.parsedData;
     }
     throw new FirebaseAppError(
@@ -114,7 +114,7 @@ class DefaultHttpResponse implements HttpResponse {
     );
   }
 
-  get contentJson(): boolean {
+  public isJson(): boolean {
     return typeof this.parsedData !== 'undefined';
   }
 }

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -82,6 +82,7 @@ export function responseFrom(data: any, status: number = 200, headers: any = {})
     headers,
     data,
     text: JSON.stringify(data),
+    isJson: true,
   };
 }
 

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -95,7 +95,7 @@ export function responseFrom(data: object | string, status: number = 200, header
     headers,
     data: responseData,
     text: responseText,
-    isJson: responseData != null,
+    contentJson: responseData != null,
   };
 }
 

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -95,7 +95,7 @@ export function responseFrom(data: object | string, status: number = 200, header
     headers,
     data: responseData,
     text: responseText,
-    contentJson: responseData != null,
+    isJson: () => responseData != null,
   };
 }
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -165,7 +165,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.text).to.equal(JSON.stringify(respData));
       expect(resp.data).to.deep.equal(respData);
-      expect(resp.contentJson).to.be.true;
+      expect(resp.isJson()).to.be.true;
     });
   });
 
@@ -186,7 +186,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('text/plain');
       expect(resp.text).to.equal(respData);
       expect(() => { resp.data; }).to.throw('Error while parsing response data');
-      expect(resp.contentJson).to.be.false;
+      expect(resp.isJson()).to.be.false;
     });
   });
 
@@ -219,7 +219,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(200);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(respData);
-      expect(resp.contentJson).to.be.true;
+      expect(resp.isJson()).to.be.true;
     });
   });
 
@@ -236,7 +236,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(400);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
-      expect(resp.contentJson).to.be.true;
+      expect(resp.isJson()).to.be.true;
     });
   });
 
@@ -253,7 +253,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(500);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
-      expect(resp.contentJson).to.be.true;
+      expect(resp.isJson()).to.be.true;
     });
   });
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -165,7 +165,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.text).to.equal(JSON.stringify(respData));
       expect(resp.data).to.deep.equal(respData);
-      expect(resp.isJson).to.be.true;
+      expect(resp.contentJson).to.be.true;
     });
   });
 
@@ -186,7 +186,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('text/plain');
       expect(resp.text).to.equal(respData);
       expect(() => { resp.data; }).to.throw('Error while parsing response data');
-      expect(resp.isJson).to.be.false;
+      expect(resp.contentJson).to.be.false;
     });
   });
 
@@ -219,7 +219,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(200);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(respData);
-      expect(resp.isJson).to.be.true;
+      expect(resp.contentJson).to.be.true;
     });
   });
 
@@ -236,7 +236,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(400);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
-      expect(resp.isJson).to.be.true;
+      expect(resp.contentJson).to.be.true;
     });
   });
 
@@ -253,7 +253,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(500);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
-      expect(resp.isJson).to.be.true;
+      expect(resp.contentJson).to.be.true;
     });
   });
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -165,6 +165,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.text).to.equal(JSON.stringify(respData));
       expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson).to.be.true;
     });
   });
 
@@ -185,6 +186,7 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('text/plain');
       expect(resp.text).to.equal(respData);
       expect(() => { resp.data; }).to.throw('Error while parsing response data');
+      expect(resp.isJson).to.be.false;
     });
   });
 
@@ -217,6 +219,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(200);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson).to.be.true;
     });
   });
 
@@ -233,6 +236,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(400);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
+      expect(resp.isJson).to.be.true;
     });
   });
 
@@ -249,6 +253,7 @@ describe('HttpClient', () => {
       expect(resp.status).to.equal(500);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(data);
+      expect(resp.isJson).to.be.true;
     });
   });
 


### PR DESCRIPTION
Using the new `AuthorizedHttpClient` implementation in the FCM code.

This is a follow up of #280 and #291.

Also introducing the `isJson` field to the HTTP response interface, to make it easier to handle JSON-formatted responses.