### PR TITLE
Made Firestore and GCS Optional Deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - [changed] Upgraded Cloud Firestore client to v0.16.0.
+- [changed] Firestore and Storage client libraries are now defined as optional
+  dependencies.
 
 # v5.13.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.16.0.tgz",
       "integrity": "sha512-QnpaDOQhDJS3ZA6wSDh3larC418Ph8DIbPEfRk7K3rn5shBYV9u6cFQpX44sKS2gINT0nlCCTyTtkybBgPsEgQ==",
+      "optional": true,
       "requires": {
         "@google-cloud/projectify": "0.3.0",
         "bun": "0.0.12",
@@ -108,12 +109,14 @@
     "@google-cloud/projectify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-0.3.0.tgz",
-      "integrity": "sha512-ic3vU+rBLlQ9rU6vyMcQ/GoYQX9hP0P56jdbnSkGvXrVnO1DtYrkPV3Qg/NUrpAfKnmNC4hb0O/v2hCj8uGnbQ=="
+      "integrity": "sha512-ic3vU+rBLlQ9rU6vyMcQ/GoYQX9hP0P56jdbnSkGvXrVnO1DtYrkPV3Qg/NUrpAfKnmNC4hb0O/v2hCj8uGnbQ==",
+      "optional": true
     },
     "@google-cloud/storage": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.6.0.tgz",
       "integrity": "sha512-yQ63bJYoiwY220gn/KdTLPoHppAPwFHfG7VFLPwJ+1R5U1eqUN5XV2a7uPj1szGF8/gxlKm2UbE8DgoJJ76DFw==",
+      "optional": true,
       "requires": {
         "@google-cloud/common": "0.16.2",
         "arrify": "1.0.1",
@@ -142,6 +145,7 @@
           "version": "0.16.2",
           "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.16.2.tgz",
           "integrity": "sha512-GrkaFoj0/oO36pNs4yLmaYhTujuA3i21FdQik99Fd/APix1uhf01VlpJY4lAteTDFLRNkRx6ydEh7OVvmeUHng==",
+          "optional": true,
           "requires": {
             "array-uniq": "1.0.3",
             "arrify": "1.0.1",
@@ -167,6 +171,7 @@
           "version": "0.9.7",
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.7.tgz",
           "integrity": "sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==",
+          "optional": true,
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
@@ -178,6 +183,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
           "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
+          "optional": true,
           "requires": {
             "async": "2.6.0",
             "is-stream-ended": "0.1.4"
@@ -309,6 +315,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.7.tgz",
       "integrity": "sha512-010Llp+5ze+XWWmZuLDxs0pZgFjOgtJQVt9icJ0Ed67ZFLq7PnXkYx8x/k9nwDojR5/X4XoLPNqB1F627TScdQ==",
+      "optional": true,
       "requires": {
         "@types/node": "8.10.15"
       }
@@ -608,6 +615,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "optional": true,
       "requires": {
         "colour": "0.7.1",
         "optjs": "3.2.2"
@@ -938,7 +946,8 @@
     "buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "optional": true
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -959,6 +968,7 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
       "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
+      "optional": true,
       "requires": {
         "readable-stream": "1.0.34"
       },
@@ -966,12 +976,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -982,7 +994,8 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         }
       }
     },
@@ -990,6 +1003,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "optional": true,
       "requires": {
         "long": "3.2.0"
       },
@@ -997,7 +1011,8 @@
         "long": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+          "optional": true
         }
       }
     },
@@ -1054,7 +1069,8 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "optional": true
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -1139,6 +1155,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "optional": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
@@ -1200,7 +1217,8 @@
     "colour": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1234,6 +1252,7 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+      "optional": true,
       "requires": {
         "mime-db": "1.33.0"
       }
@@ -1275,6 +1294,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "optional": true,
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
@@ -1353,7 +1373,8 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "optional": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -1600,6 +1621,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "optional": true,
       "requires": {
         "is-obj": "1.0.1"
       }
