### PR TITLE
Updated dependency to fix build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -541,6 +541,12 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
@@ -1925,12 +1931,6 @@
         "is-obj": "1.0.1"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
     "duplexer2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
@@ -2084,30 +2084,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
-    },
-    "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1",
-        "flatmap-stream": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "0.0.11",
-        "split": "1.0.1",
-        "stream-combiner": "0.2.2",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "map-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-          "dev": true
-        }
-      }
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -2424,12 +2400,6 @@
       "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
       "dev": true
     },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-      "dev": true
-    },
     "follow-redirects": {
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
@@ -2486,12 +2456,6 @@
       "requires": {
         "map-cache": "0.2.2"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3928,6 +3892,12 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "has-gulplog": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
@@ -5257,9 +5227,9 @@
       }
     },
     "npm-run-all": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
-      "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
@@ -5267,7 +5237,7 @@
         "cross-spawn": "6.0.5",
         "memorystream": "0.3.1",
         "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
+        "pidtree": "0.3.0",
         "read-pkg": "3.0.0",
         "shell-quote": "1.6.1",
         "string.prototype.padend": "3.0.0"
@@ -5292,12 +5262,6 @@
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.5.0"
           }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -8577,19 +8541,16 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -8665,15 +8626,6 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.8.tgz",
           "integrity": "sha512-INamyRZG4rW3lDCUmwVd5Xho/bXvQm/v1yP8V0UN1RuInU7RoWoaO570b+yLX4Ia/0szsx1wa8VzcsVlsvbWLA=="
         }
-      }
-    },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.6"
       }
     },
     "pseudomap": {
@@ -9056,14 +9008,6 @@
         "array-map": "0.0.0",
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
-      },
-      "dependencies": {
-        "array-filter": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-          "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-          "dev": true
-        }
       }
     },
     "sigmund": {
@@ -9282,7 +9226,7 @@
       "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-exceptions": {
@@ -9298,23 +9242,14 @@
       "dev": true,
       "requires": {
         "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-license-ids": "3.0.2"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
-    },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
     },
     "split-array-stream": {
       "version": "1.0.3",
@@ -9383,16 +9318,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1",
-        "through": "2.3.8"
-      }
     },
     "stream-consume": {
       "version": "0.1.1",
@@ -9511,12 +9436,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
       "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "minimist": "^1.2.0",
     "mocha": "^5.2.0",
     "nock": "^9.6.0",
-    "npm-run-all": "^4.1.2",
+    "npm-run-all": "^4.1.5",
     "nyc": "^11.5.0",
     "request": "^2.75.0",
     "request-promise": "^4.1.1",


### PR DESCRIPTION
A dependency has been pulled from NPM due to a venerability , and it's causing a build break: https://github.com/dominictarr/event-stream/issues/116

Build break: https://travis-ci.org/firebase/firebase-admin-node/jobs/460497899

This PR fixes it by upgrading the affected dependency.