### PR TITLE
Make Project Management list*Apps() integration tests more robust.

### DIFF
--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -55,6 +55,7 @@ describe('admin.projectManagement', () => {
             expect(metadatas.length).to.be.at.least(1);
             const metadataOwnedByTest =
                 metadatas.find((metadata) => isIntegrationTestApp(metadata.packageName));
+            expect(metadataOwnedByTest).to.exist;
             expect(metadataOwnedByTest.appId).to.equal(androidApp.appId);
           });
     });
@@ -68,6 +69,7 @@ describe('admin.projectManagement', () => {
             expect(metadatas.length).to.be.at.least(1);
             const metadataOwnedByTest =
                 metadatas.find((metadata) => isIntegrationTestApp(metadata.bundleId));
+            expect(metadataOwnedByTest).to.exist;
             expect(metadataOwnedByTest.appId).to.equal(iosApp.appId);
           });
     });

--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -49,19 +49,27 @@ describe('admin.projectManagement', () => {
 
   describe('listAndroidApps()', () => {
     it('successfully lists Android apps', () => {
-      return admin.projectManagement().listAndroidApps().then((results) => {
-        expect(results.length).to.be.at.least(1);
-        expect(results[0].appId).to.equal(androidApp.appId);
-      });
+      return admin.projectManagement().listAndroidApps()
+          .then((apps) => Promise.all(apps.map((app) => app.getMetadata())))
+          .then((metadatas) => {
+            expect(metadatas.length).to.be.at.least(1);
+            const metadataOwnedByTest =
+                metadatas.find((metadata) => isIntegrationTestApp(metadata.packageName));
+            expect(metadataOwnedByTest.appId).to.equal(androidApp.appId);
+          });
     });
   });
 
   describe('listIosApps()', () => {
     it('successfully lists iOS apps', () => {
-      return admin.projectManagement().listIosApps().then((results) => {
-        expect(results.length).to.be.at.least(1);
-        expect(results[0].appId).to.equal(iosApp.appId);
-      });
+      return admin.projectManagement().listIosApps()
+          .then((apps) => Promise.all(apps.map((app) => app.getMetadata())))
+          .then((metadatas) => {
+            expect(metadatas.length).to.be.at.least(1);
+            const metadataOwnedByTest =
+                metadatas.find((metadata) => isIntegrationTestApp(metadata.bundleId));
+            expect(metadataOwnedByTest.appId).to.equal(iosApp.appId);
+          });
     });
   });
 


### PR DESCRIPTION
Search through the list of apps on a project to find the ones created by
these integration tests, rather than just using the first returned
results.