### PR TITLE
ThenableReference should extend Promise, not PromiseLike

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -443,7 +443,7 @@ declare namespace admin.database {
     update(values: Object, onComplete?: (a: Error|null) => any): Promise<void>;
   }
 
-  interface ThenableReference extends admin.database.Reference, PromiseLike<any> {}
+  interface ThenableReference extends admin.database.Reference, Promise<admin.database.Reference> {}
 
   function enableLogging(logger?: boolean|((message: string) => any), persistent?: boolean): any;
 }


### PR DESCRIPTION
ThenableReference implements a `.catch()` method, but `ref.push(...).catch(...)` generates a TypeScript error, since neither the `Reference` nor `PromiseLike` interfaces have that method.

This change was [already done on the JS SDK](https://github.com/firebase/firebase-js-sdk/pull/1462) back in January, and this PR simply puts the admin SDK back in line with it.

PS: This fixes issue #144, which was already closed.