### PR TITLE
Refactoring unit tests to reduce dependency on credentials

### DIFF
--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -26,7 +26,7 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {deepCopy, deepExtend} from '../../../src/utils/deep-copy';
-import {FirebaseApp, FirebaseAppInternals} from '../../../src/firebase-app';
+import {FirebaseApp} from '../../../src/firebase-app';
 import {HttpClient, HttpRequestConfig} from '../../../src/utils/api-request';
 import * as validator from '../../../src/utils/validator';
 import {

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -739,10 +739,7 @@ describe('FirebaseAuthRequestHandler', () => {
   };
 
   before(() => {
-    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
-      accessToken: mockAccessToken,
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
   });
 
   after(() => {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
+import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {Auth, DecodedIdToken} from '../../../src/auth/auth';
@@ -161,10 +162,7 @@ describe('Auth', () => {
 
   beforeEach(() => {
     mockApp = mocks.app();
-    getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
-      accessToken: 'mock-access-token',
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(undefined, mockApp);
     auth = new Auth(mockApp);
 
     nullAccessTokenAuth = new Auth(mocks.appReturningNullAccessToken());

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -18,12 +18,10 @@
 
 import * as _ from 'lodash';
 import * as chai from 'chai';
-import * as nock from 'nock';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {Auth, DecodedIdToken} from '../../../src/auth/auth';
@@ -155,17 +153,18 @@ function getDecodedSessionCookie(uid: string, authTime: Date): DecodedIdToken {
 describe('Auth', () => {
   let auth: Auth;
   let mockApp: FirebaseApp;
+  let getTokenStub: sinon.SinonStub;
   let oldProcessEnv: NodeJS.ProcessEnv;
   let nullAccessTokenAuth: Auth;
   let malformedAccessTokenAuth: Auth;
   let rejectedPromiseAccessTokenAuth: Auth;
 
-  before(() => utils.mockFetchAccessTokenRequests());
-
-  after(() => nock.cleanAll());
-
   beforeEach(() => {
     mockApp = mocks.app();
+    getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
+      accessToken: 'mock-access-token',
+      expirationTime: Date.now() + 3600,
+    });
     auth = new Auth(mockApp);
 
     nullAccessTokenAuth = new Auth(mocks.appReturningNullAccessToken());
@@ -179,6 +178,7 @@ describe('Auth', () => {
   });
 
   afterEach(() => {
+    getTokenStub.restore();
     process.env = oldProcessEnv;
     return mockApp.delete();
   });

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -317,10 +317,7 @@ describe('Credential', () => {
   });
 
   describe('ApplicationDefaultCredential', () => {
-    let credPath: string;
     let fsStub: sinon.SinonStub;
-
-    beforeEach(()  => credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS);
 
     afterEach(() => {
       if (fsStub) {

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -351,6 +351,7 @@ describe('Credential', () => {
         console.log(
           'WARNING: Test being skipped because gcloud credentials not found. Run `gcloud beta auth ' +
           'application-default login`.');
+        return;
       }
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       expect((new ApplicationDefaultCredential()).getCredential()).to.be.an.instanceof(RefreshTokenCredential);

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -22,7 +22,6 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as nock from 'nock';
 
 import * as mocks from '../../resources/mocks';
 import {FirebaseTokenGenerator, ServiceAccountSigner, IAMSigner} from '../../../src/auth/token-generator';
@@ -106,20 +105,20 @@ describe('CryptoSigner', () => {
 
   describe('IAMSigner', () => {
     let mockApp: FirebaseApp;
+    let getTokenStub: sinon.SinonStub;
     const mockAccessToken: string = utils.generateRandomAccessToken();
-
-    before(() => {
-      utils.mockFetchAccessTokenRequests(mockAccessToken);
-    });
-
-    after(() => nock.cleanAll());
 
     beforeEach(() => {
       mockApp = mocks.app();
+      getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
+        accessToken: mockAccessToken,
+        expirationTime: Date.now() + 3600,
+      });
       return mockApp.INTERNAL.getToken();
     });
 
     afterEach(() => {
+      getTokenStub.restore();
       return mockApp.delete();
     });
 

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -110,10 +110,7 @@ describe('CryptoSigner', () => {
 
     beforeEach(() => {
       mockApp = mocks.app();
-      getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
-        accessToken: mockAccessToken,
-        expirationTime: Date.now() + 3600,
-      });
+      getTokenStub = utils.stubGetAccessToken(mockAccessToken, mockApp);
       return mockApp.INTERNAL.getToken();
     });
 

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -21,7 +21,6 @@ import https = require('https');
 
 import * as _ from 'lodash';
 import * as chai from 'chai';
-import * as nock from 'nock';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -64,13 +63,16 @@ function mockServiceFactory(app: FirebaseApp): FirebaseServiceInterface {
 
 describe('FirebaseApp', () => {
   let mockApp: FirebaseApp;
-  let mockedRequests: nock.Scope[] = [];
+  let getTokenStub: sinon.SinonStub;
   let firebaseNamespace: FirebaseNamespace;
   let firebaseNamespaceInternals: FirebaseNamespaceInternals;
   let firebaseConfigVar: string;
 
   beforeEach(() => {
-    utils.mockFetchAccessTokenRequests();
+    getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').resolves({
+      access_token: 'mock-access-token',
+      expires_in: 3600,
+    });
 
     this.clock = sinon.useFakeTimers(1000);
 
@@ -86,6 +88,7 @@ describe('FirebaseApp', () => {
   });
 
   afterEach(() => {
+    getTokenStub.restore();
     this.clock.restore();
     if (firebaseConfigVar) {
       process.env[FIREBASE_CONFIG_VAR] = firebaseConfigVar;
@@ -95,11 +98,6 @@ describe('FirebaseApp', () => {
 
     deleteSpy.resetHistory();
     (firebaseNamespaceInternals.removeApp as any).restore();
-
-    _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
-    mockedRequests = [];
-
-    nock.cleanAll();
   });
 
   describe('#name', () => {
@@ -624,25 +622,6 @@ describe('FirebaseApp', () => {
   });
 
   describe('INTERNAL.getToken()', () => {
-    let httpsSpy: sinon.SinonSpy;
-    let getAccessTokenSpy: sinon.SinonSpy;
-    let getAccessTokenStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      httpsSpy = sinon.spy(https, 'request');
-    });
-
-    afterEach(() => {
-      httpsSpy.restore();
-
-      if (typeof getAccessTokenSpy !== 'undefined') {
-        getAccessTokenSpy.restore();
-      }
-
-      if (typeof getAccessTokenStub !== 'undefined') {
-        getAccessTokenStub.restore();
-      }
-    });
 
     it('throws a custom credential implementation which returns invalid access tokens', () => {
       const credential = {
@@ -698,7 +677,7 @@ describe('FirebaseApp', () => {
         this.clock.tick(1000);
         return mockApp.INTERNAL.getToken().then((token2) => {
           expect(token1).to.deep.equal(token2);
-          expect(httpsSpy).to.have.been.calledOnce;
+          expect(getTokenStub).to.have.been.calledOnce;
         });
       });
     });
@@ -708,7 +687,7 @@ describe('FirebaseApp', () => {
         this.clock.tick(1000);
         return mockApp.INTERNAL.getToken(true).then((token2) => {
           expect(token1).to.not.deep.equal(token2);
-          expect(httpsSpy).to.have.been.calledTwice;
+          expect(getTokenStub).to.have.been.calledTwice;
         });
       });
     });
@@ -723,7 +702,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken().then((token2) => {
           // Ensure the token has not been proactively refreshed.
           expect(token1).to.deep.equal(token2);
-          expect(httpsSpy).to.have.been.calledOnce;
+          expect(getTokenStub).to.have.been.calledOnce;
 
           // Forward the clock to exactly five minutes before expiry.
           this.clock.tick(1000);
@@ -731,7 +710,7 @@ describe('FirebaseApp', () => {
           return mockApp.INTERNAL.getToken().then((token3) => {
             // Ensure the token was proactively refreshed.
             expect(token1).to.not.deep.equal(token3);
-            expect(httpsSpy).to.have.been.calledTwice;
+            expect(getTokenStub).to.have.been.calledTwice;
           });
         });
       });
@@ -741,8 +720,9 @@ describe('FirebaseApp', () => {
       // Force a token refresh.
       return mockApp.INTERNAL.getToken(true).then((token1) => {
         // Stub the getToken() method to return a rejected promise.
-        getAccessTokenStub = sinon.stub(mockApp.options.credential, 'getAccessToken');
-        getAccessTokenStub.returns(Promise.reject(new Error('Intentionally rejected')));
+        getTokenStub.restore();
+        getTokenStub = sinon.stub(mockApp.options.credential, 'getAccessToken')
+          .rejects(new Error('Intentionally rejected'));
 
         // Forward the clock to exactly five minutes before expiry.
         const expiryInMilliseconds = token1.expirationTime - Date.now();
@@ -752,13 +732,16 @@ describe('FirebaseApp', () => {
         this.clock.tick(60 * 1000);
 
         // Restore the stubbed getAccessToken() method.
-        getAccessTokenStub.restore();
-        getAccessTokenStub = undefined;
+        getTokenStub.restore();
+        getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').resolves({
+          access_token: 'mock-access-token',
+          expires_in: 3600,
+        });
 
         return mockApp.INTERNAL.getToken().then((token2) => {
           // Ensure the token has not been proactively refreshed.
           expect(token1).to.deep.equal(token2);
-          expect(httpsSpy).to.have.been.calledOnce;
+          expect(getTokenStub).to.have.not.been.called;
 
           // Forward the clock to exactly three minutes before expiry.
           this.clock.tick(60 * 1000);
@@ -766,7 +749,7 @@ describe('FirebaseApp', () => {
           return mockApp.INTERNAL.getToken().then((token3) => {
             // Ensure the token was proactively refreshed.
             expect(token1).to.not.deep.equal(token3);
-            expect(httpsSpy).to.have.been.calledTwice;
+            expect(getTokenStub).to.have.been.calledOnce;
           });
         });
       });
@@ -779,11 +762,12 @@ describe('FirebaseApp', () => {
         originalToken = token;
 
         // Stub the credential's getAccessToken() method to always return a rejected promise.
-        getAccessTokenStub = sinon.stub(mockApp.options.credential, 'getAccessToken');
-        getAccessTokenStub.returns(Promise.reject(new Error('Intentionally rejected')));
+        getTokenStub.restore();
+        getTokenStub = sinon.stub(mockApp.options.credential, 'getAccessToken')
+          .rejects(new Error('Intentionally rejected'));
 
         // Expect the call count to initially be zero.
-        expect(getAccessTokenStub.callCount).to.equal(0);
+        expect(getTokenStub.callCount).to.equal(0);
 
         // Forward the clock to exactly five minutes before expiry.
         const expiryInMilliseconds = token.expirationTime - Date.now();
@@ -795,7 +779,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was attempted to be proactively refreshed one time.
-        expect(getAccessTokenStub.callCount).to.equal(1);
+        expect(getTokenStub.callCount).to.equal(1);
 
         // Ensure the proactive refresh failed.
         expect(token).to.deep.equal(originalToken);
@@ -807,7 +791,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was attempted to be proactively refreshed two times.
-        expect(getAccessTokenStub.callCount).to.equal(2);
+        expect(getTokenStub.callCount).to.equal(2);
 
         // Ensure the proactive refresh failed.
         expect(token).to.deep.equal(originalToken);
@@ -819,7 +803,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was attempted to be proactively refreshed three times.
-        expect(getAccessTokenStub.callCount).to.equal(3);
+        expect(getTokenStub.callCount).to.equal(3);
 
         // Ensure the proactive refresh failed.
         expect(token).to.deep.equal(originalToken);
@@ -831,7 +815,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was attempted to be proactively refreshed four times.
-        expect(getAccessTokenStub.callCount).to.equal(4);
+        expect(getTokenStub.callCount).to.equal(4);
 
         // Ensure the proactive refresh failed.
         expect(token).to.deep.equal(originalToken);
@@ -843,7 +827,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was attempted to be proactively refreshed five times.
-        expect(getAccessTokenStub.callCount).to.equal(5);
+        expect(getTokenStub.callCount).to.equal(5);
 
         // Ensure the proactive refresh failed.
         expect(token).to.deep.equal(originalToken);
@@ -855,7 +839,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken();
       }).then((token) => {
         // Ensure the token was not attempted to be proactively refreshed a sixth time.
-        expect(getAccessTokenStub.callCount).to.equal(5);
+        expect(getTokenStub.callCount).to.equal(5);
 
         // Ensure the token has never been refresh.
         expect(token).to.deep.equal(originalToken);
@@ -873,7 +857,7 @@ describe('FirebaseApp', () => {
         return mockApp.INTERNAL.getToken(true).then((token2) => {
           // Ensure the token was force refreshed.
           expect(token1).to.not.deep.equal(token2);
-          expect(httpsSpy).to.have.been.calledTwice;
+          expect(getTokenStub).to.have.been.calledTwice;
 
           // Forward the clock to exactly five minutes before the original token's expiry.
           this.clock.tick(1000);
@@ -881,7 +865,7 @@ describe('FirebaseApp', () => {
           return mockApp.INTERNAL.getToken().then((token3) => {
             // Ensure the token hasn't changed, meaning the proactive refresh was canceled.
             expect(token2).to.deep.equal(token3);
-            expect(httpsSpy).to.have.been.calledTwice;
+            expect(getTokenStub).to.have.been.calledTwice;
 
             // Forward the clock to exactly five minutes before the refreshed token's expiry.
             expiryInMilliseconds = token3.expirationTime - Date.now();
@@ -890,7 +874,7 @@ describe('FirebaseApp', () => {
             return mockApp.INTERNAL.getToken().then((token4) => {
               // Ensure the token was proactively refreshed.
               expect(token3).to.not.deep.equal(token4);
-              expect(httpsSpy).to.have.been.calledThrice;
+              expect(getTokenStub).to.have.been.calledThrice;
             });
           });
         });
@@ -899,24 +883,26 @@ describe('FirebaseApp', () => {
 
     it('proactively refreshes the token at the next full minute if it expires in five minutes or less', () => {
       // Turn off default mocking of one hour access tokens and replace it with a short-lived token.
-      nock.cleanAll();
-      utils.mockFetchAccessTokenRequests(/* token */ undefined, /* expiresIn */ 3 * 60 + 10);
+      getTokenStub.restore();
+      getTokenStub = sinon.stub(mockApp.options.credential, 'getAccessToken').resolves({
+        access_token: utils.generateRandomAccessToken(),
+        expires_in: 3 * 60 + 10,
+      });
+      // Expect the call count to initially be zero.
+      expect(getTokenStub.callCount).to.equal(0);
 
       // Force a token refresh.
       return mockApp.INTERNAL.getToken(true).then((token1) => {
-        getAccessTokenSpy = sinon.spy(mockApp.options.credential, 'getAccessToken');
 
         // Move the clock forward to three minutes and one second before expiry.
         this.clock.tick(9 * 1000);
-
-        // Expect the call count to initially be zero.
-        expect(getAccessTokenSpy.callCount).to.equal(0);
+        expect(getTokenStub.callCount).to.equal(1);
 
         // Move the clock forward to exactly three minutes before expiry.
         this.clock.tick(1000);
 
         // Expect the underlying getAccessToken() method to have been called once.
-        expect(getAccessTokenSpy.callCount).to.equal(1);
+        expect(getTokenStub.callCount).to.equal(2);
 
         return mockApp.INTERNAL.getToken().then((token2) => {
           // Ensure the token was proactively refreshed.

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -18,12 +18,10 @@
 
 import * as _ from 'lodash';
 import * as chai from 'chai';
-import * as nock from 'nock';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import * as utils from './utils';
 import * as mocks from '../resources/mocks';
 
 import {FirebaseNamespace} from '../../src/firebase-namespace';
@@ -63,10 +61,6 @@ const DEFAULT_APP_NOT_FOUND = 'The default Firebase app does not exist. Make sur
 
 describe('FirebaseNamespace', () => {
   let firebaseNamespace: FirebaseNamespace;
-
-  before(() => utils.mockFetchAccessTokenRequests());
-
-  after(() => nock.cleanAll());
 
   beforeEach(() => {
     firebaseNamespace = new FirebaseNamespace();

--- a/test/unit/instance-id/instance-id-request.spec.ts
+++ b/test/unit/instance-id/instance-id-request.spec.ts
@@ -25,7 +25,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
-import {FirebaseApp, FirebaseAppInternals} from '../../../src/firebase-app';
+import {FirebaseApp} from '../../../src/firebase-app';
 import {HttpClient} from '../../../src/utils/api-request';
 import {FirebaseInstanceIdRequestHandler} from '../../../src/instance-id/instance-id-request';
 

--- a/test/unit/instance-id/instance-id-request.spec.ts
+++ b/test/unit/instance-id/instance-id-request.spec.ts
@@ -44,10 +44,7 @@ describe('FirebaseInstanceIdRequestHandler', () => {
   let expectedHeaders: object;
 
   before(() => {
-    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
-      accessToken: mockAccessToken,
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
   });
 
   after(() => {

--- a/test/unit/instance-id/instance-id.spec.ts
+++ b/test/unit/instance-id/instance-id.spec.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
+import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {InstanceId} from '../../../src/instance-id/instance-id';
@@ -54,10 +55,7 @@ describe('InstanceId', () => {
 
   beforeEach(() => {
     mockApp = mocks.app();
-    getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
-      accessToken: 'mock-access-token',
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(undefined, mockApp);
     mockCredentialApp = mocks.mockCredentialApp();
     iid = new InstanceId(mockApp);
 

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -26,7 +26,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
-import {FirebaseApp, FirebaseAppInternals} from '../../../src/firebase-app';
+import {FirebaseApp} from '../../../src/firebase-app';
 import {
   Message, Messaging, MessagingOptions, MessagingPayload, MessagingDevicesResponse,
   MessagingTopicManagementResponse,

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -267,10 +267,7 @@ describe('Messaging', () => {
 
   beforeEach(() => {
     mockApp = mocks.app();
-    getTokenStub = sinon.stub(mockApp.INTERNAL, 'getToken').resolves({
-      accessToken: mockAccessToken,
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken, mockApp);
     messaging = new Messaging(mockApp);
     nullAccessTokenMessaging = new Messaging(mocks.appReturningNullAccessToken());
     messagingService = messaging;

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -21,7 +21,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as _ from 'lodash';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
-import { FirebaseApp, FirebaseAppInternals } from '../../../src/firebase-app';
+import { FirebaseApp } from '../../../src/firebase-app';
 import { ProjectManagementRequestHandler } from '../../../src/project-management/project-management-api-request';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -19,10 +19,9 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as _ from 'lodash';
-import * as nock from 'nock';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
-import { FirebaseApp } from '../../../src/firebase-app';
+import { FirebaseApp, FirebaseAppInternals } from '../../../src/firebase-app';
 import { ProjectManagementRequestHandler } from '../../../src/project-management/project-management-api-request';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as mocks from '../../resources/mocks';
@@ -49,18 +48,23 @@ describe('ProjectManagementRequestHandler', () => {
   const DISPLAY_NAME: string = 'test-display-name';
   const OPERATION_RESOURCE_NAME: string = 'test-operation-resource-name';
 
-  const mockedRequests: nock.Scope[] = [];
   const mockAccessToken: string = utils.generateRandomAccessToken();
   let stubs: sinon.SinonStub[] = [];
+  let getTokenStub: sinon.SinonStub;
   let mockApp: FirebaseApp;
   let expectedHeaders: object;
   let requestHandler: ProjectManagementRequestHandler;
 
-  before(() => utils.mockFetchAccessTokenRequests(mockAccessToken));
+  before(() => {
+    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
+      accessToken: mockAccessToken,
+      expirationTime: Date.now() + 3600,
+    });
+  });
 
   after(() => {
     stubs = [];
-    nock.cleanAll();
+    getTokenStub.restore();
   });
 
   beforeEach(() => {
@@ -75,7 +79,6 @@ describe('ProjectManagementRequestHandler', () => {
 
   afterEach(() => {
     _.forEach(stubs, (stub) => stub.restore());
-    _.forEach(mockedRequests, (mockedRequest) => mockedRequest.done());
     return mockApp.delete();
   });
 

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -56,10 +56,7 @@ describe('ProjectManagementRequestHandler', () => {
   let requestHandler: ProjectManagementRequestHandler;
 
   before(() => {
-    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
-      accessToken: mockAccessToken,
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
   });
 
   after(() => {

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -15,11 +15,12 @@
  */
 
 import * as _ from 'lodash';
+import * as sinon from 'sinon';
 
 import * as mocks from '../resources/mocks';
 
 import {FirebaseNamespace} from '../../src/firebase-namespace';
-import {FirebaseApp, FirebaseAppOptions} from '../../src/firebase-app';
+import {FirebaseApp, FirebaseAppOptions, FirebaseAppInternals, FirebaseAccessToken} from '../../src/firebase-app';
 import { HttpError, HttpResponse } from '../../src/utils/api-request';
 
 /**
@@ -37,6 +38,29 @@ export function createAppWithOptions(options: object) {
 /** @return {string} A randomly generated access token string. */
 export function generateRandomAccessToken(): string {
   return 'access_token_' + _.random(999999999);
+}
+
+/**
+ * Creates a stub for retrieving an access token from a FirebaseApp. All services should use this
+ * method for stubbing the OAuth2 flow during unit tests.
+ *
+ * @param {string} accessToken The access token string to return.
+ * @param {FirebaseApp} app The app instance to stub. If not specified, the stub will affect all apps.
+ * @return {sinon.SinonStub} A Sinon stub.
+ */
+export function stubGetAccessToken(accessToken?: string, app?: FirebaseApp): sinon.SinonStub {
+  if (typeof accessToken === 'undefined') {
+    accessToken = generateRandomAccessToken();
+  }
+  const result: FirebaseAccessToken = {
+    accessToken,
+    expirationTime: Date.now() + 3600,
+  };
+  if (app) {
+    return sinon.stub(app.INTERNAL, 'getToken').resolves(result);
+  } else {
+    return sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves(result);
+  }
 }
 
 /**

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -15,7 +15,6 @@
  */
 
 import * as _ from 'lodash';
-import * as nock from 'nock';
 
 import * as mocks from '../resources/mocks';
 
@@ -32,34 +31,6 @@ import { HttpError, HttpResponse } from '../../src/utils/api-request';
 export function createAppWithOptions(options: object) {
   const mockFirebaseNamespaceInternals = new FirebaseNamespace().INTERNAL;
   return new FirebaseApp(options as FirebaseAppOptions, mocks.appName, mockFirebaseNamespaceInternals);
-}
-
-
-/**
- * Returns a mocked out success response from the URL generating Google access tokens given a JWT
- * signed with a service account private key.
- *
- * Calling this once will mock ALL future requests to this endpoint. Use nock.cleanAll() to unmock.
- *
- * @param {string} [token] The optional access token to return. If not specified, a random one
- *     is created.
- * @param {number} [expiresIn] The optional expires in value to use for the access token.
- * @return {Object} A nock response object.
- */
-export function mockFetchAccessTokenRequests(
-  token: string = generateRandomAccessToken(),
-  expiresIn: number = 60 * 60,
-): nock.Scope {
-  return nock('https://accounts.google.com')
-    .persist()
-    .post('/o/oauth2/token')
-    .reply(200, {
-      access_token: token,
-      token_type: 'Bearer',
-      expires_in: expiresIn,
-    }, {
-      'cache-control': 'no-cache, no-store, max-age=0, must-revalidate',
-    });
 }
 
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -445,10 +445,7 @@ describe('AuthorizedHttpClient', () => {
   };
 
   before(() => {
-    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
-      accessToken: mockAccessToken,
-      expirationTime: Date.now() + 3600,
-    });
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
   });
 
   after(() => {

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -25,7 +25,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
-import {FirebaseApp, FirebaseAppInternals} from '../../../src/firebase-app';
+import {FirebaseApp} from '../../../src/firebase-app';
 import {
   ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig,
 } from '../../../src/utils/api-request';

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -25,7 +25,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
-import {FirebaseApp} from '../../../src/firebase-app';
+import {FirebaseApp, FirebaseAppInternals} from '../../../src/firebase-app';
 import {
   ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig,
 } from '../../../src/utils/api-request';
@@ -353,7 +353,6 @@ describe('HttpClient', () => {
   });
 
   it('should fail with a FirebaseAppError for a network error', () => {
-    const data = {foo: 'bar'};
     mockedRequests.push(mockRequestWithError({message: 'test error', code: 'AWFUL_ERROR'}));
     const client = new HttpClient();
     const err = 'Error while making request: test error. Error code: AWFUL_ERROR';
@@ -436,6 +435,7 @@ describe('HttpClient', () => {
 describe('AuthorizedHttpClient', () => {
   let mockApp: FirebaseApp;
   let mockedRequests: nock.Scope[] = [];
+  let getTokenStub: sinon.SinonStub;
 
   const mockAccessToken: string = utils.generateRandomAccessToken();
   const requestHeaders = {
@@ -444,9 +444,16 @@ describe('AuthorizedHttpClient', () => {
     },
   };
 
-  before(() => utils.mockFetchAccessTokenRequests(mockAccessToken));
+  before(() => {
+    getTokenStub = sinon.stub(FirebaseAppInternals.prototype, 'getToken').resolves({
+      accessToken: mockAccessToken,
+      expirationTime: Date.now() + 3600,
+    });
+  });
 
-  after(() => nock.cleanAll());
+  after(() => {
+    getTokenStub.restore();
+  });
 
   beforeEach(() => {
     mockApp = mocks.app();
@@ -514,9 +521,8 @@ describe('AuthorizedHttpClient', () => {
         httpAgent,
       }).then((resp) => {
         expect(resp.status).to.equal(200);
-        // First call is to the token server
-        expect(transportSpy.callCount).to.equal(2);
-        const options = transportSpy.args[1][0];
+        expect(transportSpy.callCount).to.equal(1);
+        const options = transportSpy.args[0][0];
         expect(options.agent).to.equal(httpAgent);
       });
     });
@@ -535,9 +541,8 @@ describe('AuthorizedHttpClient', () => {
         url: mockUrl,
       }).then((resp) => {
         expect(resp.status).to.equal(200);
-        // First call is to the token server
-        expect(transportSpy.callCount).to.equal(2);
-        const options = transportSpy.args[1][0];
+        expect(transportSpy.callCount).to.equal(1);
+        const options = transportSpy.args[0][0];
         expect(options.agent).to.equal(agentForApp);
       });
     });


### PR DESCRIPTION
I want to implement some changes to our credentials, but every time I touch that code a large number of unit tests break. This is because many of our unit tests are tightly coupled with the credentials. A lot of the tests emulate the behavior of credentials by mocking the HTTP call to token servers, and if the credentials change how they talk to the servers even slightly, all the dependent tests break.

This PR reduces this level of coupling by implementing the following changes:

1. Service-level unit tests (auth, fcm etc.) no longer mock the HTTP call to token servers. Instead, they stub the `FirebaseApp.Internals.getToken()` method.
2. `FirebaseApp` and `FirebaseNamespace` unit tests stub the `getAccessToken()` method on the credential classes.
3. Only the `Credential` unit tests are allowed to mock the token server HTTP calls. To this end the `utils.mockFetchAccessTokenRequests()` method has been removed.