### PR TITLE
Adding common headers to all sub requests in FCM batch API

### DIFF
--- a/src/messaging/batch-request.ts
+++ b/src/messaging/batch-request.ts
@@ -59,6 +59,10 @@ export class BatchRequestClient {
    * @return {Promise<HttpResponse[]>} A promise that resolves when the send operation is complete.
    */
   public send(requests: SubRequest[]): Promise<HttpResponse[]> {
+    requests = requests.map((req) => {
+      req.headers = Object.assign({}, this.commonHeaders, req.headers);
+      return req;
+    });
     const requestHeaders = {
       'Content-Type': `multipart/mixed; boundary=${PART_BOUNDARY}`,
     };

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -29,6 +29,10 @@ const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {
   'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
 };
+const LEGACY_FIREBASE_MESSAGING_HEADERS = {
+  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'access_token_auth': 'true',
+};
 
 
 /**
@@ -61,7 +65,7 @@ export class FirebaseMessagingRequestHandler {
       method: FIREBASE_MESSAGING_HTTP_METHOD,
       url: `https://${host}${path}`,
       data: requestData,
-      headers: FIREBASE_MESSAGING_HEADERS,
+      headers: LEGACY_FIREBASE_MESSAGING_HEADERS,
       timeout: FIREBASE_MESSAGING_TIMEOUT,
     };
     return this.httpClient.send(request).then((response) => {

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -28,7 +28,6 @@ const FIREBASE_MESSAGING_BATCH_URL = 'https://fcm.googleapis.com/batch';
 const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {
   'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
-  'access_token_auth': 'true',
 };
 
 

--- a/test/unit/messaging/batch-requests.spec.ts
+++ b/test/unit/messaging/batch-requests.spec.ts
@@ -169,12 +169,13 @@ describe('BatchRequestClient', () => {
     }
   });
 
-  it('should add common headers to the batch requests', async () => {
+  it('should add common headers to the parent and sub requests in a batch', async () => {
     const stub = sinon.stub(httpClient, 'send').resolves(
       createMultipartResponse([responseObject]));
     stubs.push(stub);
     const requests: SubRequest[] = [
       {url: 'https://example.com', body: {foo: 1}},
+      {url: 'https://example.com', body: {foo: 2}},
     ];
     const commonHeaders = {'X-Custom-Header': 'value'};
     const batch = new BatchRequestClient(httpClient, batchUrl, commonHeaders);
@@ -185,9 +186,39 @@ describe('BatchRequestClient', () => {
     expect(stub).to.have.been.calledOnce;
     const args: HttpRequestConfig = stub.getCall(0).args[0];
     expect(args.headers).to.have.property('X-Custom-Header', 'value');
+
+    const parsedRequest = parseHttpRequest(args.data as Buffer);
+    expect(parsedRequest.multipart.length).to.equal(requests.length);
+    parsedRequest.multipart.forEach((sub: {body: Buffer}) => {
+      const parsedSubRequest: {headers: object} = parseHttpRequest(sub.body.toString().trim());
+      expect(parsedSubRequest.headers).to.have.property('X-Custom-Header', 'value');
+    });
   });
 
   it('should add sub request headers to the payload', async () => {
+    const stub = sinon.stub(httpClient, 'send').resolves(
+      createMultipartResponse([responseObject]));
+    stubs.push(stub);
+    const requests: SubRequest[] = [
+      {url: 'https://example.com', body: {foo: 1}, headers: {'X-Custom-Header': 'value'}},
+      {url: 'https://example.com', body: {foo: 1}, headers: {'X-Custom-Header': 'value'}},
+    ];
+    const batch = new BatchRequestClient(httpClient, batchUrl);
+
+    const responses: HttpResponse[] = await batch.send(requests);
+
+    expect(responses.length).to.equal(1);
+    expect(stub).to.have.been.calledOnce;
+    const args: HttpRequestConfig = stub.getCall(0).args[0];
+    const parsedRequest = parseHttpRequest(args.data as Buffer);
+    expect(parsedRequest.multipart.length).to.equal(requests.length);
+    parsedRequest.multipart.forEach((part: {body: Buffer}) => {
+      const parsedPart: {headers: object} = parseHttpRequest(part.body.toString().trim());
+      expect(parsedPart.headers).to.have.property('X-Custom-Header', 'value');
+    });
+  });
+
+  it('sub request headers should get precedence', async () => {
     const stub = sinon.stub(httpClient, 'send').resolves(
       createMultipartResponse([responseObject]));
     stubs.push(stub);

--- a/test/unit/messaging/batch-requests.spec.ts
+++ b/test/unit/messaging/batch-requests.spec.ts
@@ -212,9 +212,9 @@ describe('BatchRequestClient', () => {
     const args: HttpRequestConfig = stub.getCall(0).args[0];
     const parsedRequest = parseHttpRequest(args.data as Buffer);
     expect(parsedRequest.multipart.length).to.equal(requests.length);
-    parsedRequest.multipart.forEach((part: {body: Buffer}) => {
-      const parsedPart: {headers: object} = parseHttpRequest(part.body.toString().trim());
-      expect(parsedPart.headers).to.have.property('X-Custom-Header', 'value');
+    parsedRequest.multipart.forEach((sub: {body: Buffer}) => {
+      const parsedSubRequest: {headers: object} = parseHttpRequest(sub.body.toString().trim());
+      expect(parsedSubRequest.headers).to.have.property('X-Custom-Header', 'value');
     });
   });
 

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -315,6 +315,7 @@ describe('Messaging', () => {
   const expectedHeaders = {
     'Authorization': 'Bearer ' + mockAccessToken,
     'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'access_token_auth': 'true',
   };
   const emptyResponse = utils.responseFrom({});
 

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -315,7 +315,6 @@ describe('Messaging', () => {
   const expectedHeaders = {
     'Authorization': 'Bearer ' + mockAccessToken,
     'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
-    'access_token_auth': 'true',
   };
   const emptyResponse = utils.responseFrom({});
 


### PR DESCRIPTION
* Adding `commonHeaders` to all sub requests in a batch. This includes the `X-Firebase-Client` header.
* Removing `access_token_auth` header from batch requests (this is only needed for the legacy API calls).