@@ -1707,7 +1729,8 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "optional": true
     },
     "error-ex": {
       "version": "1.3.1",
@@ -2303,7 +2326,8 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "optional": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -2344,6 +2368,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.9.0.tgz",
       "integrity": "sha512-+Zrmr0JKO2y/2mg953TW6JLu+NAMHqQsKzqCm7CIT24gMQakolPJCMzDleVpVjXAqB7ZCD276tcUq2ebOfqTug==",
+      "optional": true,
       "requires": {
         "buffer-equal": "1.0.0",
         "configstore": "3.1.2",
@@ -2358,6 +2383,7 @@
           "version": "0.9.7",
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.7.tgz",
           "integrity": "sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==",
+          "optional": true,
           "requires": {
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
@@ -2689,6 +2715,7 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.17.1.tgz",
       "integrity": "sha512-fAKvFx++SRr6bGWamWuVOkJzJnQqMgpJkhaB2oEwfFJ91rbFgEmIPRmZZ/MeIVVFUOuHUVyZ8nwjm5peyTZJ6g==",
+      "optional": true,
       "requires": {
         "duplexify": "3.6.0",
         "extend": "3.0.1",
@@ -2707,6 +2734,7 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
           "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
+          "optional": true,
           "requires": {
             "axios": "0.18.0",
             "gcp-metadata": "0.6.3",
@@ -2721,6 +2749,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.0.0.tgz",
           "integrity": "sha512-S4HNLaWcMP6r8E4TMH52Y7/pM8uNayOcTDDQNBwsCccL1uI+Ol2TljxRDPzaNfbhOB30+XWP5NnZkB3LiJxi1w==",
+          "optional": true,
           "requires": {
             "through2": "2.0.3"
           }
@@ -2767,6 +2796,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.13.1.tgz",
       "integrity": "sha512-yl0xChnlUISTefOPU2NQ1cYPh5m/DTatEUV6jdRyQPE9NCrtPq7Gn6J2alMTglN7ufYbJapOd00dvhGurHH6HQ==",
+      "optional": true,
       "requires": {
         "lodash": "4.17.10",
         "nan": "2.10.0",
@@ -2776,7 +2806,8 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -2784,11 +2815,13 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.6"
@@ -2808,7 +2841,8 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -2824,30 +2858,36 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minipass": "2.3.3"
           }
@@ -2859,6 +2899,7 @@
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -2884,11 +2925,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
@@ -2896,6 +2939,7 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimatch": "3.0.4"
           }
@@ -2914,7 +2958,8 @@
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -2925,7 +2970,8 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -2936,7 +2982,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.3",
@@ -2949,6 +2996,7 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minipass": "2.3.3"
           }
@@ -2968,11 +3016,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "needle": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "iconv-lite": "0.4.23",
@@ -2982,6 +3032,7 @@
         "node-pre-gyp": {
           "version": "0.10.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
@@ -2998,6 +3049,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -3005,11 +3057,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
@@ -3018,6 +3072,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.5",
             "console-control-strings": "1.1.0",
@@ -3031,7 +3086,8 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
@@ -3042,15 +3098,18 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -3062,7 +3121,8 @@
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "protobufjs": {
           "version": "5.0.3",
@@ -3078,6 +3138,7 @@
         "rc": {
           "version": "1.2.8",
           "bundled": true,
+          "optional": true,
           "requires": {
             "deep-extend": "0.6.0",
             "ini": "1.3.5",
@@ -3088,6 +3149,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
+          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -3101,6 +3163,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }
@@ -3111,23 +3174,28 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -3141,6 +3209,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
           }
@@ -3154,11 +3223,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
@@ -3171,11 +3242,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -3745,6 +3818,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
+      "optional": true,
       "requires": {
         "through2": "2.0.3"
       }
@@ -4030,7 +4104,8 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "optional": true
     },
     "is-odd": {
       "version": "2.0.0",
@@ -4118,7 +4193,8 @@
     "is-stream-ended": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
+      "optional": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -4720,7 +4796,8 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "optional": true
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -4763,7 +4840,8 @@
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "optional": true
     },
     "lolex": {
       "version": "2.5.0",
@@ -4803,6 +4881,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "optional": true,
       "requires": {
         "pify": "3.0.0"
       }
@@ -4911,7 +4990,8 @@
     "methmeth": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
-      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk="
+      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk=",
+      "optional": true
     },
     "micromatch": {
       "version": "3.1.10",
@@ -5064,7 +5144,8 @@
     "modelo": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",
-      "integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA=="
+      "integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA==",
+      "optional": true
     },
     "ms": {
       "version": "2.0.0",
@@ -5743,7 +5824,8 @@
     "optjs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
+      "optional": true
     },
     "orchestrator": {
       "version": "0.3.8",
@@ -5792,6 +5874,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "optional": true,
       "requires": {
         "lcid": "1.0.0"
       }
@@ -6045,6 +6128,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "optional": true,
       "requires": {
         "find-up": "2.1.0"
       }
@@ -6668,6 +6752,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
+      "optional": true,
       "requires": {
         "request": "2.85.0",
         "through2": "2.0.3"
@@ -6869,7 +6954,8 @@
     "snakeize": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=",
+      "optional": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7823,6 +7909,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "optional": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -8073,7 +8160,8 @@
     "window-size": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -8099,6 +8187,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "optional": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -8108,7 +8197,8 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "optional": true
     },
     "xmlhttprequest": {
       "version": "1.8.0",
@@ -8134,6 +8224,7 @@
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "optional": true,
       "requires": {
         "camelcase": "2.1.1",
         "cliui": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,14 @@
   "dependencies": {
     "@firebase/app": "^0.3.1",
     "@firebase/database": "^0.3.1",
-    "@google-cloud/firestore": "^0.16.0",
-    "@google-cloud/storage": "^1.6.0",
-    "@types/google-cloud__storage": "^1.1.7",
     "@types/node": "^8.0.53",
     "jsonwebtoken": "8.1.0",
     "node-forge": "0.7.4"
+  },
+  "optionalDependencies": {
+    "@google-cloud/firestore": "^0.16.0",
+    "@google-cloud/storage": "^1.6.0",
+    "@types/google-cloud__storage": "^1.1.7"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -118,7 +118,8 @@ function initFirestore(app: FirebaseApp): Firestore {
     throw new FirebaseFirestoreError({
       code: 'missing-dependencies',
       message: 'Failed to import the Cloud Firestore client library for Node.js. '
-          + 'Make sure to install the "@google-cloud/firestore" npm package.',
+          + 'Make sure to install the "@google-cloud/firestore" npm package. '
+          + `Original error: ${err}`,
     });
   }
   return new firestoreDatabase(options);

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -110,7 +110,16 @@ export function getFirestoreOptions(app: FirebaseApp): any {
 
 function initFirestore(app: FirebaseApp): Firestore {
   const options = getFirestoreOptions(app);
-  // Lazy-load the Firestore implementation here, which in turns loads gRPC.
-  const firestoreDatabase: typeof Firestore = require('@google-cloud/firestore');
+  let firestoreDatabase: typeof Firestore;
+  try {
+    // Lazy-load the Firestore implementation here, which in turns loads gRPC.
+    firestoreDatabase = require('@google-cloud/firestore');
+  } catch (err) {
+    throw new FirebaseFirestoreError({
+      code: 'missing-dependencies',
+      message: 'Failed to import the Cloud Firestore client library for Node.js. '
+          + 'Make sure to install the "@google-cloud/firestore" npm package.',
+    });
+  }
   return new firestoreDatabase(options);
 }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -65,7 +65,7 @@ export class Storage implements FirebaseServiceInterface {
       throw new FirebaseError({
         code: 'storage/missing-dependencies',
         message: 'Failed to import the Cloud Storage client library for Node.js. '
-          + 'Make sure to install the "@google-cloud/storage" npm package.'
+          + 'Make sure to install the "@google-cloud/storage" npm package. '
           + `Original error: ${err}`,
       });
     }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -60,13 +60,13 @@ export class Storage implements FirebaseServiceInterface {
 
     let storage: typeof gcs;
     try {
-      /* tslint:disable-next-line:no-var-requires */
       storage = require('@google-cloud/storage');
-    } catch (e) {
+    } catch (err) {
       throw new FirebaseError({
         code: 'storage/missing-dependencies',
         message: 'Failed to import the Cloud Storage client library for Node.js. '
-          + 'Make sure to install the "@google-cloud/storage" npm package.',
+          + 'Make sure to install the "@google-cloud/storage" npm package.'
+          + `Original error: ${err}`,
       });
     }
 

--- a/tslint-test.json
+++ b/tslint-test.json
@@ -8,7 +8,7 @@
       "variables-before-functions"
     ],
     "prefer-object-spread": false,
-    "no-implicit-dependencies": [true, "dev"],
+    "no-implicit-dependencies": [true, "dev", "optional"],
     "max-classes-per-file": false,
     "max-line-length": [true, 120],
     "no-consecutive-blank-lines": false,

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
       "variables-before-functions"
     ],
     "prefer-object-spread": false,
-    "no-implicit-dependencies": [true, "dev"],
+    "no-implicit-dependencies": [true, "dev", "optional"],
     "max-classes-per-file": false,
     "max-line-length": [true, 120],
     "no-consecutive-blank-lines": false,


### PR DESCRIPTION
Since some users frequently encounter installation issues with GCP libraries (when they are not even using them), this PR re-declares those dependencies as `optional`. 

Partially resolves #295 