### PR TITLE
Correctly parses error codes with details messages in Firebase Auth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [fixed] Correctly parses error codes with details messages in Firebase Auth.
 - [fixed] Fixed optional fields in UserRecord types to be optional.
 
 # v6.4.0

--- a/test/unit/utils/error.spec.ts
+++ b/test/unit/utils/error.spec.ts
@@ -88,6 +88,13 @@ describe('FirebaseAuthError', () => {
         expect(error.code).to.be.equal('auth/internal-error');
         expect(error.message).to.be.equal('An internal error has occurred.');
       });
+
+      it('should initialize an error from an expected server with server detailed message', () => {
+        // Error code should be separated from detailed message at first colon.
+        const error = FirebaseAuthError.fromServerError('CONFIGURATION_NOT_FOUND : more details key: value');
+        expect(error.code).to.be.equal('auth/configuration-not-found');
+        expect(error.message).to.be.equal('more details key: value');
+      });
     });
 
     describe('with message specified', () => {
@@ -103,6 +110,14 @@ describe('FirebaseAuthError', () => {
             'UNEXPECTED_ERROR', 'An unexpected error occurred.');
         expect(error.code).to.be.equal('auth/internal-error');
         expect(error.message).to.be.equal('An unexpected error occurred.');
+      });
+
+      it('should initialize an error from an expected server with server detailed message', () => {
+        const error = FirebaseAuthError.fromServerError(
+            'CONFIGURATION_NOT_FOUND : more details',
+            'Ignored message');
+        expect(error.code).to.be.equal('auth/configuration-not-found');
+        expect(error.message).to.be.equal('more details');
       });
     });
 


### PR DESCRIPTION
```
{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "invalid",
    "message": "INVALID_PHONE_NUMBER : Phone number is too short"
   }
  ],
  "code": 400,
  "message": "INVALID_PHONE_NUMBER : Phone number is too short"
 }
}
```

The above will throw error code auth/invalid-phone-number and the
message will be "Phone number is too short".