### PR TITLE
Adding the engines config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "homepage": "https://firebase.google.com/",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "scripts": {
     "build": "gulp build",
     "lint": "run-p lint:src lint:unit lint:integration",


### PR DESCRIPTION
A wise man told me we should add the `engines` attribute to our package.json (#328). He's usually right :)