### PR TITLE
Preventing deep copying the request when making http calls

### DIFF
--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -182,7 +182,7 @@ export class HttpClient {
 function sendRequest(config: HttpRequestConfig): Promise<LowLevelResponse> {
   return new Promise((resolve, reject) => {
     let data: Buffer;
-    const headers = config.headers ? deepCopy(config.headers) : {};
+    const headers = Object.assign({}, config.headers);
     let fullUrl: string = config.url;
     if (config.data) {
       // GET and HEAD do not support body in request.
@@ -354,8 +354,8 @@ export class AuthorizedHttpClient extends HttpClient {
 
   public send(request: HttpRequestConfig): Promise<HttpResponse> {
     return this.app.INTERNAL.getToken().then((accessTokenObj) => {
-      const requestCopy = deepCopy(request);
-      requestCopy.headers = requestCopy.headers || {};
+      const requestCopy = Object.assign({}, request);
+      requestCopy.headers = Object.assign({}, request.headers);
       const authHeader = 'Authorization';
       requestCopy.headers[authHeader] = `Bearer ${accessTokenObj.accessToken}`;
       return super.send(requestCopy);

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -16,7 +16,6 @@
 
 'use strict';
 
-import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as nock from 'nock';
 import * as sinonChai from 'sinon-chai';
@@ -27,8 +26,9 @@ import * as mocks from '../../resources/mocks';
 
 import {FirebaseApp} from '../../../src/firebase-app';
 import {
-  ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction,
+  ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig,
 } from '../../../src/utils/api-request';
+import { deepCopy } from '../../../src/utils/deep-copy';
 
 chai.should();
 chai.use(sinonChai);
@@ -127,7 +127,7 @@ describe('HttpClient', () => {
   let mockedRequests: nock.Scope[] = [];
 
   afterEach(() => {
-    _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
+    mockedRequests.forEach((mockedRequest) => mockedRequest.done());
     mockedRequests = [];
   });
 
@@ -203,6 +203,38 @@ describe('HttpClient', () => {
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(respData);
       expect(resp.isJson()).to.be.true;
+    });
+  });
+
+  it('should not mutate the arguments', () => {
+    const reqData = {request: 'data'};
+    const scope = nock('https://' + mockHost, {
+      reqheaders: {
+        'Authorization': 'Bearer token',
+        'Content-Type': (header) => {
+          return header.startsWith('application/json'); // auto-inserted
+        },
+        'My-Custom-Header': 'CustomValue',
+      },
+    }).post(mockPath, reqData)
+    .reply(200, {success: true}, {
+      'content-type': 'application/json',
+    });
+    mockedRequests.push(scope);
+    const client = new HttpClient();
+    const request: HttpRequestConfig = {
+      method: 'POST',
+      url: mockUrl,
+      headers: {
+        'authorization': 'Bearer token',
+        'My-Custom-Header': 'CustomValue',
+      },
+      data: reqData,
+    };
+    const requestCopy = deepCopy(request);
+    return client.send(request).then((resp) => {
+      expect(resp.status).to.equal(200);
+      expect(request).to.deep.equal(requestCopy);
     });
   });
 
@@ -425,7 +457,7 @@ describe('AuthorizedHttpClient', () => {
   });
 
   afterEach(() => {
-    _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
+    mockedRequests.forEach((mockedRequest) => mockedRequest.done());
     mockedRequests = [];
     return mockApp.delete();
   });


### PR DESCRIPTION
`HttpClient` class currently deep copies the entire request (including headers, data, agent) when making outgoing HTTP calls. If using the`AuthorizedHttpClient`, the request gets deep copied twice. This is done to prevent modifying the request config passed in as the input. However, we only ever modify the headers in `HttpClient`, so we can save a few cycles by only copying them.