### PR TITLE
Bumped version to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+-
+
+# v7.0.0
+
 - [changed] Updated the Google Cloud Firestore client to v1.0.1. This contains
   breaking changes. Refer to Cloud Firestore
   [release notes](https://github.com/googleapis/nodejs-firestore/releases/tag/v0.20.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "6.5.1",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "6.5.1",
+  "version": "7.0.0",
   "description": "Firebase admin SDK for Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",

--- a/test/integration/typescript/tsconfig.json
+++ b/test/integration/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "target": "es5",
     "noImplicitAny": false,
-    "lib": ["es5", "es2015.promise"],
+    "lib": ["es2015"],
     "outDir": "lib",
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
Also updated one of the test configuration files to prevent the following error:

```
+ firebase-admin@7.0.0
added 278 packages in 12.228s
> tsc -p tsconfig.json
node_modules/google-auth-library/build/src/auth/oauth2client.d.ts:280:37 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.

280     protected refreshTokenPromises: Map<string, Promise<GetTokenResponse>>;
                                        ~~~


Found 1 error.
```