### PR TITLE
Allow DataSnapshot.forEach to return void

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -261,7 +261,7 @@ declare namespace admin.database {
     child(path: string): admin.database.DataSnapshot;
     exists(): boolean;
     exportVal(): any;
-    forEach(action: (a: admin.database.DataSnapshot) => boolean): boolean;
+    forEach(action: (a: admin.database.DataSnapshot) => boolean | void): boolean;
     getPriority(): string|number|null;
     hasChild(path: string): boolean;
     hasChildren(): boolean;


### PR DESCRIPTION
The forEach method on a DataSnapshot should be able to return `void`, as shown in the [example in the docs](https://firebase.google.com/docs/reference/admin/node/admin.database.DataSnapshot#forEach). 

Related to https://github.com/firebase/firebase-js-sdk/issues/555
