### PR TITLE
Remove DOM from lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   method to return a more specific type.
 - [changed] Admin SDK can now read the Firebase/GCP project ID from both
   `GCLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT` environment variables.
+- [changed] Updated the `WebpushNotification` typings to match
+  [the current API](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig).
 
 # v5.12.1
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -446,8 +446,26 @@ declare namespace admin.messaging {
     notification?: WebpushNotification;
   };
 
-  interface WebpushNotification extends NotificationOptions {
+  interface WebpushNotification {
     title?: string;
+    actions?: Array<{
+      action: string;
+      icon?: string;
+      title: string;
+    }>;
+    badge?: string;
+    body?: string;
+    data?: any;
+    dir?: 'auto' | 'ltr' | 'rtl';
+    icon?: string;
+    image?: string;
+    lang?: string;
+    renotify?: boolean;
+    requireInteraction?: boolean;
+    silent?: boolean;
+    tag?: string;
+    timestamp?: number;
+    vibrate?: number | number[];
     [key: string]: any;
   }
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -129,8 +129,26 @@ export interface WebpushConfig {
   notification?: WebpushNotification;
 }
 
-export interface WebpushNotification extends NotificationOptions {
+export interface WebpushNotification {
   title?: string;
+  actions?: Array<{
+    action: string;
+    icon?: string;
+    title: string;
+  }>;
+  badge?: string;
+  body?: string;
+  data?: any;
+  dir?: 'auto' | 'ltr' | 'rtl';
+  icon?: string;
+  image?: string;
+  lang?: string;
+  renotify?: boolean;
+  requireInteraction?: boolean;
+  silent?: boolean;
+  tag?: string;
+  timestamp?: number;
+  vibrate?: number | number[];
   [key: string]: any;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": false,
-    "lib": ["es5", "es2015.promise", "es2015", "dom"],
+    "lib": ["es2015"],
     "outDir": "lib",
     // We manually craft typings in src/index.d.ts instead of auto-generating them.
     // "declaration": true,


### PR DESCRIPTION
Added DOM types manually. We should keep these in sync with any spec changes.

Also removed ES5 and ES2015.Promise from lib as they are already [included in ES2015](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es2015.d.ts).

Based on offline discussion about #286. Notification types are based on NotificationOptions [from TypeScript](https://github.com/Microsoft/TSJS-lib-generator/blob/master/baselines/dom.generated.d.ts).