### PR TITLE
Integration test improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "run-s lint test:unit",
     "integration": "run-s build test:integration",
     "test:unit": "mocha test/unit/*.spec.ts --require ts-node/register",
-    "test:integration": "mocha test/integration/*.ts --slow 5000 --timeout 5000 --require ts-node/register",
+    "test:integration": "mocha test/integration/*.ts --slow 5000 --timeout 20000 --require ts-node/register",
     "test:coverage": "nyc npm run test:unit",
     "lint:src": "tslint --format stylish -p tsconfig.json",
     "lint:unit": "tslint -c tslint-test.json --format stylish test/unit/*.ts test/unit/**/*.ts",

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -220,7 +220,7 @@ describe('admin.auth', () => {
         return admin.auth().verifyIdToken(idToken, true)
           .should.eventually.be.fulfilled;
       });
-  }).timeout(10000);
+  });
 
   it('setCustomUserClaims() sets claims that are accessible via user\'s ID token', () => {
     // Set custom claims on the user.

--- a/test/integration/firestore.spec.ts
+++ b/test/integration/firestore.spec.ts
@@ -65,7 +65,7 @@ describe('admin.firestore', () => {
       .then((snapshot) => {
         expect(snapshot.exists).to.be.false;
       });
-  }).timeout(5000);
+  });
 
   it('admin.firestore.FieldValue.serverTimestamp() provides a server-side timestamp', () => {
     const expected: any = clone(mountainView);
@@ -81,7 +81,7 @@ describe('admin.firestore', () => {
         return reference.delete();
       })
       .should.eventually.be.fulfilled;
-  }).timeout(5000);
+  });
 
   it('admin.firestore.CollectionReference type is defined', () => {
     expect(typeof admin.firestore.CollectionReference).to.be.not.undefined;
@@ -132,7 +132,7 @@ describe('admin.firestore', () => {
         return Promise.all(promises);
       })
       .should.eventually.be.fulfilled;
-  }).timeout(5000);
+  });
 
   it('admin.firestore.setLogFunction() enables logging for the Firestore module', () => {
     const logs = [];
@@ -147,5 +147,5 @@ describe('admin.firestore', () => {
       .then((result) => {
         expect(logs.length).greaterThan(0);
       });
-  }).timeout(5000);
+  });
 });

--- a/test/integration/storage.spec.ts
+++ b/test/integration/storage.spec.ts
@@ -31,13 +31,13 @@ describe('admin.storage', () => {
     const bucket: Bucket = admin.storage().bucket();
     return verifyBucket(bucket, 'storage().bucket()')
       .should.eventually.be.fulfilled;
-  }).timeout(5000);
+  });
 
   it('bucket(string) returns a handle to the specified bucket', () => {
     const bucket: Bucket = admin.storage().bucket(projectId + '.appspot.com');
     return verifyBucket(bucket, 'storage().bucket(string)')
       .should.eventually.be.fulfilled;
-  }).timeout(5000);
+  });
 
   it('bucket(non-existing) returns a handle which can be queried for existence', () => {
     const bucket: Bucket = admin.storage().bucket('non.existing');

--- a/test/integration/typescript/src/example.test.ts
+++ b/test/integration/typescript/src/example.test.ts
@@ -26,6 +26,10 @@ const serviceAccount = require('../mock.key.json');
 describe('Init App', () => {
     const app: admin.app.App = initApp(serviceAccount, 'TestApp');
 
+    after(() => {
+        return app.delete();
+    });
+
     it('Should return an initialized App', () => {
         expect(app.name).to.equal('TestApp');
     });


### PR DESCRIPTION
* Increase mocha timeout to 20s, since some tests occasionally take as long as 10-11s.
* Made all tests honor the timeout configured in package.json (no more test-specific timeouts)
* Cleaning up the app instance after tests in TS smoke test suite to ensure clean termination