### PR TITLE
Using the correct message copies in sendAll() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [fixed] Fixed a bug in the FCM batch APIs that prevented them from correctly
+  handling some message parameters like `AndroidConfig.ttl`.
 
 # v7.1.0
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -306,7 +306,7 @@ export class Messaging implements FirebaseServiceInterface {
         MessagingClientErrorCode.INVALID_ARGUMENT, 'dryRun must be a boolean');
     }
 
-    const requests: SubRequest[] = messages.map((message) => {
+    const requests: SubRequest[] = copy.map((message) => {
       validateMessage(message);
       const request: {message: Message, validate_only?: boolean} = {message};
       if (dryRun) {

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -873,16 +873,22 @@ describe('Messaging', () => {
         'projects/projec_id/messages/3',
       ];
       mockedRequests.push(mockBatchRequest(messageIds));
-      return messaging.sendMulticast({tokens: ['a', 'b', 'c']})
-        .then((response: BatchResponse) => {
-          expect(response.successCount).to.equal(3);
-          expect(response.failureCount).to.equal(0);
-          response.responses.forEach((resp, idx) => {
-            expect(resp.success).to.be.true;
-            expect(resp.messageId).to.equal(messageIds[idx]);
-            expect(resp.error).to.be.undefined;
-          });
+      return messaging.sendMulticast({
+        tokens: ['a', 'b', 'c'],
+        android: {ttl: 100},
+        apns: {payload: {aps: {badge: 42}}},
+        data: {key: 'value'},
+        notification: {title: 'test title'},
+        webpush: {data: {webKey: 'webValue'}},
+      }).then((response: BatchResponse) => {
+        expect(response.successCount).to.equal(3);
+        expect(response.failureCount).to.equal(0);
+        response.responses.forEach((resp, idx) => {
+          expect(resp.success).to.be.true;
+          expect(resp.messageId).to.equal(messageIds[idx]);
+          expect(resp.error).to.be.undefined;
         });
+      });
     });
 
     it('should be fulfilled with a BatchResponse given valid message in dryRun mode', () => {
@@ -892,15 +898,21 @@ describe('Messaging', () => {
         'projects/projec_id/messages/3',
       ];
       mockedRequests.push(mockBatchRequest(messageIds));
-      return messaging.sendMulticast({tokens: ['a', 'b', 'c']}, true)
-        .then((response: BatchResponse) => {
-          expect(response.successCount).to.equal(3);
-          expect(response.failureCount).to.equal(0);
-          expect(response.responses.length).to.equal(3);
-          response.responses.forEach((resp, idx) => {
-            checkSendResponseSuccess(resp, messageIds[idx]);
-          });
+      return messaging.sendMulticast({
+        tokens: ['a', 'b', 'c'],
+        android: {ttl: 100},
+        apns: {payload: {aps: {badge: 42}}},
+        data: {key: 'value'},
+        notification: {title: 'test title'},
+        webpush: {data: {webKey: 'webValue'}},
+      }, true).then((response: BatchResponse) => {
+        expect(response.successCount).to.equal(3);
+        expect(response.failureCount).to.equal(0);
+        expect(response.responses.length).to.equal(3);
+        response.responses.forEach((resp, idx) => {
+          checkSendResponseSuccess(resp, messageIds[idx]);
         });
+      });
     });
 
     it('should be fulfilled with a BatchResponse when the response contains some errors', () => {


### PR DESCRIPTION
Resolves #479