### PR TITLE
Added hash input order option when importing users

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,6 +157,7 @@ declare namespace admin.auth {
       'HMAC_SHA256' | 'HMAC_SHA1' | 'HMAC_MD5' | 'MD5' | 'PBKDF_SHA1' | 'BCRYPT' |
       'PBKDF2_SHA256' | 'SHA512' | 'SHA256' | 'SHA1';
 
+  type HashInputOrderType = 'SALT_FIRST' | 'PASSWORD_FIRST';
 
   interface UserImportOptions {
     hash: {
@@ -168,6 +169,7 @@ declare namespace admin.auth {
       parallelization?: number;
       blockSize?: number;
       derivedKeyLength?: number;
+      inputOrder?: HashInputOrderType;
     };
   }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -407,6 +407,10 @@ export class AuthClientErrorCode {
     code: 'invalid-hash-salt-separator',
     message: 'The hashing algorithm salt separator field must be a valid byte buffer.',
   };
+  public static INVALID_HASH_INPUT_ORDER = {
+    code: 'invalid-hash-input-order',
+    message: 'The hash input order must be "SALT_FIRST" or "PASSWORD_FIRST".',
+  };
   public static INVALID_LAST_SIGN_IN_TIME = {
     code: 'invalid-last-sign-in-time',
     message: 'The last sign-in time must be a valid UTC date string.',


### PR DESCRIPTION
Implements #313.

This PR includes the implementation of a new `hash.inputOrder` option for the `importUsers()` auth methods, with the relevant unit and integration tests and type definitions. See the issue for more information and a usage example.

Note that all unit tests pass on my local machine and all integration tests except `admin.auth importUsers() successfully imports users with MD5 to Firebase Auth w/ explicit password-first hash` pass as well. It is my understanding from the [`--hash-input-order` documentation](https://firebase.google.com/docs/cli/auth) that it should apply to the `MD5` algorithm as well. However, this integration test fails although the request being made to the Firebase Auth backend looks correct to me. It would be great if someone from the Firebase Auth team took a look into what is going wrong with that test.