### PR TITLE
Implementing the sendMulticast() API for FCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
--
+- [added] A new `messaging.sendAll()` API for sending multiple messages as a
+  single batch.
+- [added] A new `messaging.sendMulticast()` API for sending a message to
+  multiple device registration tokens.
 
 # v7.0.0
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -412,6 +412,10 @@ interface ConditionMessage extends BaseMessage {
 declare namespace admin.messaging {
   type Message = TokenMessage | TopicMessage | ConditionMessage;
 
+  interface MulticastMessage extends BaseMessage {
+    tokens: string[];
+  }
+
   type AndroidConfig = {
     collapseKey?: string;
     priority?: ('high'|'normal');
@@ -604,6 +608,10 @@ declare namespace admin.messaging {
     send(message: admin.messaging.Message, dryRun?: boolean): Promise<string>;
     sendAll(
       messages: Array<admin.messaging.Message>,
+      dryRun?: boolean
+    ): Promise<admin.messaging.BatchResponse>;
+    sendMulticase(
+      message: admin.messaging.MulticastMessage,
       dryRun?: boolean
     ): Promise<admin.messaging.BatchResponse>;
     sendToDevice(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -610,7 +610,7 @@ declare namespace admin.messaging {
       messages: Array<admin.messaging.Message>,
       dryRun?: boolean
     ): Promise<admin.messaging.BatchResponse>;
-    sendMulticase(
+    sendMulticast(
       message: admin.messaging.MulticastMessage,
       dryRun?: boolean
     ): Promise<admin.messaging.BatchResponse>;

--- a/src/messaging/messaging-types.ts
+++ b/src/messaging/messaging-types.ts
@@ -47,6 +47,14 @@ interface ConditionMessage extends BaseMessage {
  */
 export type Message = TokenMessage | TopicMessage | ConditionMessage;
 
+/**
+ * Payload for the admin.messaing.sendMulticase() method. The payload contains all the fields
+ * in the BaseMessage type, and a list of tokens.
+ */
+export interface MulticastMessage extends BaseMessage {
+  tokens: string[];
+}
+
 export interface Notification {
   title?: string;
   body?: string;

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -326,7 +326,7 @@ export class Messaging implements FirebaseServiceInterface {
    * This method uses the sendAll() API under the hood to send the given
    * message to all the target recipients. The responses list obtained from the return value
    * corresponds to the order of tokens in the MulticastMessage. An error from this method
-   * indicates a total failure -- i.e. none of the messages in the list could be sent. Partial
+   * indicates a total failure -- i.e. none of the tokens in the list could be sent to. Partial
    * failures are indicated by a BatchResponse return value.
    *
    * @param {MulticastMessage} message A multicast message containing up to 100 tokens.
@@ -352,13 +352,14 @@ export class Messaging implements FirebaseServiceInterface {
     }
 
     const messages: Message[] = copy.tokens.map((token) => {
-      const subMessage: Message = {token};
-      subMessage.android = copy.android;
-      subMessage.apns = copy.apns;
-      subMessage.data = copy.data;
-      subMessage.notification = copy.notification;
-      subMessage.webpush = copy.webpush;
-      return subMessage;
+      return {
+        token,
+        android: copy.android,
+        apns: copy.apns,
+        data: copy.data,
+        notification: copy.notification,
+        webpush: copy.webpush,
+      };
     });
     return this.sendAll(messages, dryRun);
   }

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -329,7 +329,7 @@ export class Messaging implements FirebaseServiceInterface {
    * indicates a total failure -- i.e. none of the messages in the list could be sent. Partial
    * failures are indicated by a BatchResponse return value.
    *
-   * @param {MulticastMessage} message A multicast message containing up to 1000 tokens.
+   * @param {MulticastMessage} message A multicast message containing up to 100 tokens.
    * @param {boolean=} dryRun Whether to send the message in the dry-run (validation only) mode.
    *
    * @return {Promise<BatchResponse>} A Promise fulfilled with an object representing the result

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -119,6 +119,25 @@ describe('admin.messaging', () => {
       });
   });
 
+  it('sendMulticast()', () => {
+    const multicastMessage: admin.messaging.MulticastMessage = {
+      data: message.data,
+      android: message.android,
+      tokens: ['not-a-token', 'also-not-a-token'],
+    };
+    return admin.messaging().sendMulticast(multicastMessage, true)
+      .then((response) => {
+        expect(response.responses.length).to.equal(2);
+        expect(response.successCount).to.equal(0);
+        expect(response.failureCount).to.equal(2);
+        response.responses.forEach((resp) => {
+          expect(resp.success).to.be.false;
+          expect(resp.messageId).to.be.undefined;
+          expect(resp.error).to.have.property('code', 'messaging/invalid-argument');
+        });
+      });
+  });
+
   it('sendToDevice(token) returns a response with multicast ID', () => {
     return admin.messaging().sendToDevice(registrationToken, payload, options)
       .then((response) => {

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -29,7 +29,7 @@ import * as mocks from '../../resources/mocks';
 import {FirebaseApp} from '../../../src/firebase-app';
 import {
   Message, MessagingOptions, MessagingPayload, MessagingDevicesResponse,
-  MessagingTopicManagementResponse, BatchResponse, SendResponse,
+  MessagingTopicManagementResponse, BatchResponse, SendResponse, MulticastMessage,
 } from '../../../src/messaging/messaging-types';
 import {
   Messaging, BLACKLISTED_OPTIONS_KEYS, BLACKLISTED_DATA_PAYLOAD_KEYS,
@@ -735,6 +735,301 @@ describe('Messaging', () => {
     it('should be rejected given an app which returns null access tokens', () => {
       return nullAccessTokenMessaging.sendAll(
         [validMessage],
+      ).should.eventually.be.rejected.and.have.property('code', 'app/invalid-credential');
+    });
+
+    function checkSendResponseSuccess(response: SendResponse, messageId: string) {
+      expect(response.success).to.be.true;
+      expect(response.messageId).to.equal(messageId);
+      expect(response.error).to.be.undefined;
+    }
+
+    function checkSendResponseFailure(response: SendResponse, code: string, msg?: string) {
+      expect(response.success).to.be.false;
+      expect(response.messageId).to.be.undefined;
+      expect(response.error).to.have.property('code', code);
+      if (msg) {
+        expect(response.error.toString()).to.contain(msg);
+      }
+    }
+  });
+
+  describe('sendMulticast()', () => {
+    const mockResponse: BatchResponse = {
+      successCount: 3,
+      failureCount: 0,
+      responses: [
+        {success: true, messageId: 'projects/projec_id/messages/1'},
+        {success: true, messageId: 'projects/projec_id/messages/2'},
+        {success: true, messageId: 'projects/projec_id/messages/3'},
+      ],
+    };
+
+    let stub: sinon.SinonStub;
+
+    afterEach(() => {
+      if (stub) {
+        stub.restore();
+      }
+      stub = null;
+    });
+
+    it('should throw given no messages', () => {
+      expect(() => {
+        messaging.sendMulticast(undefined as MulticastMessage);
+      }).to.throw('MulticastMessage must be a non-null object');
+      expect(() => {
+        messaging.sendMulticast({} as any);
+      }).to.throw('tokens must be a non-empty array');
+      expect(() => {
+        messaging.sendMulticast({tokens: []});
+      }).to.throw('tokens must be a non-empty array');
+    });
+
+    it('should throw when called with more than 1000 messages', () => {
+      const tokens: string[] = [];
+      for (let i = 0; i < 1001; i++) {
+        tokens.push(`token${i}`);
+      }
+      expect(() => {
+        messaging.sendMulticast({tokens});
+      }).to.throw('tokens list must not contain more than 1000 items');
+    });
+
+    const invalidDryRun = [null, NaN, 0, 1, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];
+    invalidDryRun.forEach((dryRun) => {
+      it(`should throw given invalid dryRun parameter: ${JSON.stringify(dryRun)}`, () => {
+        expect(() => {
+          messaging.sendMulticast({tokens: ['a']}, dryRun as any);
+        }).to.throw('dryRun must be a boolean');
+      });
+    });
+
+    it('should create multiple messages using the empty multicast payload', () => {
+      stub = sinon.stub(messaging, 'sendAll').resolves(mockResponse);
+      const tokens = ['a', 'b', 'c'];
+      return messaging.sendMulticast({tokens})
+        .then((response: BatchResponse) => {
+          expect(response).to.deep.equal(mockResponse);
+          expect(stub).to.have.been.calledOnce;
+          const messages: Message[] = stub.args[0][0];
+          expect(messages.length).to.equal(3);
+          expect(stub.args[0][1]).to.be.undefined;
+          messages.forEach((message, idx) => {
+            expect((message as any).token).to.equal(tokens[idx]);
+            expect(message.android).to.be.undefined;
+            expect(message.apns).to.be.undefined;
+            expect(message.data).to.be.undefined;
+            expect(message.notification).to.be.undefined;
+            expect(message.webpush).to.be.undefined;
+          });
+        });
+    });
+
+    it('should create multiple messages using the multicast payload', () => {
+      stub = sinon.stub(messaging, 'sendAll').resolves(mockResponse);
+      const tokens = ['a', 'b', 'c'];
+      const multicast: MulticastMessage = {
+        tokens,
+        android: {ttl: 100},
+        apns: {payload: {aps: {badge: 42}}},
+        data: {key: 'value'},
+        notification: {title: 'test title'},
+        webpush: {data: {webKey: 'webValue'}},
+      };
+      return messaging.sendMulticast(multicast)
+        .then((response: BatchResponse) => {
+          expect(response).to.deep.equal(mockResponse);
+          expect(stub).to.have.been.calledOnce;
+          const messages: Message[] = stub.args[0][0];
+          expect(messages.length).to.equal(3);
+          expect(stub.args[0][1]).to.be.undefined;
+          messages.forEach((message, idx) => {
+            expect((message as any).token).to.equal(tokens[idx]);
+            expect(message.android).to.deep.equal(multicast.android);
+            expect(message.apns).to.be.deep.equal(multicast.apns);
+            expect(message.data).to.be.deep.equal(multicast.data);
+            expect(message.notification).to.deep.equal(multicast.notification);
+            expect(message.webpush).to.deep.equal(multicast.webpush);
+          });
+        });
+    });
+
+    it('should pass dryRun argument through', () => {
+      stub = sinon.stub(messaging, 'sendAll').resolves(mockResponse);
+      const tokens = ['a', 'b', 'c'];
+      return messaging.sendMulticast({tokens}, true)
+        .then((response: BatchResponse) => {
+          expect(response).to.deep.equal(mockResponse);
+          expect(stub).to.have.been.calledOnce;
+          expect(stub.args[0][1]).to.be.true;
+        });
+    });
+
+    it('should be fulfilled with a BatchResponse given valid message', () => {
+      const messageIds = [
+        'projects/projec_id/messages/1',
+        'projects/projec_id/messages/2',
+        'projects/projec_id/messages/3',
+      ];
+      mockedRequests.push(mockBatchRequest(messageIds));
+      return messaging.sendMulticast({tokens: ['a', 'b', 'c']})
+        .then((response: BatchResponse) => {
+          expect(response.successCount).to.equal(3);
+          expect(response.failureCount).to.equal(0);
+          response.responses.forEach((resp, idx) => {
+            expect(resp.success).to.be.true;
+            expect(resp.messageId).to.equal(messageIds[idx]);
+            expect(resp.error).to.be.undefined;
+          });
+        });
+    });
+
+    it('should be fulfilled with a BatchResponse given valid message in dryRun mode', () => {
+      const messageIds = [
+        'projects/projec_id/messages/1',
+        'projects/projec_id/messages/2',
+        'projects/projec_id/messages/3',
+      ];
+      mockedRequests.push(mockBatchRequest(messageIds));
+      return messaging.sendMulticast({tokens: ['a', 'b', 'c']}, true)
+        .then((response: BatchResponse) => {
+          expect(response.successCount).to.equal(3);
+          expect(response.failureCount).to.equal(0);
+          expect(response.responses.length).to.equal(3);
+          response.responses.forEach((resp, idx) => {
+            checkSendResponseSuccess(resp, messageIds[idx]);
+          });
+        });
+    });
+
+    it('should be fulfilled with a BatchResponse when the response contains some errors', () => {
+      const messageIds = [
+        'projects/projec_id/messages/1',
+        'projects/projec_id/messages/2',
+      ];
+      const errors = [
+        {
+          error: {
+            status: 'INVALID_ARGUMENT',
+            message: 'test error message',
+          },
+        },
+      ];
+      mockedRequests.push(mockBatchRequestWithErrors(messageIds, errors));
+      return messaging.sendMulticast({tokens: ['a', 'b']})
+        .then((response: BatchResponse) => {
+          expect(response.successCount).to.equal(2);
+          expect(response.failureCount).to.equal(1);
+          expect(response.responses.length).to.equal(3);
+
+          const responses = response.responses;
+          checkSendResponseSuccess(responses[0], messageIds[0]);
+          checkSendResponseSuccess(responses[1], messageIds[1]);
+          checkSendResponseFailure(
+            responses[2], 'messaging/invalid-argument', 'test error message');
+        });
+    });
+
+    it('should expose the FCM error code via BatchResponse', () => {
+      const messageIds = [
+        'projects/projec_id/messages/1',
+      ];
+      const errors = [
+        {
+          error: {
+            status: 'INVALID_ARGUMENT',
+            message: 'test error message',
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                'errorCode': 'UNREGISTERED',
+              },
+            ],
+          },
+        },
+      ];
+      mockedRequests.push(mockBatchRequestWithErrors(messageIds, errors));
+      return messaging.sendMulticast({tokens: ['a', 'b']})
+        .then((response: BatchResponse) => {
+          expect(response.successCount).to.equal(1);
+          expect(response.failureCount).to.equal(1);
+          expect(response.responses.length).to.equal(2);
+
+          const responses = response.responses;
+          checkSendResponseSuccess(responses[0], messageIds[0]);
+          checkSendResponseFailure(
+            responses[1], 'messaging/registration-token-not-registered');
+        });
+    });
+
+    it('should fail when the backend server returns a detailed error', () => {
+      const resp = {
+        error: {
+          status: 'INVALID_ARGUMENT',
+          message: 'test error message',
+        },
+      };
+      mockedRequests.push(mockBatchError(400, 'json', resp));
+      return messaging.sendMulticast(
+        {tokens: ['a']},
+      ).should.eventually.be.rejectedWith('test error message')
+       .and.have.property('code', 'messaging/invalid-argument');
+    });
+
+    it('should fail when the backend server returns a detailed error with FCM error code', () => {
+      const resp = {
+        error: {
+          status: 'INVALID_ARGUMENT',
+          message: 'test error message',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+              'errorCode': 'UNREGISTERED',
+            },
+          ],
+        },
+      };
+      mockedRequests.push(mockBatchError(404, 'json', resp));
+      return messaging.sendMulticast(
+        {tokens: ['a']},
+      ).should.eventually.be.rejectedWith('test error message')
+       .and.have.property('code', 'messaging/registration-token-not-registered');
+    });
+
+    it('should map server error code to client-side error', () => {
+      const resp = {
+        error: {
+          status: 'NOT_FOUND',
+          message: 'test error message',
+        },
+      };
+      mockedRequests.push(mockBatchError(404, 'json', resp));
+      return messaging.sendMulticast(
+        {tokens: ['a']},
+      ).should.eventually.be.rejectedWith('test error message')
+       .and.have.property('code', 'messaging/registration-token-not-registered');
+    });
+
+    it('should fail when the backend server returns an unknown error', () => {
+      const resp = {error: 'test error message'};
+      mockedRequests.push(mockBatchError(400, 'json', resp));
+      return messaging.sendMulticast(
+        {tokens: ['a']},
+      ).should.eventually.be.rejected.and.have.property('code', 'messaging/unknown-error');
+    });
+
+    it('should fail when the backend server returns a non-json error', () => {
+      // Error code will be determined based on the status code.
+      mockedRequests.push(mockBatchError(400, 'text', 'foo bar'));
+      return messaging.sendMulticast(
+        {tokens: ['a']},
+      ).should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-argument');
+    });
+
+    it('should be rejected given an app which returns null access tokens', () => {
+      return nullAccessTokenMessaging.sendMulticast(
+        {tokens: ['a']},
       ).should.eventually.be.rejected.and.have.property('code', 'app/invalid-credential');
     });
 


### PR DESCRIPTION
This is a follow up to #453. The `sendMulticast()` API uses the `sendAll()` method to send a single message to a batch of 100 tokens.