### PR TITLE
WIP: Implement Rules API

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -796,6 +796,45 @@ declare namespace admin.projectManagement {
     getConfig(): Promise<string>;
   }
 
+  type RulesService = 'firestore' | 'storage' | 'database';
+
+  interface Ruleset {
+    name: string;
+    createTime: string;
+  }
+
+  interface RulesetWithFiles extends Ruleset {
+    files: RulesetFile[];
+  }
+
+  interface RulesetFile {
+    name: string;
+    content: string;
+  }
+
+  interface ListRulesReleasesFilter {
+    releaseName?: string;
+    rulesetName?: string;
+    testSuiteName?: string;
+  }
+
+  interface ListRulesReleasesResult {
+    releases: RulesRelease[];
+    pageToken?: string;
+  }
+
+  interface RulesRelease {
+    name: string;
+    rulesetName: string;
+    createTime: string;
+    updateTime: string;
+  }
+
+  interface ListRulesetsResult {
+    rulesets: Ruleset[];
+    pageToken?: string;
+  }
+
   interface ProjectManagement {
     app: admin.app.App;
 
@@ -807,8 +846,39 @@ declare namespace admin.projectManagement {
     createAndroidApp(
         packageName: string, displayName?: string): Promise<admin.projectManagement.AndroidApp>;
     createIosApp(bundleId: string, displayName?: string): Promise<admin.projectManagement.IosApp>;
-    getDatabaseRules(): Promise<string>;
-    setDatabaseRules(rules: string): Promise<void>;
+    getRules(service: admin.projectManagement.RulesService): Promise<string>;
+    setRules(
+      service: admin.projectManagement.RulesService,
+      content: string,
+    ): Promise<void>;
+    setRulesFromFile(
+      service: admin.projectManagement.RulesService,
+      filePath: string,
+    ): Promise<void>;
+    listRulesReleases(
+      filter?: admin.projectManagement.ListRulesReleasesFilter,
+      maxResults?: number,
+      pageToken?: string,
+    ): Promise<admin.projectManagement.ListRulesReleasesResult>;
+    getRulesRelease(name: string): Promise<admin.projectManagement.RulesRelease>;
+    createRulesRelease(
+      name: string,
+      rulesetName: string,
+    ): Promise<admin.projectManagement.RulesRelease>;
+    updateRulesRelease(
+      name: string,
+      rulesetName: string,
+    ): Promise<admin.projectManagement.RulesRelease>;
+    deleteRulesRelease(name: string): Promise<void>;
+    listRulesets(
+      maxResults?: number,
+      pageToken?: string,
+    ): Promise<admin.projectManagement.ListRulesetsResult>;
+    getRuleset(name: string): Promise<admin.projectManagement.RulesetWithFiles>;
+    createRuleset(
+      files: RulesetFile[],
+    ): Promise<admin.projectManagement.RulesetWithFiles>;
+    deleteRuleset(name: string): Promise<void>;
   }
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -857,7 +857,7 @@ declare namespace admin.projectManagement {
     ): Promise<void>;
     listRulesReleases(
       filter?: admin.projectManagement.ListRulesReleasesFilter,
-      maxResults?: number,
+      pageSize?: number,
       pageToken?: string,
     ): Promise<admin.projectManagement.ListRulesReleasesResult>;
     getRulesRelease(name: string): Promise<admin.projectManagement.RulesRelease>;
@@ -871,7 +871,7 @@ declare namespace admin.projectManagement {
     ): Promise<admin.projectManagement.RulesRelease>;
     deleteRulesRelease(name: string): Promise<void>;
     listRulesets(
-      maxResults?: number,
+      pageSize?: number,
       pageToken?: string,
     ): Promise<admin.projectManagement.ListRulesetsResult>;
     getRuleset(rulesetId: string): Promise<admin.projectManagement.RulesetWithFiles>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -807,6 +807,8 @@ declare namespace admin.projectManagement {
     createAndroidApp(
         packageName: string, displayName?: string): Promise<admin.projectManagement.AndroidApp>;
     createIosApp(bundleId: string, displayName?: string): Promise<admin.projectManagement.IosApp>;
+    getDatabaseRules(): Promise<string>;
+    setDatabaseRules(rules: string): Promise<void>;
   }
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -825,9 +825,9 @@ declare namespace admin.projectManagement {
 
   interface RulesRelease {
     name: string;
-    rulesetName: string;
+    rulesetId: string;
     createTime: string;
-    updateTime?: string;
+    updateTime: string;
   }
 
   interface ListRulesetsResult {
@@ -863,11 +863,11 @@ declare namespace admin.projectManagement {
     getRulesRelease(name: string): Promise<admin.projectManagement.RulesRelease>;
     createRulesRelease(
       name: string,
-      rulesetName: string,
+      rulesetId: string,
     ): Promise<admin.projectManagement.RulesRelease>;
     updateRulesRelease(
       name: string,
-      rulesetName: string,
+      rulesetId: string,
     ): Promise<admin.projectManagement.RulesRelease>;
     deleteRulesRelease(name: string): Promise<void>;
     listRulesets(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -827,7 +827,7 @@ declare namespace admin.projectManagement {
     name: string;
     rulesetName: string;
     createTime: string;
-    updateTime: string;
+    updateTime?: string;
   }
 
   interface ListRulesetsResult {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -799,7 +799,7 @@ declare namespace admin.projectManagement {
   type RulesService = 'firestore' | 'storage' | 'database';
 
   interface Ruleset {
-    name: string;
+    id: string;
     createTime: string;
   }
 
@@ -874,11 +874,11 @@ declare namespace admin.projectManagement {
       maxResults?: number,
       pageToken?: string,
     ): Promise<admin.projectManagement.ListRulesetsResult>;
-    getRuleset(name: string): Promise<admin.projectManagement.RulesetWithFiles>;
+    getRuleset(rulesetId: string): Promise<admin.projectManagement.RulesetWithFiles>;
     createRuleset(
       files: RulesetFile[],
     ): Promise<admin.projectManagement.RulesetWithFiles>;
-    deleteRuleset(name: string): Promise<void>;
+    deleteRuleset(rulesetId: string): Promise<void>;
   }
 }
 

--- a/src/project-management/android-app.ts
+++ b/src/project-management/android-app.ts
@@ -16,7 +16,8 @@
 
 import { FirebaseProjectManagementError } from '../utils/error';
 import * as validator from '../utils/validator';
-import { ProjectManagementRequestHandler, assertServerResponse } from './project-management-api-request';
+import { ProjectManagementRequestHandler } from './project-management-api-request';
+import { assertServerResponse } from './request-handler-base';
 
 export class AndroidApp {
   private readonly resourceName: string;

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -17,7 +17,11 @@
 import { FirebaseApp } from '../firebase-app';
 import { FirebaseProjectManagementError } from '../utils/error';
 import * as validator from '../utils/validator';
-import { RequestHandlerBase } from './request-handler-base';
+import {
+  RequestHandlerBase,
+  InvokeRequestHandlerOptions,
+} from './request-handler-base';
+import { HttpMethod } from '../utils/api-request';
 
 /** Database REST API security rules path. */
 const DATABASE_RULES_PATH = '/.settings/rules.json';
@@ -93,6 +97,21 @@ export class DatabaseRequestHandler extends RequestHandlerBase {
       rules,
       { isJSONData: false },
     ).then(() => undefined);
+  }
+
+  protected invokeRequestHandler<T = object>(
+    method: HttpMethod,
+    path: string,
+    requestData: object | string | null = null,
+    options?: InvokeRequestHandlerOptions,
+  ): Promise<T> {
+    return super.invokeRequestHandler(
+      method,
+      path,
+      requestData,
+      options,
+      DatabaseRequestHandler.wrapAndRethrowHttpError,
+    );
   }
 
   private assertDatabaseURL() {

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -38,8 +38,8 @@ export class DatabaseRequestHandler extends RequestHandlerBase {
     errText: string,
   ) {
     if (errStatusCode === 423) {
-      const errorCode = 'service-unavailable';
-      const errorMessage = 'The database has been locked.';
+      const errorCode = 'failed-precondition';
+      const errorMessage = 'The database has been manually locked by an owner.';
       throw new FirebaseProjectManagementError(
         errorCode,
         `${errorMessage} Status code: ${errStatusCode}. Raw server response: "${errText}".`,

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -62,6 +62,15 @@ export class DatabaseRequestHandler extends RequestHandlerBase {
     this.assertDatabaseURL();
     return this.invokeRequestHandler<string>('GET', DATABASE_RULES_PATH, null, {
       isJSONData: false,
+    }).then((response) => {
+      if (!validator.isNonEmptyString(response)) {
+        throw new FirebaseProjectManagementError(
+          'invalid-server-response',
+          "getDatabaseRules()'s response must be a non-empty string.",
+        );
+      }
+
+      return response;
     });
   }
 

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -29,7 +29,7 @@ const DATABASE_RULES_PATH = '/.settings/rules.json';
 const DATABASE_URL_OPTION = 'databaseURL';
 
 /**
- * Class that provides a mechanism to send requests to the Firebase Rules backend
+ * Class that provides a mechanism to send requests to the RTDB rules backend
  * endpoints.
  *
  * @private

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from '../firebase-app';
+import {
+  AuthorizedHttpClient,
+  HttpError,
+  HttpMethod,
+  HttpRequestConfig,
+} from '../utils/api-request';
+import {
+  FirebaseProjectManagementError,
+  ProjectManagementErrorCode,
+} from '../utils/error';
+import * as validator from '../utils/validator';
+
+/** Database REST API security rules path. */
+const DATABASE_RULES_PATH = '/.settings/rules.json';
+/** Database REST API request header. */
+const DATABASE_REST_HEADERS = {
+  'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+};
+/** Database REST API request timeout duration in milliseconds. */
+const DATABASE_REST_TIMEOUT_MILLIS = 10000;
+/** Database URL field in the Firebase App options */
+const DATABASE_URL_OPTION = 'databaseURL';
+
+/**
+ * Class that provides mechanism to send requests to the Firebase project management backend
+ * endpoints.
+ *
+ * @private
+ */
+export class DatabaseRequestHandler {
+  private readonly baseUrl: string;
+  private readonly httpClient: AuthorizedHttpClient;
+
+  private static wrapAndRethrowHttpError(
+    errStatusCode: number,
+    errText: string,
+  ) {
+    let errorCode: ProjectManagementErrorCode;
+    let errorMessage: string;
+
+    switch (errStatusCode) {
+      case 400:
+        errorCode = 'invalid-argument';
+        errorMessage = 'Invalid argument provided.';
+        break;
+      case 401:
+      case 403:
+        errorCode = 'authentication-error';
+        errorMessage =
+          'An error occurred when trying to authenticate. Make sure the credential ' +
+          'used to authenticate this SDK has the proper permissions. See ' +
+          'https://firebase.google.com/docs/admin/setup for setup instructions.';
+        break;
+      case 423:
+        errorCode = 'service-unavailable';
+        errorMessage = 'The database has been locked.';
+        break;
+      case 500:
+        errorCode = 'internal-error';
+        errorMessage =
+          'An internal error has occurred. Please retry the request.';
+        break;
+      case 503:
+        errorCode = 'service-unavailable';
+        errorMessage =
+          'The server could not process the request in time. See the error ' +
+          'documentation for more details.';
+        break;
+      default:
+        errorCode = 'unknown-error';
+        errorMessage = 'An unknown server error was returned.';
+    }
+
+    throw new FirebaseProjectManagementError(
+      errorCode,
+      `${errorMessage} Status code: ${errStatusCode}. Raw server response: "${errText}".`,
+    );
+  }
+
+  /**
+   * @param {FirebaseApp} app The app used to fetch access tokens to sign API requests.
+   * @constructor
+   */
+  constructor(app: FirebaseApp) {
+    this.httpClient = new AuthorizedHttpClient(app);
+    this.baseUrl = app.options[DATABASE_URL_OPTION];
+  }
+
+  public getDatabaseRules(): Promise<string> {
+    this.assertDatabaseURL();
+    return this.invokeRequestHandler('GET', DATABASE_RULES_PATH);
+  }
+
+  /**
+   * @param {string} rules The Database Security Rules to deploy.
+   */
+  public setDatabaseRules(rules: string): Promise<void> {
+    this.assertDatabaseURL();
+
+    if (!validator.isNonEmptyString(rules)) {
+      throw new FirebaseProjectManagementError(
+        'invalid-argument',
+        'Database rules must be a non-empty string.',
+      );
+    }
+
+    return this.invokeRequestHandler('PUT', DATABASE_RULES_PATH, rules).then(
+      () => undefined,
+    );
+  }
+
+  private assertDatabaseURL() {
+    if (!validator.isNonEmptyString(this.baseUrl)) {
+      throw new FirebaseProjectManagementError(
+        'invalid-argument',
+        "Can't determine Firebase Database URL.",
+      );
+    }
+  }
+
+  /**
+   * Invokes the request handler with the provided request data.
+   */
+  private invokeRequestHandler(
+    method: HttpMethod,
+    path: string,
+    requestData?: string | object,
+  ): Promise<string> {
+    const request: HttpRequestConfig = {
+      method,
+      url: `${this.baseUrl}${path}`,
+      headers: DATABASE_REST_HEADERS,
+      data: requestData,
+      timeout: DATABASE_REST_TIMEOUT_MILLIS,
+    };
+
+    return this.httpClient
+      .send(request)
+      .then((response) => {
+        // Send error responses to the catch() below.
+        if (response.status >= 400) {
+          throw new HttpError(response);
+        }
+        return response.text;
+      })
+      .catch((err) => {
+        if (err instanceof HttpError) {
+          DatabaseRequestHandler.wrapAndRethrowHttpError(
+            err.response.status,
+            err.response.text,
+          );
+        }
+        throw err;
+      });
+  }
+}

--- a/src/project-management/database-api-request.ts
+++ b/src/project-management/database-api-request.ts
@@ -70,7 +70,7 @@ export class DatabaseRequestHandler extends RequestHandlerBase {
       if (!validator.isNonEmptyString(response)) {
         throw new FirebaseProjectManagementError(
           'invalid-server-response',
-          "getDatabaseRules()'s response must be a non-empty string.",
+          "getRules()'s response must be a non-empty string.",
         );
       }
 

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -30,7 +30,7 @@ const FIREBASE_RULES_HOST_AND_PORT = 'firebaserules.googleapis.com:443';
 /** Project management backend path. */
 const FIREBASE_RULES_PATH = '/v1/';
 
-function assertResponseIsRulesetWithFiles(
+function assertValidIsRulesetWithFilesResponse(
   responseData: any,
   method: string,
 ): void {
@@ -56,6 +56,29 @@ function assertResponseIsRulesetWithFiles(
     validator.isArray(responseData.source.files),
     responseData,
     `"source.files" field must be an array in ${method}()'s response data.`,
+  );
+}
+
+function assertValidRulesReleaseResponse(
+  responseData: RulesReleaseResponse,
+  method: string,
+): void {
+  assertServerResponse(
+    validator.isNonNullObject(responseData),
+    responseData,
+    `${method}()'s responseData must be a non-null object.`,
+  );
+
+  assertServerResponse(
+    validator.isNonEmptyString(responseData.name),
+    responseData,
+    `"name" field must be a non-empty string in ${method}()'s response data.`,
+  );
+
+  assertServerResponse(
+    validator.isNonEmptyString(responseData.rulesetName),
+    responseData,
+    `"rulesetName" field must be a non-empty string in ${method}()'s response data.`,
   );
 }
 
@@ -148,24 +171,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       'GET',
       `${this.resourceName}/releases/${name}`,
     ).then((responseData) => {
-      assertServerResponse(
-        validator.isNonNullObject(responseData),
-        responseData,
-        "getRulesRelease()'s responseData must be a non-null object.",
-      );
-
-      assertServerResponse(
-        validator.isNonEmptyString(responseData.name),
-        responseData,
-        `"name" field must be a non-empty string in getRulesRelease()'s response data.`,
-      );
-
-      assertServerResponse(
-        validator.isNonEmptyString(responseData.rulesetName),
-        responseData,
-        `"rulesetName" field must be a non-empty string in getRulesRelease()'s response data.`,
-      );
-
+      assertValidRulesReleaseResponse(responseData, 'getRulesRelease');
       return responseData;
     });
   }
@@ -185,24 +191,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
           : `${this.resourceName}/rulesets/${rulesetId}`,
       },
     ).then((responseData) => {
-      assertServerResponse(
-        validator.isNonNullObject(responseData),
-        responseData,
-        "createRulesRelease()'s responseData must be a non-null object.",
-      );
-
-      assertServerResponse(
-        validator.isNonEmptyString(responseData.name),
-        responseData,
-        `"name" field must be a non-empty string in createRulesRelease()'s response data.`,
-      );
-
-      assertServerResponse(
-        validator.isNonEmptyString(responseData.rulesetName),
-        responseData,
-        `"rulesetName" field must be a non-empty string in createRulesRelease()'s response data.`,
-      );
-
+      assertValidRulesReleaseResponse(responseData, 'createRulesRelease');
       return responseData;
     });
   }
@@ -224,18 +213,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         },
       },
     ).then((responseData) => {
-      assertServerResponse(
-        validator.isNonNullObject(responseData),
-        responseData,
-        "updateRulesRelease()'s responseData must be a non-null object.",
-      );
-
-      assertServerResponse(
-        validator.isNonEmptyString(responseData.name),
-        responseData,
-        `"name" field must be a non-empty string in updateRulesRelease()'s response data.`,
-      );
-
+      assertValidRulesReleaseResponse(responseData, 'updateRulesRelease');
       return responseData;
     });
   }
@@ -284,8 +262,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       'GET',
       isFullName ? rulesetId : `${this.resourceName}/rulesets/${rulesetId}`,
     ).then((responseData) => {
-      assertResponseIsRulesetWithFiles(responseData, 'getRuleset');
-
+      assertValidIsRulesetWithFilesResponse(responseData, 'getRuleset');
       return responseData;
     });
   }
@@ -300,7 +277,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         source: { files },
       },
     ).then((responseData) => {
-      assertResponseIsRulesetWithFiles(responseData, 'createRuleset');
+      assertValidIsRulesetWithFilesResponse(responseData, 'createRuleset');
       return responseData;
     });
   }

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -49,13 +49,13 @@ function assertResponseIsRulesetWithFiles(
   assertServerResponse(
     validator.isNonNullObject(responseData.source),
     responseData,
-    `"responseData.source" field  must be a non-null object in ${method}()'s response data.`,
+    `"responseData.source" field must be a non-null object in ${method}()'s response data.`,
   );
 
   assertServerResponse(
     validator.isArray(responseData.source.files),
     responseData,
-    `"responseData.source.files" field  must be an array in ${method}()'s response data.`,
+    `"responseData.source.files" field must be an array in ${method}()'s response data.`,
   );
 }
 
@@ -215,13 +215,13 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isNonNullObject(responseData),
         responseData,
-        "createRulesRelease()'s responseData must be a non-null object.",
+        "updateRulesRelease()'s responseData must be a non-null object.",
       );
 
       assertServerResponse(
         validator.isNonEmptyString(responseData.name),
         responseData,
-        `"responseData.name" field must be a non-empty string in createRulesRelease()'s response data.`,
+        `"responseData.name" field must be a non-empty string in updateRulesRelease()'s response data.`,
       );
 
       return responseData;

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -160,6 +160,12 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         `"name" field must be a non-empty string in getRulesRelease()'s response data.`,
       );
 
+      assertServerResponse(
+        validator.isNonEmptyString(responseData.rulesetName),
+        responseData,
+        `"rulesetName" field must be a non-empty string in getRulesRelease()'s response data.`,
+      );
+
       return responseData;
     });
   }
@@ -189,6 +195,12 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         validator.isNonEmptyString(responseData.name),
         responseData,
         `"name" field must be a non-empty string in createRulesRelease()'s response data.`,
+      );
+
+      assertServerResponse(
+        validator.isNonEmptyString(responseData.rulesetName),
+        responseData,
+        `"rulesetName" field must be a non-empty string in createRulesRelease()'s response data.`,
       );
 
       return responseData;

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -95,7 +95,6 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
     errStatusCode: number,
     errText: string,
   ) {
-    console.log(errStatusCode, errText);
     if (errStatusCode === 429) {
       const errorCode = 'resource-exhausted';
       const errorMessage = 'Quota exceeded for the requested resource.';

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -1,0 +1,213 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from '../firebase-app';
+import * as validator from '../utils/validator';
+import { RequestHandlerBase } from './request-handler-base';
+
+/** Project management backend host and port. */
+const FIREBASE_RULES_HOST_AND_PORT = 'firebaserules.googleapis.com:443';
+/** Project management backend path. */
+const FIREBASE_RULES_PATH = '/v1/';
+
+/**
+ * Class that provides a mechanism to send requests to the Firebase Rules backend
+ * endpoints.
+ *
+ * @private
+ */
+export class FirebaseRulesRequestHandler extends RequestHandlerBase {
+  protected readonly baseUrl: string = `https://${FIREBASE_RULES_HOST_AND_PORT}${FIREBASE_RULES_PATH}`;
+
+  /**
+   * @param {FirebaseApp} app The app used to fetch access tokens to sign API requests.
+   * @constructor
+   */
+  constructor(app: FirebaseApp) {
+    super(app);
+  }
+
+  // **************************************************** //
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the project whose Android
+   *     apps you want to list.
+   */
+  public listAndroidApps(parentResourceName: string): Promise<object> {
+    return this.invokeRequestHandler(
+      'GET',
+      `${parentResourceName}/androidApps?page_size=${LIST_APPS_MAX_PAGE_SIZE}`,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    );
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the project whose iOS apps
+   *     you want to list.
+   */
+  public listIosApps(parentResourceName: string): Promise<object> {
+    return this.invokeRequestHandler(
+      'GET',
+      `${parentResourceName}/iosApps?page_size=${LIST_APPS_MAX_PAGE_SIZE}`,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    );
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the project that you want
+   *     to create the Android app within.
+   */
+  public createAndroidApp(
+    parentResourceName: string,
+    packageName: string,
+    displayName?: string,
+  ): Promise<object> {
+    const requestData: any = {
+      packageName,
+    };
+    if (validator.isNonEmptyString(displayName)) {
+      requestData.displayName = displayName;
+    }
+    return this.invokeRequestHandler(
+      'POST',
+      `${parentResourceName}/androidApps`,
+      requestData,
+      { useBetaUrl: true },
+    ).then((responseData: any) => {
+      RequestHandlerBase.assertServerResponse(
+        validator.isNonNullObject(responseData),
+        responseData,
+        `createAndroidApp's responseData must be a non-null object.`,
+      );
+      RequestHandlerBase.assertServerResponse(
+        validator.isNonEmptyString(responseData.name),
+        responseData,
+        `createAndroidApp's responseData.name must be a non-empty string.`,
+      );
+      return this.pollRemoteOperationWithExponentialBackoff(responseData.name);
+    });
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the project that you want
+   *     to create the iOS app within.
+   */
+  public createIosApp(
+    parentResourceName: string,
+    bundleId: string,
+    displayName?: string,
+  ): Promise<object> {
+    const requestData: any = {
+      bundleId,
+    };
+    if (validator.isNonEmptyString(displayName)) {
+      requestData.displayName = displayName;
+    }
+    return this.invokeRequestHandler(
+      'POST',
+      `${parentResourceName}/iosApps`,
+      requestData,
+      { useBetaUrl: true },
+    ).then((responseData: any) => {
+      RequestHandlerBase.assertServerResponse(
+        validator.isNonNullObject(responseData),
+        responseData,
+        `createIosApp's responseData must be a non-null object.`,
+      );
+      RequestHandlerBase.assertServerResponse(
+        validator.isNonEmptyString(responseData.name),
+        responseData,
+        `createIosApp's responseData.name must be a non-empty string.`,
+      );
+      return this.pollRemoteOperationWithExponentialBackoff(responseData.name);
+    });
+  }
+
+  /**
+   * @param {string} resourceName Fully-qualified resource name of the entity whose display name you
+   *     want to set.
+   */
+  public setDisplayName(
+    resourceName: string,
+    newDisplayName: string,
+  ): Promise<void> {
+    const requestData = {
+      displayName: newDisplayName,
+    };
+    return this.invokeRequestHandler(
+      'PATCH',
+      `${resourceName}?update_mask=display_name`,
+      requestData,
+      { useBetaUrl: true },
+    ).then(() => null);
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the Android app whose SHA
+   *     certificates you want to get.
+   */
+  public getAndroidShaCertificates(
+    parentResourceName: string,
+  ): Promise<object> {
+    return this.invokeRequestHandler(
+      'GET',
+      `${parentResourceName}/sha`,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    );
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the app whose config you
+   *     want to get.
+   */
+  public getConfig(parentResourceName: string): Promise<object> {
+    return this.invokeRequestHandler(
+      'GET',
+      `${parentResourceName}/config`,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    );
+  }
+
+  /**
+   * @param {string} parentResourceName Fully-qualified resource name of the entity that you want to
+   *     get.
+   */
+  public getResource(parentResourceName: string): Promise<object> {
+    return this.invokeRequestHandler(
+      'GET',
+      parentResourceName,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    );
+  }
+
+  /**
+   * @param {string} resourceName Fully-qualified resource name of the entity that you want to
+   *     delete.
+   */
+  public deleteResource(resourceName: string): Promise<void> {
+    return this.invokeRequestHandler(
+      'DELETE',
+      resourceName,
+      /* requestData */ null,
+      { useBetaUrl: true },
+    ).then(() => null);
+  }
+}

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -43,19 +43,19 @@ function assertResponseIsRulesetWithFiles(
   assertServerResponse(
     validator.isNonEmptyString(responseData.name),
     responseData,
-    `"responseData.name" field must be a non-empty string in ${method}()'s response data.`,
+    `"name" field must be a non-empty string in ${method}()'s response data.`,
   );
 
   assertServerResponse(
     validator.isNonNullObject(responseData.source),
     responseData,
-    `"responseData.source" field must be a non-null object in ${method}()'s response data.`,
+    `"source" field must be a non-null object in ${method}()'s response data.`,
   );
 
   assertServerResponse(
     validator.isArray(responseData.source.files),
     responseData,
-    `"responseData.source.files" field must be an array in ${method}()'s response data.`,
+    `"source.files" field must be an array in ${method}()'s response data.`,
   );
 }
 
@@ -136,7 +136,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isArray(responseData.releases),
         responseData,
-        `"responseData.releases" field must be an array in listRulesReleases()'s response data.`,
+        `"releases" field must be an array in listRulesReleases()'s response data.`,
       );
 
       return responseData;
@@ -157,7 +157,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isNonEmptyString(responseData.name),
         responseData,
-        `"responseData.name" field must be a non-empty string in getRulesRelease()'s response data.`,
+        `"name" field must be a non-empty string in getRulesRelease()'s response data.`,
       );
 
       return responseData;
@@ -188,7 +188,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isNonEmptyString(responseData.name),
         responseData,
-        `"responseData.name" field must be a non-empty string in createRulesRelease()'s response data.`,
+        `"name" field must be a non-empty string in createRulesRelease()'s response data.`,
       );
 
       return responseData;
@@ -221,7 +221,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isNonEmptyString(responseData.name),
         responseData,
-        `"responseData.name" field must be a non-empty string in updateRulesRelease()'s response data.`,
+        `"name" field must be a non-empty string in updateRulesRelease()'s response data.`,
       );
 
       return responseData;
@@ -257,7 +257,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       assertServerResponse(
         validator.isArray(responseData.rulesets),
         responseData,
-        `"responseData.rulesets" field must be an array in listRulesets()'s response data.`,
+        `"rulesets" field must be an array in listRulesets()'s response data.`,
       );
 
       return responseData;

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -228,11 +228,11 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
     });
   }
 
-  public deleteRulesRelease(name: string): Promise<void> {
+  public deleteRulesRelease(name: string): Promise<any> {
     return this.invokeRequestHandler(
       'DELETE',
       `${this.resourceName}/releases/${name}`,
-    ).then(() => undefined);
+    );
   }
 
   public listRulesets(
@@ -296,11 +296,11 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
   public deleteRuleset(
     rulesetId: string,
     { isFullName = false }: { isFullName?: boolean } = {},
-  ): Promise<void> {
+  ): Promise<any> {
     return this.invokeRequestHandler(
       'DELETE',
       isFullName ? rulesetId : `${this.resourceName}/rulesets/${rulesetId}`,
-    ).then(() => undefined);
+    );
   }
 
   protected invokeRequestHandler<T = object>(

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -30,7 +30,7 @@ const FIREBASE_RULES_HOST_AND_PORT = 'firebaserules.googleapis.com:443';
 /** Project management backend path. */
 const FIREBASE_RULES_PATH = '/v1/';
 
-function assertValidIsRulesetWithFilesResponse(
+function assertValidRulesetWithFilesResponse(
   responseData: any,
   method: string,
 ): void {
@@ -291,7 +291,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       'GET',
       isFullName ? rulesetId : `${this.resourceName}/rulesets/${rulesetId}`,
     ).then((responseData) => {
-      assertValidIsRulesetWithFilesResponse(responseData, 'getRuleset');
+      assertValidRulesetWithFilesResponse(responseData, 'getRuleset');
       return responseData;
     });
   }
@@ -306,7 +306,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         source: { files },
       },
     ).then((responseData) => {
-      assertValidIsRulesetWithFilesResponse(responseData, 'createRuleset');
+      assertValidRulesetWithFilesResponse(responseData, 'createRuleset');
       return responseData;
     });
   }

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -19,9 +19,11 @@ import * as validator from '../utils/validator';
 import {
   RequestHandlerBase,
   assertServerResponse,
+  InvokeRequestHandlerOptions,
 } from './request-handler-base';
 import { RulesRelease, RulesetFile } from './rules';
 import { FirebaseProjectManagementError } from '../utils/error';
+import { HttpMethod } from '../utils/api-request';
 
 /** Project management backend host and port. */
 const FIREBASE_RULES_HOST_AND_PORT = 'firebaserules.googleapis.com:443';
@@ -93,6 +95,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
     errStatusCode: number,
     errText: string,
   ) {
+    console.log(errStatusCode, errText);
     if (errStatusCode === 429) {
       const errorCode = 'resource-exhausted';
       const errorMessage = 'Quota exceeded for the requested resource.';
@@ -299,5 +302,20 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       'DELETE',
       isFullName ? rulesetId : `${this.resourceName}/rulesets/${rulesetId}`,
     ).then(() => undefined);
+  }
+
+  protected invokeRequestHandler<T = object>(
+    method: HttpMethod,
+    path: string,
+    requestData: object | string | null = null,
+    options?: InvokeRequestHandlerOptions,
+  ): Promise<T> {
+    return super.invokeRequestHandler(
+      method,
+      path,
+      requestData,
+      options,
+      FirebaseRulesRequestHandler.wrapAndRethrowHttpError,
+    );
   }
 }

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -30,6 +30,7 @@ import {
   RulesetWithFiles,
   RulesetFile,
 } from './rules';
+import { FirebaseProjectManagementError } from '../utils/error';
 
 /** Project management backend host and port. */
 const FIREBASE_RULES_HOST_AND_PORT = 'firebaserules.googleapis.com:443';
@@ -73,6 +74,22 @@ function assertResponseIsRulesetWithFiles(
  */
 export class FirebaseRulesRequestHandler extends RequestHandlerBase {
   protected readonly baseUrl: string = `https://${FIREBASE_RULES_HOST_AND_PORT}${FIREBASE_RULES_PATH}`;
+
+  protected static wrapAndRethrowHttpError(
+    errStatusCode: number,
+    errText: string,
+  ) {
+    if (errStatusCode === 429) {
+      const errorCode = 'resource-exhausted';
+      const errorMessage = 'Quota exceeded for the requested resource.';
+      throw new FirebaseProjectManagementError(
+        errorCode,
+        `${errorMessage} Status code: ${errStatusCode}. Raw server response: "${errText}".`,
+      );
+    } else {
+      return super.wrapAndRethrowHttpError(errStatusCode, errText);
+    }
+  }
 
   /**
    * @param app The app used to fetch access tokens to sign API requests.

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -141,14 +141,26 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
 
   public listRulesReleases(
     filter?: string,
-    maxResults?: number,
-    nextPageToken?: string,
+    pageSize?: number,
+    pageToken?: string,
   ): Promise<ListRulesReleasesResponse> {
-    return this.invokeRequestHandler('GET', `${this.resourceName}/releases`, {
-      filter,
-      maxResults,
-      nextPageToken,
-    }).then((responseData: ListRulesReleasesResponse) => {
+    const options: { [k: string]: any } = {};
+
+    if (typeof filter === 'string') {
+      options.filter = filter;
+    }
+    if (typeof pageSize === 'number') {
+      options.pageSize = pageSize;
+    }
+    if (typeof pageToken === 'string') {
+      options.pageToken = pageToken;
+    }
+
+    return this.invokeRequestHandler(
+      'GET',
+      `${this.resourceName}/releases`,
+      options,
+    ).then((responseData: ListRulesReleasesResponse) => {
       assertServerResponse(
         validator.isNonNullObject(responseData),
         responseData,
@@ -226,16 +238,22 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
   }
 
   public listRulesets(
-    maxResults?: number,
-    nextPageToken?: string,
+    pageSize?: number,
+    pageToken?: string,
   ): Promise<ListRulesetsResponse> {
+    const options: { [k: string]: any } = {};
+
+    if (typeof pageSize === 'number') {
+      options.pageSize = pageSize;
+    }
+    if (typeof pageToken === 'string') {
+      options.pageToken = pageToken;
+    }
+
     return this.invokeRequestHandler<ListRulesetsResponse>(
       'GET',
       `${this.resourceName}/rulesets`,
-      {
-        maxResults,
-        nextPageToken,
-      },
+      options,
     ).then((responseData) => {
       assertServerResponse(
         validator.isNonNullObject(responseData),

--- a/src/project-management/firebase-rules-api-request.ts
+++ b/src/project-management/firebase-rules-api-request.ts
@@ -21,7 +21,7 @@ import {
   assertServerResponse,
   InvokeRequestHandlerOptions,
 } from './request-handler-base';
-import { RulesRelease, RulesetFile } from './rules';
+import { RulesetFile } from './rules';
 import { FirebaseProjectManagementError } from '../utils/error';
 import { HttpMethod } from '../utils/api-request';
 
@@ -87,7 +87,12 @@ export interface ListRulesReleasesResponse {
   nextPageToken?: string;
 }
 
-export type RulesReleaseResponse = RulesRelease;
+export interface RulesReleaseResponse {
+  name: string;
+  rulesetName: string;
+  createTime: string;
+  updateTime: string;
+}
 
 export interface ListRulesetsResponse {
   rulesets: RulesetResponse[];
@@ -167,7 +172,10 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         "listRulesReleases()'s responseData must be a non-null object.",
       );
 
-      // TODO: when there are no releases, is this an empty array or is the field missing?
+      if (!Object.prototype.hasOwnProperty.call(responseData, 'releases')) {
+        responseData.releases = [];
+      }
+
       assertServerResponse(
         validator.isArray(responseData.releases),
         responseData,
@@ -191,14 +199,14 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
   public createRulesRelease(
     name: string,
     rulesetId: string,
-    { isFullRulesetName = false }: { isFullRulesetName?: boolean } = {},
+    { isRulesetName = false }: { isRulesetName?: boolean } = {},
   ): Promise<RulesReleaseResponse> {
     return this.invokeRequestHandler<RulesReleaseResponse>(
       'POST',
       `${this.resourceName}/releases`,
       {
         name: `${this.resourceName}/releases/${name}`,
-        rulesetName: isFullRulesetName
+        rulesetName: isRulesetName
           ? rulesetId
           : `${this.resourceName}/rulesets/${rulesetId}`,
       },
@@ -211,7 +219,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
   public updateRulesRelease(
     name: string,
     rulesetId: string,
-    { isFullRulesetName = false }: { isFullRulesetName?: boolean } = {},
+    { isRulesetName = false }: { isRulesetName?: boolean } = {},
   ): Promise<RulesReleaseResponse> {
     return this.invokeRequestHandler<RulesReleaseResponse>(
       'PATCH',
@@ -219,7 +227,7 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
       {
         release: {
           name: `${this.resourceName}/releases/${name}`,
-          rulesetName: isFullRulesetName
+          rulesetName: isRulesetName
             ? rulesetId
             : `${this.resourceName}/rulesets/${rulesetId}`,
         },
@@ -261,7 +269,10 @@ export class FirebaseRulesRequestHandler extends RequestHandlerBase {
         "listRulesets()'s responseData must be a non-null object.",
       );
 
-      // TODO: when there are no rulesets, is this an empty array or is the field missing?
+      if (!Object.prototype.hasOwnProperty.call(responseData, 'rulesets')) {
+        responseData.rulesets = [];
+      }
+
       assertServerResponse(
         validator.isArray(responseData.rulesets),
         responseData,

--- a/src/project-management/ios-app.ts
+++ b/src/project-management/ios-app.ts
@@ -16,7 +16,8 @@
 
 import { FirebaseProjectManagementError } from '../utils/error';
 import * as validator from '../utils/validator';
-import { ProjectManagementRequestHandler, assertServerResponse } from './project-management-api-request';
+import { ProjectManagementRequestHandler } from './project-management-api-request';
+import { assertServerResponse } from './request-handler-base';
 
 export class IosApp {
   private readonly resourceName: string;

--- a/src/project-management/project-management-api-request.ts
+++ b/src/project-management/project-management-api-request.ts
@@ -16,7 +16,10 @@
 
 import * as validator from '../utils/validator';
 import { ShaCertificate } from './android-app';
-import { RequestHandlerBase } from './request-handler-base';
+import {
+  RequestHandlerBase,
+  assertServerResponse,
+} from './request-handler-base';
 
 /** Project management backend host and port. */
 const PROJECT_MANAGEMENT_HOST_AND_PORT = 'firebase.googleapis.com:443';
@@ -83,11 +86,11 @@ export class ProjectManagementRequestHandler extends RequestHandlerBase {
     return this
         .invokeRequestHandler('POST', `${parentResourceName}/androidApps`, requestData, { useBetaUrl: true })
         .then((responseData: any) => {
-          RequestHandlerBase.assertServerResponse(
+          assertServerResponse(
               validator.isNonNullObject(responseData),
               responseData,
               `createAndroidApp's responseData must be a non-null object.`);
-          RequestHandlerBase.assertServerResponse(
+          assertServerResponse(
               validator.isNonEmptyString(responseData.name),
               responseData,
               `createAndroidApp's responseData.name must be a non-empty string.`);
@@ -110,11 +113,11 @@ export class ProjectManagementRequestHandler extends RequestHandlerBase {
     return this
         .invokeRequestHandler('POST', `${parentResourceName}/iosApps`, requestData, { useBetaUrl: true })
         .then((responseData: any) => {
-          RequestHandlerBase.assertServerResponse(
+          assertServerResponse(
               validator.isNonNullObject(responseData),
               responseData,
               `createIosApp's responseData must be a non-null object.`);
-          RequestHandlerBase.assertServerResponse(
+          assertServerResponse(
               validator.isNonEmptyString(responseData.name),
               responseData,
               `createIosApp's responseData.name must be a non-empty string.`);

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -38,6 +38,7 @@ import {
   processRulesetResponse,
   processReleaseResponse,
   RULES_RELEASE_NAME_FOR_SERVICE,
+  Ruleset,
 } from './rules';
 
 /**
@@ -406,10 +407,19 @@ export class ProjectManagement implements FirebaseServiceInterface {
     return this.rulesRequestHandler
       .listRulesets(maxResults, pageToken)
       .then((response) => {
+        const rulesets: Ruleset[] = [];
+
+        response.rulesets.forEach((ruleset) => {
+          assertServerResponse(
+            validator.isNonEmptyString(ruleset.name),
+            response,
+            '"ruleset[].name" field must be present in the listRulesets() response data.',
+          );
+          rulesets.push(processRulesetResponse(ruleset));
+        });
+
         return {
-          rulesets: response.rulesets.map((ruleset) =>
-            processRulesetResponse(ruleset),
-          ),
+          rulesets,
           pageToken: response.nextPageToken,
         };
       });

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -299,24 +299,24 @@ export class ProjectManagement implements FirebaseServiceInterface {
    * It optionally accepts an object specifying filters to use.
    *
    * The maximum number of rulesets to return is determined by the optional
-   * `maxResults` argument. Defaults to 10, maximum is 100 (according to API docs).
+   * `pageSize` argument. Defaults to 10, maximum is 100 (according to API docs).
    */
   public listRulesReleases(
     filter: ListRulesReleasesFilter = {},
-    maxResults?: number,
+    pageSize?: number,
     pageToken?: string,
   ): Promise<ListRulesReleasesResult> {
     const filters: string[] = [];
 
-    if (validator.isNonEmptyString(filter.releaseName)) {
+    if (filter && validator.isNonEmptyString(filter.releaseName)) {
       filters.push('name=' + filter.releaseName);
     }
 
-    if (validator.isNonEmptyString(filter.rulesetName)) {
+    if (filter && validator.isNonEmptyString(filter.rulesetName)) {
       filters.push('ruleset_name=' + filter.rulesetName);
     }
 
-    if (validator.isNonEmptyString(filter.testSuiteName)) {
+    if (filter && validator.isNonEmptyString(filter.testSuiteName)) {
       filters.push('test_suite_name=' + filter.testSuiteName);
     }
 
@@ -325,7 +325,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
       filters.length > 0 ? filters.join('; ') : undefined;
 
     return this.rulesRequestHandler
-      .listRulesReleases(requestFilter, maxResults, pageToken)
+      .listRulesReleases(requestFilter, pageSize, pageToken)
       .then((response) => {
         const releases: RulesRelease[] = [];
 
@@ -396,17 +396,17 @@ export class ProjectManagement implements FirebaseServiceInterface {
    * metadata (`name` and `createTime`), not the actual files.
    *
    * The maximum number of rulesets to return is determined by the optional
-   * `maxResults` argument. Defaults to 10, maximum is 100 (according to API docs).
+   * `pageSize` argument. Defaults to 10, maximum is 100 (according to API docs).
    *
    * It optionally accepts a pageToken returned from a previous call, in order
    * to get the next set of results if there's more.
    */
   public listRulesets(
-    maxResults?: number,
+    pageSize?: number,
     pageToken?: string,
   ): Promise<ListRulesetsResult> {
     return this.rulesRequestHandler
-      .listRulesets(maxResults, pageToken)
+      .listRulesets(pageSize, pageToken)
       .then((response) => {
         const rulesets: Ruleset[] = [];
 

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -280,7 +280,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
       );
     }
 
-    return this.setRules(service, content);
+    return this.setRules(service, content).then(() => undefined);
   }
 
   /**
@@ -367,7 +367,9 @@ export class ProjectManagement implements FirebaseServiceInterface {
    * This method's behavior should be properly documented if it's included.
    */
   public deleteRulesRelease(name: string): Promise<void> {
-    return this.rulesRequestHandler.deleteRulesRelease(name);
+    return this.rulesRequestHandler
+      .deleteRulesRelease(name)
+      .then(() => undefined);
   }
 
   /**
@@ -429,7 +431,9 @@ export class ProjectManagement implements FirebaseServiceInterface {
    * This method's behavior should be properly documented if it's included.
    */
   public deleteRuleset(name: string): Promise<void> {
-    return this.rulesRequestHandler.deleteRuleset(name);
+    return this.rulesRequestHandler
+      .deleteRuleset(name)
+      .then(() => undefined);
   }
 
   /**

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -22,6 +22,7 @@ import * as validator from '../utils/validator';
 import { AndroidApp, ShaCertificate } from './android-app';
 import { IosApp } from './ios-app';
 import { ProjectManagementRequestHandler, assertServerResponse } from './project-management-api-request';
+import { DatabaseRequestHandler } from './database-api-request';
 
 /**
  * Internals of a Project Management instance.
@@ -47,6 +48,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
   private readonly resourceName: string;
   private readonly projectId: string;
   private readonly requestHandler: ProjectManagementRequestHandler;
+  private readonly databaseRequestHandler: DatabaseRequestHandler;
 
   /**
    * @param {object} app The app for this ProjectManagement service.
@@ -72,6 +74,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
     this.resourceName = `projects/${this.projectId}`;
 
     this.requestHandler = new ProjectManagementRequestHandler(app);
+    this.databaseRequestHandler = new DatabaseRequestHandler(app);
   }
 
   /**
@@ -145,6 +148,30 @@ export class ProjectManagement implements FirebaseServiceInterface {
               `"responseData.appId" field must be present in createIosApp()'s response data.`);
           return new IosApp(responseData.appId, this.requestHandler);
         });
+  }
+
+  /**
+   * Returns a string with the Realtime Database Rules for the Database
+   * instance associated with this Firebase App.
+   */
+  public getDatabaseRules(): Promise<string> {
+    return this.databaseRequestHandler.getDatabaseRules().then((response) => {
+      if (!validator.isNonEmptyString(response)) {
+        throw new FirebaseProjectManagementError(
+            'invalid-server-response',
+            "getDatabaseRules()'s response must be a non-empty string.");
+      }
+
+      return response;
+    });
+  }
+
+  /**
+   * Sets the Realtime Database Rules for the Database instance associated
+   * with this Firebase App.
+   */
+  public setDatabaseRules(rules: string): Promise<void> {
+    return this.databaseRequestHandler.setDatabaseRules(rules);
   }
 
   /**

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -21,7 +21,7 @@ import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
 import { AndroidApp, ShaCertificate } from './android-app';
 import { IosApp } from './ios-app';
-import { ProjectManagementRequestHandler, assertServerResponse } from './project-management-api-request';
+import { ProjectManagementRequestHandler } from './project-management-api-request';
 import { DatabaseRequestHandler } from './database-api-request';
 
 /**
@@ -118,12 +118,12 @@ export class ProjectManagement implements FirebaseServiceInterface {
   public createAndroidApp(packageName: string, displayName?: string): Promise<AndroidApp> {
     return this.requestHandler.createAndroidApp(this.resourceName, packageName, displayName)
         .then((responseData: any) => {
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isNonNullObject(responseData),
               responseData,
               'createAndroidApp()\'s responseData must be a non-null object.');
 
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isNonEmptyString(responseData.appId),
               responseData,
               `"responseData.appId" field must be present in createAndroidApp()'s response data.`);
@@ -137,12 +137,12 @@ export class ProjectManagement implements FirebaseServiceInterface {
   public createIosApp(bundleId: string, displayName?: string): Promise<IosApp> {
     return this.requestHandler.createIosApp(this.resourceName, bundleId, displayName)
         .then((responseData: any) => {
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isNonNullObject(responseData),
               responseData,
               'createIosApp()\'s responseData must be a non-null object.');
 
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isNonEmptyString(responseData.appId),
               responseData,
               `"responseData.appId" field must be present in createIosApp()'s response data.`);
@@ -150,29 +150,144 @@ export class ProjectManagement implements FirebaseServiceInterface {
         });
   }
 
-  /**
-   * Returns a string with the Realtime Database Rules for the Database
-   * instance associated with this Firebase App.
-   */
-  public getDatabaseRules(): Promise<string> {
-    return this.databaseRequestHandler.getDatabaseRules().then((response) => {
-      if (!validator.isNonEmptyString(response)) {
-        throw new FirebaseProjectManagementError(
-            'invalid-server-response',
-            "getDatabaseRules()'s response must be a non-empty string.");
-      }
+  // ************************************************ //
 
-      return response;
-    });
+  // /**
+  //  * Returns a string with the Realtime Database Rules for the Database
+  //  * instance associated with this Firebase App.
+  //  */
+  // public getDatabaseRules(): Promise<string> {
+  //   return this.databaseRequestHandler.getRules().then((response) => {
+  //     if (!validator.isNonEmptyString(response)) {
+  //       throw new FirebaseProjectManagementError(
+  //           'invalid-server-response',
+  //           "getDatabaseRules()'s response must be a non-empty string.");
+  //     }
+
+  //     return response;
+  //   });
+  // }
+
+  // /**
+  //  * Sets the Realtime Database Rules for the Database instance associated
+  //  * with this Firebase App.
+  //  */
+  // public setDatabaseRules(rules: string): Promise<void> {
+  //   return this.databaseRequestHandler.setRules(rules);
+  // }
+
+
+  public async getRules(service: Service): Promise<string> {
+    // ...
   }
 
   /**
-   * Sets the Realtime Database Rules for the Database instance associated
-   * with this Firebase App.
+   * Sets the new rules to be used with the service:
+   *   - For RTDB it PUTs them to `.settings/rules.json`.
+   *   - For Firestore/Storage it creates a new ruleset with the specified
+   *     content and updates/creates the appropriate release for the
+   *     service with that ruleset.
    */
-  public setDatabaseRules(rules: string): Promise<void> {
-    return this.databaseRequestHandler.setDatabaseRules(rules);
+  public async setRules(service: Service, content: string): Promise<void> {
+    // ...
   }
+
+  /**
+   * Like `setRules()` but reads the rules content from a file.
+   * (Just for convenience for the user, but this one could be skiped)
+   */
+  public async setRulesFromFile(service: Service, filePath: string): Promise<void> {
+    // ...
+  }
+
+  /**
+   * Gets the list of rules releases for the project.
+   *
+   * It optionally accepts an object specifying filters to use.
+   *
+   * The maximum number of rulesets to return is determined by the optional
+   * `maxResults` argument. Defaults to 10, maximum is 100 (according to API docs).
+   */
+  public async listRulesReleases(
+    filter?: ListRulesReleasesFilter,
+    maxResults?: number,
+    pageToken?: string,
+  ): Promise<ListRulesReleasesResult> {
+    // ...
+  }
+
+  /**
+   * Gets the named rules release.
+   */
+  public async getRulesRelease(name: string): Promise<RulesRelease> {
+    // ...
+  }
+
+  /**
+   * Creates a new rules release with the given name and associated to
+   * the given ruleset name.
+   */
+  public async createRulesRelease(
+    name: string,
+    rulesetName: string,
+  ): Promise<RulesRelease> {
+    // ...
+  }
+
+  /**
+   * Deletes the named rules release.
+   * Note: I'm not sure what happens when you do this. For example, if you
+   * delete the release for Firestore rules, does Firestore stop working?
+   * This method's behavior should be properly documented if it's included.
+   */
+  public async deleteRulesRelease(name: string): Promise<void> {
+    // ...
+  }
+
+  /**
+   * Gets the list of rulesets for the project. The Rulesets only contain
+   * metadata (`name` and `createTime`), not the actual files.
+   *
+   * The maximum number of rulesets to return is determined by the optional
+   * `maxResults` argument. Defaults to 10, maximum is 100 (according to API docs).
+   *
+   * It optionally accepts a pageToken returned from a previous call, in order
+   * to get the next set of results if there's more.
+   */
+  public async listRulesets(
+    maxResults?: number,
+    pageToken?: string,
+  ): Promise<ListRulesetsResult> {
+    // ...
+  }
+
+  /**
+   * Gets the named ruleset. The returned Ruleset contains its files.
+   */
+  public async getRuleset(name: string): Promise<RulesetWithFiles> {
+    // ...
+  }
+
+  /**
+   * Creates a new ruleset with the given files.
+   */
+  public async createRuleset(files: RulesetFile[]): Promise<RulesetWithFiles> {
+    // ...
+  }
+
+  /**
+   * Deletes the named rules ruleset.
+   * Note: I'm not sure what happens when you do this. For example, if you
+   * delete the ruleset currently associated with the release for Firestore
+   * rules, does Firestore stop working? Is the release automatically
+   * associated with the most recent previous ruleset? No idea.
+   * This method's behavior should be properly documented if it's included.
+   */
+  public async deleteRuleset(name: string): Promise<void> {
+    // ...
+  }
+
+  // ************************************************ //
 
   /**
    * Lists up to 100 Firebase apps for a specified platform, associated with this Firebase project.
@@ -184,7 +299,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
 
     return listPromise
         .then((responseData: any) => {
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isNonNullObject(responseData),
               responseData,
               `${callerName}\'s responseData must be a non-null object.`);
@@ -193,13 +308,13 @@ export class ProjectManagement implements FirebaseServiceInterface {
             return [];
           }
 
-          assertServerResponse(
+          ProjectManagementRequestHandler.assertServerResponse(
               validator.isArray(responseData.apps),
               responseData,
               `"apps" field must be present in the ${callerName} response data.`);
 
           return responseData.apps.map((appJson: any) => {
-            assertServerResponse(
+            ProjectManagementRequestHandler.assertServerResponse(
                 validator.isNonEmptyString(appJson.appId),
                 responseData,
                 `"apps[].appId" field must be present in the ${callerName} response data.`);

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -175,7 +175,11 @@ export class ProjectManagement implements FirebaseServiceInterface {
    *     associated with that service.
    */
   public getRules(service: RulesService): Promise<string> {
-    assertValidRulesService(service, 'getRules');
+    try {
+      assertValidRulesService(service, 'getRules');
+    } catch (err) {
+      return Promise.reject(err);
+    }
 
     if (service === 'database') {
       return this.databaseRequestHandler.getRules();
@@ -217,7 +221,11 @@ export class ProjectManagement implements FirebaseServiceInterface {
    *     service with that ruleset.
    */
   public setRules(service: RulesService, content: string): Promise<void> {
-    assertValidRulesService(service, 'setRules');
+    try {
+      assertValidRulesService(service, 'setRules');
+    } catch (err) {
+      return Promise.reject(err);
+    }
 
     if (service === 'database') {
       return this.databaseRequestHandler.setRules(content);

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -346,7 +346,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
   }
 
   /**
-   * Gets the named rules release.
+   * Gets the given rules release.
    */
   public getRulesRelease(name: string): Promise<RulesRelease> {
     return this.rulesRequestHandler
@@ -380,7 +380,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
   }
 
   /**
-   * Deletes the named rules release.
+   * Deletes the given rules release.
    */
   public deleteRulesRelease(name: string): Promise<void> {
     return this.rulesRequestHandler
@@ -448,7 +448,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
   }
 
   /**
-   * Deletes the named rules ruleset.
+   * Deletes the given rules ruleset.
    */
   public deleteRuleset(name: string): Promise<void> {
     return this.rulesRequestHandler

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -245,14 +245,14 @@ export class ProjectManagement implements FirebaseServiceInterface {
           const releaseName = this.getRulesReleaseNameForService(service);
           return this.rulesRequestHandler
             .updateRulesRelease(releaseName, rulesetResponse.name, {
-              isFullRulesetName: true,
+              isRulesetName: true,
             })
             .catch(() => {
               // Updating the release fails if it doesn't exist. In that case we
               // create a new one.
               return this.rulesRequestHandler
                 .createRulesRelease(releaseName, rulesetResponse.name, {
-                  isFullRulesetName: true,
+                  isRulesetName: true,
                 })
                 .then((response) => processReleaseResponse(response));
             })
@@ -322,7 +322,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
 
     // TODO: check how the filters are supposed to be concatenated
     const requestFilter =
-      filters.length > 0 ? filters.join('; ') : undefined;
+      filters.length > 0 ? filters.join(' ') : undefined;
 
     return this.rulesRequestHandler
       .listRulesReleases(requestFilter, pageSize, pageToken)
@@ -381,9 +381,6 @@ export class ProjectManagement implements FirebaseServiceInterface {
 
   /**
    * Deletes the named rules release.
-   * TODO: I'm not sure what happens when you do this. For example, if you
-   * delete the release for Firestore rules, does Firestore stop working?
-   * This method's behavior should be properly documented if it's included.
    */
   public deleteRulesRelease(name: string): Promise<void> {
     return this.rulesRequestHandler
@@ -452,11 +449,6 @@ export class ProjectManagement implements FirebaseServiceInterface {
 
   /**
    * Deletes the named rules ruleset.
-   * TODO: I'm not sure what happens when you do this. For example, if you
-   * delete the ruleset currently associated with the release for Firestore
-   * rules, does Firestore stop working? Is the release automatically
-   * associated with the most recent previous ruleset? No idea.
-   * This method's behavior should be properly documented if it's included.
    */
   public deleteRuleset(name: string): Promise<void> {
     return this.rulesRequestHandler

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -242,7 +242,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
       return this.rulesRequestHandler
         .createRuleset(files)
         .then((rulesetResponse) => {
-          const releaseName = RULES_RELEASE_NAME_FOR_SERVICE[service];
+          const releaseName = this.getRulesReleaseNameForService(service);
           return this.rulesRequestHandler
             .updateRulesRelease(releaseName, rulesetResponse.name, {
               isFullRulesetName: true,

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -39,7 +39,6 @@ import {
   processReleaseResponse,
   RULES_RELEASE_NAME_FOR_SERVICE,
   Ruleset,
-  shortenRulesetName,
 } from './rules';
 
 /**

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -205,7 +205,7 @@ export class ProjectManagement implements FirebaseServiceInterface {
             validator.isNonNullObject(file) &&
               validator.isNonEmptyString(file.content),
             response,
-            'ruleset.files[].content must be a non-empty string in getRules() response data',
+            'ruleset.files[].content must be present in the getRules() response data',
           );
 
           return file.content;
@@ -325,10 +325,19 @@ export class ProjectManagement implements FirebaseServiceInterface {
     return this.rulesRequestHandler
       .listRulesReleases(requestFilter, maxResults, pageToken)
       .then((response) => {
+        const releases: RulesRelease[] = [];
+
+        response.releases.forEach((release) => {
+          assertServerResponse(
+            validator.isNonEmptyString(release.rulesetName),
+            response,
+            '"releases[].rulesetName" field must be present in the listRulesReleases() response data.',
+          );
+          releases.push(processReleaseResponse(release));
+        });
+
         return {
-          releases: response.releases.map((release) =>
-            processReleaseResponse(release),
-          ),
+          releases,
           pageToken: response.nextPageToken,
         };
       });

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -39,6 +39,7 @@ import {
   processReleaseResponse,
   RULES_RELEASE_NAME_FOR_SERVICE,
   Ruleset,
+  shortenRulesetName,
 } from './rules';
 
 /**
@@ -185,7 +186,6 @@ export class ProjectManagement implements FirebaseServiceInterface {
     if (service === 'database') {
       return this.databaseRequestHandler.getRules();
     } else {
-      // const releaseName = RULES_RELEASE_NAME_FOR_SERVICE[service];
       const releaseName = this.getRulesReleaseNameForService(service);
       return this.rulesRequestHandler
         .getRulesRelease(releaseName)

--- a/src/project-management/request-handler-base.ts
+++ b/src/project-management/request-handler-base.ts
@@ -156,7 +156,7 @@ export abstract class RequestHandlerBase {
     requestData: object | string | null = null,
     { useBetaUrl = false, isJSONData = true }: InvokeRequestHandlerOptions = {},
   ): Promise<T> {
-    const baseUrlToUse = useBetaUrl ? this.baseUrl : this.baseBetaUrl;
+    const baseUrlToUse = useBetaUrl ? this.baseBetaUrl : this.baseUrl;
     const request: HttpRequestConfig = {
       method,
       url: baseUrlToUse + path,

--- a/src/project-management/request-handler-base.ts
+++ b/src/project-management/request-handler-base.ts
@@ -120,6 +120,7 @@ export abstract class RequestHandlerBase {
 
   protected pollRemoteOperationWithExponentialBackoff(
     operationResourceName: string,
+    wrapAndRethrowHttpError = RequestHandlerBase.wrapAndRethrowHttpError,
   ): Promise<object> {
     const poller = new ExponentialBackoffPoller();
 
@@ -133,7 +134,7 @@ export abstract class RequestHandlerBase {
           const errStatusCode: number = responseData.error.code || 500;
           const errText: string =
             responseData.error.message || JSON.stringify(responseData.error);
-          RequestHandlerBase.wrapAndRethrowHttpError(errStatusCode, errText);
+          wrapAndRethrowHttpError(errStatusCode, errText);
         }
 
         if (!responseData.done) {
@@ -155,6 +156,7 @@ export abstract class RequestHandlerBase {
     path: string,
     requestData: object | string | null = null,
     { useBetaUrl = false, isJSONData = true }: InvokeRequestHandlerOptions = {},
+    wrapAndRethrowHttpError = RequestHandlerBase.wrapAndRethrowHttpError,
   ): Promise<T> {
     const baseUrlToUse = useBetaUrl ? this.baseBetaUrl : this.baseUrl;
     const request: HttpRequestConfig = {
@@ -184,10 +186,7 @@ export abstract class RequestHandlerBase {
       })
       .catch((err) => {
         if (err instanceof HttpError) {
-          RequestHandlerBase.wrapAndRethrowHttpError(
-            err.response.status,
-            err.response.text,
-          );
+          wrapAndRethrowHttpError(err.response.status, err.response.text);
         }
         throw err;
       });

--- a/src/project-management/request-handler-base.ts
+++ b/src/project-management/request-handler-base.ts
@@ -1,0 +1,200 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from '../firebase-app';
+import {
+  AuthorizedHttpClient,
+  HttpError,
+  HttpMethod,
+  HttpRequestConfig,
+  ExponentialBackoffPoller,
+} from '../utils/api-request';
+import {
+  FirebaseProjectManagementError,
+  ProjectManagementErrorCode,
+} from '../utils/error';
+
+/**
+ * Abstract class that classes related to project management backend endpoints.
+ *
+ * @private
+ * @abstract
+ */
+export abstract class RequestHandlerBase {
+  protected static TIMEOUT_MILLIS = 10000;
+  protected static HEADERS = {
+    'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+  };
+
+  protected abstract readonly baseUrl: string;
+  protected readonly baseBetaUrl?: string | undefined;
+  protected readonly httpClient: AuthorizedHttpClient;
+
+  public static assertServerResponse(
+    condition: boolean,
+    responseData: object | string,
+    message: string,
+  ): void {
+    if (!condition) {
+      const stringData =
+        typeof responseData === 'string'
+          ? responseData
+          : JSON.stringify(responseData, null, 2);
+      throw new FirebaseProjectManagementError(
+        'invalid-server-response',
+        `${message} Response data: ${stringData}`,
+      );
+    }
+  }
+
+  protected static wrapAndRethrowHttpError(
+    errStatusCode: number,
+    errText: string,
+  ) {
+    let errorCode: ProjectManagementErrorCode;
+    let errorMessage: string;
+
+    switch (errStatusCode) {
+      case 400:
+        errorCode = 'invalid-argument';
+        errorMessage = 'Invalid argument provided.';
+        break;
+      case 401:
+      case 403:
+        errorCode = 'authentication-error';
+        errorMessage =
+          'An error occurred when trying to authenticate. Make sure the credential ' +
+          'used to authenticate this SDK has the proper permissions. See ' +
+          'https://firebase.google.com/docs/admin/setup for setup instructions.';
+        break;
+      case 404:
+        errorCode = 'not-found';
+        errorMessage = 'The specified entity could not be found.';
+        break;
+      case 409:
+        errorCode = 'already-exists';
+        errorMessage = 'The specified entity already exists.';
+        break;
+      case 500:
+        errorCode = 'internal-error';
+        errorMessage =
+          'An internal error has occurred. Please retry the request.';
+        break;
+      case 503:
+        errorCode = 'service-unavailable';
+        errorMessage =
+          'The server could not process the request in time. See the error ' +
+          'documentation for more details.';
+        break;
+      default:
+        errorCode = 'unknown-error';
+        errorMessage = 'An unknown server error was returned.';
+    }
+
+    throw new FirebaseProjectManagementError(
+      errorCode,
+      `${errorMessage} Status code: ${errStatusCode}. Raw server response: "${errText}".`,
+    );
+  }
+
+  /**
+   * @param {FirebaseApp} app The app used to fetch access tokens to sign API requests.
+   * @constructor
+   */
+  constructor(app: FirebaseApp) {
+    this.httpClient = new AuthorizedHttpClient(app);
+  }
+
+  protected pollRemoteOperationWithExponentialBackoff(
+    operationResourceName: string,
+  ): Promise<object> {
+    const poller = new ExponentialBackoffPoller();
+
+    return poller.poll(() => {
+      return this.invokeRequestHandler(
+        'GET',
+        operationResourceName,
+        /* requestData */ null,
+      ).then((responseData: any) => {
+        if (responseData.error) {
+          const errStatusCode: number = responseData.error.code || 500;
+          const errText: string =
+            responseData.error.message || JSON.stringify(responseData.error);
+          RequestHandlerBase.wrapAndRethrowHttpError(errStatusCode, errText);
+        }
+
+        if (!responseData.done) {
+          // Continue polling.
+          return null;
+        }
+
+        // Polling complete. Resolve with operation response JSON.
+        return responseData.response;
+      });
+    });
+  }
+
+  /**
+   * Invokes the request handler with the provided request data.
+   */
+  protected invokeRequestHandler<T = object>(
+    method: HttpMethod,
+    path: string,
+    requestData: object | string | null,
+    { useBetaUrl = false, isJSONData = true }: InvokeRequestHandlerOptions = {},
+  ): Promise<T> {
+    const baseUrlToUse = useBetaUrl ? this.baseUrl : this.baseBetaUrl;
+    const request: HttpRequestConfig = {
+      method,
+      url: baseUrlToUse + path,
+      headers: RequestHandlerBase.HEADERS,
+      data: requestData,
+      timeout: RequestHandlerBase.TIMEOUT_MILLIS,
+    };
+
+    return this.httpClient
+      .send(request)
+      .then((response) => {
+        if (isJSONData) {
+          if (!response.isJson()) {
+            // Send non-JSON responses to the catch() below, where they will be treated as errors.
+            throw new HttpError(response);
+          }
+          return response.data;
+        } else {
+          // Send error responses to the catch() below.
+          if (response.status >= 400) {
+            throw new HttpError(response);
+          }
+          return response.text;
+        }
+      })
+      .catch((err) => {
+        if (err instanceof HttpError) {
+          RequestHandlerBase.wrapAndRethrowHttpError(
+            err.response.status,
+            err.response.text,
+          );
+        }
+        throw err;
+      });
+  }
+}
+
+export interface InvokeRequestHandlerOptions {
+  useBetaUrl?: boolean;
+  isJSONData?: boolean;
+}

--- a/src/project-management/request-handler-base.ts
+++ b/src/project-management/request-handler-base.ts
@@ -27,6 +27,23 @@ import {
   ProjectManagementErrorCode,
 } from '../utils/error';
 
+export function assertServerResponse(
+  condition: boolean,
+  responseData: object | string,
+  message: string,
+): void {
+  if (!condition) {
+    const stringData =
+      typeof responseData === 'string'
+        ? responseData
+        : JSON.stringify(responseData, null, 2);
+    throw new FirebaseProjectManagementError(
+      'invalid-server-response',
+      `${message} Response data: ${stringData}`,
+    );
+  }
+}
+
 /**
  * Abstract class that classes related to project management backend endpoints.
  *
@@ -42,23 +59,6 @@ export abstract class RequestHandlerBase {
   protected abstract readonly baseUrl: string;
   protected readonly baseBetaUrl?: string | undefined;
   protected readonly httpClient: AuthorizedHttpClient;
-
-  public static assertServerResponse(
-    condition: boolean,
-    responseData: object | string,
-    message: string,
-  ): void {
-    if (!condition) {
-      const stringData =
-        typeof responseData === 'string'
-          ? responseData
-          : JSON.stringify(responseData, null, 2);
-      throw new FirebaseProjectManagementError(
-        'invalid-server-response',
-        `${message} Response data: ${stringData}`,
-      );
-    }
-  }
 
   protected static wrapAndRethrowHttpError(
     errStatusCode: number,
@@ -153,7 +153,7 @@ export abstract class RequestHandlerBase {
   protected invokeRequestHandler<T = object>(
     method: HttpMethod,
     path: string,
-    requestData: object | string | null,
+    requestData: object | string | null = null,
     { useBetaUrl = false, isJSONData = true }: InvokeRequestHandlerOptions = {},
   ): Promise<T> {
     const baseUrlToUse = useBetaUrl ? this.baseUrl : this.baseBetaUrl;

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -1,12 +1,20 @@
 import { FirebaseProjectManagementError } from '../utils/error';
 
-const VALID_SERVICES: Service[] = ['firestore', 'storage', 'database'];
-const RELEASE_NAME_FIRESTORE = 'cloud.firestore';
-const RELEASE_NAME_STORAGE = 'firebase.storage';
 const REGEX_RELEASE_NAME = /^projects\/([^\/]+)\/releases\/([^\/]+)$/;
 const REGEX_RULESET_NAME = /^projects\/([^\/]+)\/rulesets\/([^\/]+)$/;
 
-export type Service = 'firestore' | 'storage' | 'database';
+export const VALID_SERVICES: RulesService[] = [
+  'firestore',
+  'storage',
+  'database',
+];
+
+export const RELEASE_NAME_FOR_SERVICE = {
+  firestore: 'cloud.firestore',
+  storage: 'firebase.storage',
+};
+
+export type RulesService = 'firestore' | 'storage' | 'database';
 
 export interface Ruleset {
   /**
@@ -94,7 +102,10 @@ export interface ListRulesetsResult {
   pageToken?: string;
 }
 
-export function assertValidRulesService(service: Service, methodName: string) {
+export function assertValidRulesService(
+  service: RulesService,
+  methodName: string,
+) {
   if (VALID_SERVICES.indexOf(service) < 0) {
     throw new FirebaseProjectManagementError(
       'invalid-argument',
@@ -110,21 +121,7 @@ export function shortenReleaseName(release: RulesRelease): RulesRelease {
   return { ...release, name: nameMatch[2] };
 }
 
-export function expandReleaseName<T extends RulesRelease | string>(
-  release: T,
-  resourceName: string,
-): T {
-  if (typeof release === 'string') {
-    return `${resourceName}/releases/${release}` as any;
-  } else {
-    return {
-      ...release,
-      name: `${resourceName}/releases/${(release as any).name}`,
-    };
-  }
-}
-
-export function shortenRulesetName<T extends Ruleset | RulesetFile>(
+export function shortenRulesetName<T extends Ruleset | RulesetWithFiles>(
   ruleset: T,
 ): T {
   const nameMatch = ruleset.name.match(REGEX_RULESET_NAME);

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -5,13 +5,9 @@ import {
   RulesReleaseResponse,
 } from './firebase-rules-api-request';
 
-const RELEASE_NAME_REGEX = /^projects\/([^\/]+)\/releases\/([^\/]+)$/;
-const RULESET_NAME_REGEX = /^projects\/([^\/]+)\/rulesets\/([^\/]+)$/;
-const VALID_SERVICES: RulesService[] = [
-  'firestore',
-  'storage',
-  'database',
-];
+const RELEASE_NAME_REGEX = /^projects\/([^\/]+)\/releases\/(.+)$/;
+const RULESET_NAME_REGEX = /^projects\/([^\/]+)\/rulesets\/(.+)$/;
+const VALID_SERVICES: RulesService[] = ['firestore', 'storage', 'database'];
 
 export const RULES_RELEASE_NAME_FOR_SERVICE = {
   firestore: 'cloud.firestore',
@@ -118,13 +114,28 @@ export function assertValidRulesService(
   }
 }
 
-function shortenReleaseName(name: string): string {
+export function shortenReleaseName(name: string): string {
   const nameMatch = name.match(RELEASE_NAME_REGEX);
+
+  if (!nameMatch) {
+    throw new FirebaseProjectManagementError(
+      'internal-error',
+      'The rules release name has an unknown format: ' + name,
+    );
+  }
+
   return nameMatch[2];
 }
 
-function shortenRulesetName(name: string): string {
+export function shortenRulesetName(name: string): string {
   const nameMatch = name.match(RULESET_NAME_REGEX);
+
+  if (!nameMatch) {
+    throw new FirebaseProjectManagementError(
+      'internal-error',
+      'The ruleset name has an unknown format: ' + name,
+    );
+  }
   return nameMatch[2];
 }
 

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -1,7 +1,7 @@
 import { FirebaseProjectManagementError } from '../utils/error';
 
-const REGEX_RELEASE_NAME = /^projects\/([^\/]+)\/releases\/([^\/]+)$/;
-const REGEX_RULESET_NAME = /^projects\/([^\/]+)\/rulesets\/([^\/]+)$/;
+const RELEASE_NAME_REGEX = /^projects\/([^\/]+)\/releases\/([^\/]+)$/;
+const RULESET_NAME_REGEX = /^projects\/([^\/]+)\/rulesets\/([^\/]+)$/;
 
 export const VALID_SERVICES: RulesService[] = [
   'firestore',
@@ -19,7 +19,6 @@ export type RulesService = 'firestore' | 'storage' | 'database';
 export interface Ruleset {
   /**
    * The name of the ruleset.
-   * Format: `projects/{projectId}/rulesets/{uuid}`
    */
   name: string;
 
@@ -32,8 +31,6 @@ export interface Ruleset {
 export interface RulesetWithFiles extends Ruleset {
   /**
    * Array of ruleset files.
-   * This is only present when getting a specific Ruleset, but not when
-   * listing them with `listRulesets()`.
    */
   files: RulesetFile[];
 }
@@ -70,14 +67,12 @@ export interface ListRulesReleasesResult {
 export interface RulesRelease {
   /**
    * The name of the release.
-   * Format: `projects/{projectId}/releases/{id}`.
-   * `id` would be either `cloud.storage` or `cloud.firestore`.
+   * This will usually be either `firebase.storage` or `cloud.firestore`.
    */
   name: string;
 
   /**
    * Name of the ruleset associated with the release.
-   * Format: `projects/{projectId}/rulesets/{uuid}`
    */
   rulesetName: string;
 
@@ -88,7 +83,7 @@ export interface RulesRelease {
 
   /**
    * Timestamp in ISO 8601 format.
-   * Note: this might only be present if the release has been updated, I'm
+   * TODO: this might only be present if the release has been updated, I'm
    * not sure. Should check.
    */
   updateTime: string;
@@ -102,6 +97,9 @@ export interface ListRulesetsResult {
   pageToken?: string;
 }
 
+/**
+ * Assert that the given service name is among the valid ones.
+ */
 export function assertValidRulesService(
   service: RulesService,
   methodName: string,
@@ -116,14 +114,20 @@ export function assertValidRulesService(
   }
 }
 
+/**
+ * Returns the release object with its name shortened.
+ */
 export function shortenReleaseName(release: RulesRelease): RulesRelease {
-  const nameMatch = release.name.match(REGEX_RELEASE_NAME);
+  const nameMatch = release.name.match(RELEASE_NAME_REGEX);
   return { ...release, name: nameMatch[2] };
 }
 
+/**
+ * Returns the ruleset object with its name shortened.
+ */
 export function shortenRulesetName<T extends Ruleset | RulesetWithFiles>(
   ruleset: T,
 ): T {
-  const nameMatch = ruleset.name.match(REGEX_RULESET_NAME);
+  const nameMatch = ruleset.name.match(RULESET_NAME_REGEX);
   return { ...ruleset, name: nameMatch[2] };
 }

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -53,7 +53,7 @@ export interface RulesetFile {
 export interface ListRulesReleasesFilter {
   releaseName?: string;
   rulesetName?: string;
-  testSuiteName?: string; // TODO: Maybe not? Totally undocumented AFAIK.
+  testSuiteName?: string;
 }
 
 /**

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -72,9 +72,9 @@ export interface RulesRelease {
   name: string;
 
   /**
-   * Name of the ruleset associated with the release.
+   * ID of the ruleset associated with the release.
    */
-  rulesetName: string;
+  rulesetId: string;
 
   /**
    * Timestamp in ISO 8601 format.
@@ -83,10 +83,8 @@ export interface RulesRelease {
 
   /**
    * Timestamp in ISO 8601 format.
-   * TODO: this might only be present if the release has been updated, I'm
-   * not sure. Should check.
    */
-  updateTime?: string;
+  updateTime: string;
 }
 
 /**
@@ -145,9 +143,11 @@ export function shortenRulesetName(name: string): string {
 export function processReleaseResponse(
   releaseResponse: RulesReleaseResponse,
 ): RulesRelease {
+  const { name, rulesetName, ...restRelease } = releaseResponse;
   return {
-    ...releaseResponse,
-    name: shortenReleaseName(releaseResponse.name),
+    name: shortenReleaseName(name),
+    rulesetId: shortenRulesetName(rulesetName),
+    ...restRelease,
   };
 }
 
@@ -165,10 +165,10 @@ export function processRulesetResponse(
   rulesetResponse: RulesetResponse | RulesetWithFilesResponse,
   withFiles = false,
 ): Ruleset | RulesetWithFiles {
-  const { name, ...restRelease } = rulesetResponse;
+  const { name, ...restResponse } = rulesetResponse;
   const ruleset: any = {
-    ...restRelease,
     id: shortenRulesetName(name),
+    ...restResponse,
   };
 
   if (withFiles) {

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -1,0 +1,88 @@
+
+export type Service = 'firestore' | 'storage' | 'database';
+
+export interface Ruleset {
+  /**
+   * The name of the ruleset.
+   * Format: `projects/{projectId}/rulesets/{uuid}`
+   */
+  name: string;
+
+  /**
+   * Timestamp in ISO 8601 format.
+   */
+  createTime: string;
+}
+
+export interface RulesetWithFiles extends Ruleset {
+  /**
+   * Array of ruleset files.
+   * This is only present when getting a specific Ruleset, but not when
+   * listing them with `listRulesets()`.
+   */
+  files: RulesetFile[];
+}
+
+export interface RulesetFile {
+  /**
+   * Name of the file.
+   */
+  name: string;
+
+  /**
+   * The content of the file (the actual rules).
+   */
+  content: string;
+}
+
+/**
+ * Possible filters when listing releases. All optional and can be combined.
+ */
+export interface ListRulesReleasesFilter {
+  releaseName?: string;
+  rulesetName?: string;
+  testSuiteName?: string; // Maybe not? Totally undocumented AFAIK.
+}
+
+/**
+ * The result of listing rules releases.
+ */
+export interface ListRulesReleasesResult {
+  releases: RulesRelease[];
+  pageToken?: string;
+}
+
+export interface RulesRelease {
+  /**
+   * The name of the release.
+   * Format: `projects/{projectId}/releases/{id}`.
+   * `id` would be either `cloud.storage` or `cloud.firestore`.
+   */
+  name: string;
+
+  /**
+   * Name of the ruleset associated with the release.
+   * Format: `projects/{projectId}/rulesets/{uuid}`
+   */
+  rulesetName: string;
+
+  /**
+   * Timestamp in ISO 8601 format.
+   */
+  createTime: string;
+
+  /**
+   * Timestamp in ISO 8601 format.
+   * Note: this might only be present if the release has been updated, I'm
+   * not sure. Should check.
+   */
+  updateTime: string;
+}
+
+/**
+ * The result of listing rulesets.
+ */
+export interface ListRulesetsResult {
+  rulesets: Ruleset[];
+  pageToken?: string;
+}

--- a/src/project-management/rules.ts
+++ b/src/project-management/rules.ts
@@ -90,7 +90,7 @@ export interface RulesRelease {
    * TODO: this might only be present if the release has been updated, I'm
    * not sure. Should check.
    */
-  updateTime: string;
+  updateTime?: string;
 }
 
 /**

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -727,6 +727,8 @@ export type ProjectManagementErrorCode =
     | 'invalid-server-response'
     | 'not-found'
     | 'service-unavailable'
+    | 'failed-precondition'
+    | 'resource-exhausted'
     | 'unknown-error';
 
 /** @const {ServerToClientCode} Auth server to client enum error codes. */

--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -193,34 +193,34 @@ describe('admin.projectManagement', () => {
     });
   });
 
-  describe('getDatabaseRules()', () => {
-    it('successfully gets the database rules', () => {
-      return admin.projectManagement().getDatabaseRules().then((rules: string) => {
-        expect(rules).to.be.a('string');
-        expect(rules[0]).to.equal('{');
-        expect(rules.length).to.be.at.least('{"rules":{}}'.length);
-      });
-    });
-  });
+  // describe('getDatabaseRules()', () => {
+  //   it('successfully gets the database rules', () => {
+  //     return admin.projectManagement().getDatabaseRules().then((rules: string) => {
+  //       expect(rules).to.be.a('string');
+  //       expect(rules[0]).to.equal('{');
+  //       expect(rules.length).to.be.at.least('{"rules":{}}'.length);
+  //     });
+  //   });
+  // });
 
-  describe('setDatabaseRules()', () => {
-    it('successfully sets the database rules', async () => {
-      if (cmdArgs.updateRules) {
-        // We set and get the rules twice with different values each time
-        // to check that they actually change.
+  // describe('setDatabaseRules()', () => {
+  //   it('successfully sets the database rules', async () => {
+  //     if (cmdArgs.updateRules) {
+  //       // We set and get the rules twice with different values each time
+  //       // to check that they actually change.
 
-        await admin.projectManagement().setDatabaseRules(TEST_DATABASE_RULES);
-        const testRules = await admin.projectManagement().getDatabaseRules();
-        expect(testRules).to.equal(TEST_DATABASE_RULES);
+  //       await admin.projectManagement().setDatabaseRules(TEST_DATABASE_RULES);
+  //       const testRules = await admin.projectManagement().getDatabaseRules();
+  //       expect(testRules).to.equal(TEST_DATABASE_RULES);
 
-        await admin.projectManagement().setDatabaseRules(DEFAULT_DATABASE_RULES);
-        const defaultRules = await admin.projectManagement().getDatabaseRules();
-        expect(defaultRules).to.equal(DEFAULT_DATABASE_RULES);
-        } else {
-          expect.fail(null, null, "Won't set database rules without --updateRules arg.");
-        }
-    });
-  });
+  //       await admin.projectManagement().setDatabaseRules(DEFAULT_DATABASE_RULES);
+  //       const defaultRules = await admin.projectManagement().getDatabaseRules();
+  //       expect(defaultRules).to.equal(DEFAULT_DATABASE_RULES);
+  //       } else {
+  //         expect.fail(null, null, "Won't set database rules without --updateRules arg.");
+  //       }
+  //   });
+  // });
 });
 
 /**

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -56,5 +56,6 @@ import './instance-id/instance-id-request.spec';
 // ProjectManagement
 import './project-management/project-management.spec';
 import './project-management/project-management-api-request.spec';
+import './project-management/database-request.spec';
 import './project-management/android-app.spec';
 import './project-management/ios-app.spec';

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -56,6 +56,7 @@ import './instance-id/instance-id-request.spec';
 // ProjectManagement
 import './project-management/project-management.spec';
 import './project-management/project-management-api-request.spec';
-import './project-management/database-request.spec';
 import './project-management/android-app.spec';
 import './project-management/ios-app.spec';
+// import './project-management/database-api-request.spec';
+import './project-management/firebase-rules-api-request.spec';

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -58,5 +58,5 @@ import './project-management/project-management.spec';
 import './project-management/project-management-api-request.spec';
 import './project-management/android-app.spec';
 import './project-management/ios-app.spec';
-// import './project-management/database-api-request.spec';
+import './project-management/database-api-request.spec';
 import './project-management/firebase-rules-api-request.spec';

--- a/test/unit/project-management/database-request.spec.ts
+++ b/test/unit/project-management/database-request.spec.ts
@@ -1,0 +1,167 @@
+/*!
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as _ from 'lodash';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import { FirebaseApp } from '../../../src/firebase-app';
+import { DatabaseRequestHandler } from '../../../src/project-management/database-api-request';
+import { HttpClient } from '../../../src/utils/api-request';
+import * as mocks from '../../resources/mocks';
+import * as utils from '../utils';
+
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
+const DATABASE_RULES_URL = mocks.databaseURL + '/.settings/rules.json';
+const VALID_DATABASE_RULES = `{
+  "rules": {
+    // My rules
+    "foo": {
+      ".read": true,
+      ".write": false,
+    },
+  },
+}`;
+
+describe('DatabaseRequestHandler', () => {
+  const mockAccessToken: string = utils.generateRandomAccessToken();
+  let stubs: sinon.SinonStub[] = [];
+  let getTokenStub: sinon.SinonStub;
+  let mockApp: FirebaseApp;
+  let expectedHeaders: object;
+  let requestHandler: DatabaseRequestHandler;
+
+  before(() => {
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
+  });
+
+  after(() => {
+    stubs = [];
+    getTokenStub.restore();
+  });
+
+  beforeEach(() => {
+    mockApp = mocks.app();
+    expectedHeaders = {
+      'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+      'Authorization': 'Bearer ' + mockAccessToken,
+    };
+    requestHandler = new DatabaseRequestHandler(mockApp);
+    return mockApp.INTERNAL.getToken();
+  });
+
+  afterEach(() => {
+    _.forEach(stubs, (stub) => stub.restore());
+    return mockApp.delete();
+  });
+
+  function testHttpErrors(callback: () => Promise<any>) {
+    const errorCodeMap: any = {
+      400: 'project-management/invalid-argument',
+      401: 'project-management/authentication-error',
+      403: 'project-management/authentication-error',
+      423: 'project-management/service-unavailable',
+      500: 'project-management/internal-error',
+      503: 'project-management/service-unavailable',
+    };
+    Object.keys(errorCodeMap).forEach((errorCode) => {
+      if (!errorCodeMap.hasOwnProperty(errorCode)) {
+        return;
+      }
+      it(`should throw for HTTP ${errorCode} errors`, () => {
+          const stub = sinon.stub(HttpClient.prototype, 'send')
+              .rejects(utils.errorFrom({}, parseInt(errorCode, 10)));
+          stubs.push(stub);
+
+          return callback()
+              .should.eventually.be.rejected
+              .and.have.property('code', errorCodeMap[errorCode]);
+      });
+    });
+
+    it('should throw for HTTP unknown errors', () => {
+        const stub = sinon.stub(HttpClient.prototype, 'send')
+            .rejects(utils.errorFrom({}, 1337));
+        stubs.push(stub);
+
+        return callback()
+            .should.eventually.be.rejected
+            .and.have.property('code', 'project-management/unknown-error');
+    });
+  }
+
+  describe('Constructor', () => {
+    it('should succeed with a FirebaseApp instance', () => {
+      expect(() => {
+        return new DatabaseRequestHandler(mockApp);
+      }).not.to.throw(Error);
+    });
+  });
+
+  describe('getDatabaseRules', () => {
+    testHttpErrors(() => requestHandler.getDatabaseRules());
+
+    it('should succeed', () => {
+      const expectedResult = VALID_DATABASE_RULES;
+
+      const stub = sinon.stub(HttpClient.prototype, 'send')
+          .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.getDatabaseRules()
+          .then((result) => {
+            expect(result).to.deep.equal(expectedResult);
+            expect(stub).to.have.been.calledOnce.and.calledWith({
+              method: 'GET',
+              url: DATABASE_RULES_URL,
+              data: undefined,
+              headers: expectedHeaders,
+              timeout: 10000,
+            });
+          });
+    });
+  });
+
+  describe('setDatabaseRules', () => {
+    testHttpErrors(() => requestHandler.setDatabaseRules(VALID_DATABASE_RULES));
+
+    it('should succeed', () => {
+      const stub = sinon.stub(HttpClient.prototype, 'send').resolves(utils.responseFrom(''));
+      stubs.push(stub);
+
+      const requestData = VALID_DATABASE_RULES;
+      return requestHandler.setDatabaseRules(VALID_DATABASE_RULES)
+          .then((result) => {
+            expect(result).to.equal(undefined);
+            expect(stub).to.have.been.calledOnce.and.calledWith({
+              method: 'PUT',
+              url: DATABASE_RULES_URL,
+              data: requestData,
+              headers: expectedHeaders,
+              timeout: 10000,
+            });
+          });
+    });
+  });
+});

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -166,7 +166,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .listRulesReleases()
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.releases" field must be an array in listRulesReleases\(\)'s response data/,
+          /^"releases" field must be an array in listRulesReleases\(\)'s response data/,
         );
     });
 
@@ -270,7 +270,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .getRulesRelease(RELEASE_NAME)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.name" field must be a non-empty string in getRulesRelease\(\)'s response data/,
+          /^"name" field must be a non-empty string in getRulesRelease\(\)'s response data/,
         );
     });
 
@@ -327,7 +327,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .createRulesRelease(RELEASE_NAME, RULESET_UUID)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.name" field must be a non-empty string in createRulesRelease\(\)'s response data/,
+          /^"name" field must be a non-empty string in createRulesRelease\(\)'s response data/,
         );
     });
 
@@ -391,7 +391,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .updateRulesRelease(RELEASE_NAME, RULESET_UUID)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.name" field must be a non-empty string in updateRulesRelease\(\)'s response data/,
+          /^"name" field must be a non-empty string in updateRulesRelease\(\)'s response data/,
         );
     });
 
@@ -480,7 +480,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .listRulesets()
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.rulesets" field must be an array in listRulesets\(\)'s response data/,
+          /^"rulesets" field must be an array in listRulesets\(\)'s response data/,
         );
     });
 
@@ -578,7 +578,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .getRuleset(RULESET_UUID)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.name" field must be a non-empty string in getRuleset\(\)'s response data/,
+          /^"name" field must be a non-empty string in getRuleset\(\)'s response data/,
         );
     });
 
@@ -599,7 +599,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .getRuleset(RULESET_UUID)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.source\.files" field must be an array in getRuleset\(\)'s response data/,
+          /^"source\.files" field must be an array in getRuleset\(\)'s response data/,
         );
     });
 
@@ -656,7 +656,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .createRuleset(RULESET_FILES)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.name" field must be a non-empty string in createRuleset\(\)'s response data/,
+          /^"name" field must be a non-empty string in createRuleset\(\)'s response data/,
         );
     });
 
@@ -677,7 +677,7 @@ describe('FirebaseRulesRequestHandler', () => {
         .createRuleset(RULESET_FILES)
         .should.eventually.be.rejected.and.have.property('message')
         .to.match(
-          /^"responseData\.source\.files" field must be an array in createRuleset\(\)'s response data/,
+          /^"source\.files" field must be an array in createRuleset\(\)'s response data/,
         );
     });
 

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -1,0 +1,496 @@
+/*!
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as _ from 'lodash';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import { FirebaseApp } from '../../../src/firebase-app';
+import {
+  FirebaseRulesRequestHandler,
+  ListRulesReleasesResponse,
+  RulesReleaseResponse,
+  ListRulesetsResponse,
+  RulesetResponse,
+  RulesetWithFilesResponse,
+} from '../../../src/project-management/firebase-rules-api-request';
+import { HttpClient } from '../../../src/utils/api-request';
+import * as mocks from '../../resources/mocks';
+import * as utils from '../utils';
+import { RulesetFile } from '../../../src/project-management/rules';
+
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
+describe('FirebaseRulesRequestHandler', () => {
+  const HOST = 'firebaserules.googleapis.com';
+  const PORT = 443;
+  const BASE_URL = `https://${HOST}:${PORT}/v1`;
+  const PROJECT_RESOURCE_NAME = 'projects/test-project-id';
+  const RELEASE_NAME = 'cloud.firestore';
+  const RULESET_UUID = '00000000-0000-0000-0000-000000000000';
+  const RULESET_NAME = `${PROJECT_RESOURCE_NAME}/rulesets/${RULESET_UUID}`;
+  const PAGE_TOKEN = 'PAGE_TOKEN';
+  const NEXT_PAGE_TOKEN = 'NEXT_PAGE_TOKEN';
+  const TIMESTAMP_CREATE = '2012-04-13T02:00:00.000000Z';
+  const TIMESTAMP_UPDATE = '2014-10-21T16:00:00.000000Z';
+  const RULESET_FILES: RulesetFile[] = [
+    {
+      name: 'ruleset.file',
+      content: 'Ruleset file content',
+    },
+  ];
+
+  const mockAccessToken: string = utils.generateRandomAccessToken();
+  let stubs: sinon.SinonStub[] = [];
+  let getTokenStub: sinon.SinonStub;
+  let mockApp: FirebaseApp;
+  let expectedHeaders: object;
+  let requestHandler: FirebaseRulesRequestHandler;
+
+  before(() => {
+    getTokenStub = utils.stubGetAccessToken(mockAccessToken);
+  });
+
+  after(() => {
+    stubs = [];
+    getTokenStub.restore();
+  });
+
+  beforeEach(() => {
+    mockApp = mocks.app();
+    expectedHeaders = {
+      'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+      'Authorization': 'Bearer ' + mockAccessToken,
+    };
+    requestHandler = new FirebaseRulesRequestHandler(
+      mockApp,
+      PROJECT_RESOURCE_NAME,
+    );
+    return mockApp.INTERNAL.getToken();
+  });
+
+  afterEach(() => {
+    _.forEach(stubs, (stub) => stub.restore());
+    return mockApp.delete();
+  });
+
+  function testHttpErrors(callback: () => Promise<any>) {
+    const errorCodeMap: any = {
+      400: 'project-management/invalid-argument',
+      401: 'project-management/authentication-error',
+      403: 'project-management/authentication-error',
+      404: 'project-management/not-found',
+      429: 'project-management/resource-exhausted',
+      500: 'project-management/internal-error',
+      503: 'project-management/service-unavailable',
+    };
+    Object.keys(errorCodeMap).forEach((errorCode) => {
+      if (!Object.prototype.hasOwnProperty.call(errorCodeMap, errorCode)) {
+        return;
+      }
+      it(`should throw for HTTP ${errorCode} errors`, () => {
+        const stub = sinon
+          .stub(HttpClient.prototype, 'send')
+          .rejects(utils.errorFrom({}, parseInt(errorCode, 10)));
+        stubs.push(stub);
+
+        return callback().should.eventually.be.rejected.and.have.property(
+          'code',
+          errorCodeMap[errorCode],
+        );
+      });
+    });
+
+    it('should throw for HTTP unknown errors', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .rejects(utils.errorFrom({}, 1337));
+      stubs.push(stub);
+
+      return callback().should.eventually.be.rejected.and.have.property(
+        'code',
+        'project-management/unknown-error',
+      );
+    });
+  }
+
+  describe('Constructor', () => {
+    it('should succeed with a FirebaseApp instance and a project resource name', () => {
+      expect(() => {
+        return new FirebaseRulesRequestHandler(mockApp, PROJECT_RESOURCE_NAME);
+      }).not.to.throw(Error);
+    });
+  });
+
+  describe('listRulesReleases', () => {
+    testHttpErrors(() => requestHandler.listRulesReleases());
+
+    it('should succeed without arguments', () => {
+      const expectedResult: ListRulesReleasesResponse = {
+        releases: [
+          {
+            name: RELEASE_NAME,
+            rulesetName: RULESET_UUID,
+            createTime: TIMESTAMP_CREATE,
+          },
+        ],
+        nextPageToken: NEXT_PAGE_TOKEN,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.listRulesReleases().then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+
+    it('should succeed with arguments', () => {
+      const filter = 'name=prod*';
+      const maxResults = 20;
+      const nextPageToken = PAGE_TOKEN;
+
+      const expectedResult: ListRulesReleasesResponse = {
+        releases: [
+          {
+            name: RELEASE_NAME,
+            rulesetName: RULESET_UUID,
+            createTime: TIMESTAMP_CREATE,
+            updateTime: TIMESTAMP_UPDATE,
+          },
+        ],
+        nextPageToken: NEXT_PAGE_TOKEN,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .listRulesReleases(filter, maxResults, nextPageToken)
+        .then((result) => {
+          expect(result).to.deep.equal(expectedResult);
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'GET',
+            url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
+            data: {
+              filter,
+              maxResults,
+              nextPageToken,
+            },
+            headers: expectedHeaders,
+            timeout: 10000,
+          });
+        });
+    });
+  });
+
+  describe('getRulesRelease', () => {
+    testHttpErrors(() => requestHandler.getRulesRelease(RELEASE_NAME));
+
+    it('should succeed', () => {
+      const expectedResult: RulesReleaseResponse = {
+        name: RELEASE_NAME,
+        rulesetName: RULESET_NAME,
+        createTime: TIMESTAMP_CREATE,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.getRulesRelease(RELEASE_NAME).then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+  });
+
+  describe('createRulesRelease', () => {
+    testHttpErrors(() =>
+      requestHandler.createRulesRelease(RELEASE_NAME, RULESET_UUID),
+    );
+
+    it('should succeed', () => {
+      const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
+
+      const expectedResult: RulesReleaseResponse = {
+        name: RELEASE_NAME,
+        rulesetName: RULESET_NAME,
+        createTime: TIMESTAMP_CREATE,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .then((result) => {
+          expect(result).to.deep.equal(expectedResult);
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'POST',
+            url: `${BASE_URL}/${releaseName}`,
+            data: {
+              name: releaseName,
+              rulesetName: RULESET_NAME,
+            },
+            headers: expectedHeaders,
+            timeout: 10000,
+          });
+        });
+    });
+  });
+
+  describe('updateRulesRelease', () => {
+    testHttpErrors(() =>
+      requestHandler.updateRulesRelease(RELEASE_NAME, RULESET_UUID),
+    );
+
+    it('should succeed', () => {
+      const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
+
+      const expectedResult: RulesReleaseResponse = {
+        name: RELEASE_NAME,
+        rulesetName: RULESET_NAME,
+        createTime: TIMESTAMP_CREATE,
+        updateTime: TIMESTAMP_UPDATE,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .updateRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .then((result) => {
+          expect(result).to.deep.equal(expectedResult);
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'PATCH',
+            url: `${BASE_URL}/${releaseName}`,
+            data: {
+              name: releaseName,
+              rulesetName: RULESET_NAME,
+            },
+            headers: expectedHeaders,
+            timeout: 10000,
+          });
+        });
+    });
+  });
+
+  describe('deleteRulesRelease', () => {
+    testHttpErrors(() => requestHandler.deleteRulesRelease(RELEASE_NAME));
+
+    it('should succeed', () => {
+      const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
+      const expectedResult = undefined;
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.deleteRulesRelease(RELEASE_NAME).then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'DELETE',
+          url: `${BASE_URL}/${releaseName}`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+  });
+
+  describe('listRulesets', () => {
+    testHttpErrors(() => requestHandler.listRulesets());
+
+    it('should succeed without arguments', () => {
+      const expectedResult: ListRulesetsResponse = {
+        rulesets: [
+          {
+            name: RULESET_NAME,
+            createTime: TIMESTAMP_CREATE,
+          },
+        ],
+        nextPageToken: NEXT_PAGE_TOKEN,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.listRulesets().then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+
+    it('should succeed with arguments', () => {
+      const maxResults = 20;
+      const nextPageToken = PAGE_TOKEN;
+
+      const expectedResult: ListRulesetsResponse = {
+        rulesets: [
+          {
+            name: RULESET_NAME,
+            createTime: TIMESTAMP_CREATE,
+          },
+        ],
+        nextPageToken: NEXT_PAGE_TOKEN,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .listRulesets(maxResults, nextPageToken)
+        .then((result) => {
+          expect(result).to.deep.equal(expectedResult);
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'GET',
+            url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
+            data: {
+              maxResults,
+              nextPageToken,
+            },
+            headers: expectedHeaders,
+            timeout: 10000,
+          });
+        });
+    });
+  });
+
+  describe('getRuleset', () => {
+    testHttpErrors(() => requestHandler.getRuleset(RULESET_UUID));
+
+    it('should succeed', () => {
+      const expectedResult: RulesetResponse = {
+        name: RULESET_NAME,
+        createTime: TIMESTAMP_CREATE,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.getRuleset(RULESET_UUID).then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: `${BASE_URL}/${RULESET_NAME}`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+  });
+
+  describe('createRuleset', () => {
+    testHttpErrors(() => requestHandler.createRuleset(RULESET_FILES));
+
+    it('should succeed', () => {
+      const expectedResult: RulesetWithFilesResponse = {
+        name: RULESET_NAME,
+        createTime: TIMESTAMP_CREATE,
+        source: {
+          files: RULESET_FILES,
+        },
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.createRuleset(RULESET_FILES).then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'POST',
+          url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
+          data: {
+            source: { files: RULESET_FILES },
+          },
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+  });
+
+  describe('deleteRuleset', () => {
+    testHttpErrors(() => requestHandler.deleteRuleset(RULESET_UUID));
+
+    it('should succeed', () => {
+      const expectedResult = undefined;
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(expectedResult));
+      stubs.push(stub);
+
+      return requestHandler.deleteRuleset(RULESET_UUID).then((result) => {
+        expect(result).to.deep.equal(expectedResult);
+        expect(stub).to.have.been.calledOnce.and.calledWith({
+          method: 'DELETE',
+          url: `${BASE_URL}/${RULESET_NAME}`,
+          data: null,
+          headers: expectedHeaders,
+          timeout: 10000,
+        });
+      });
+    });
+  });
+});

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -192,11 +192,7 @@ describe('FirebaseRulesRequestHandler', () => {
         expect(stub).to.have.been.calledOnce.and.calledWith({
           method: 'GET',
           url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
-          data: {
-            filter: undefined,
-            maxResults: undefined,
-            nextPageToken: undefined,
-          },
+          data: {},
           headers: expectedHeaders,
           timeout: 10000,
         });
@@ -205,8 +201,8 @@ describe('FirebaseRulesRequestHandler', () => {
 
     it('should succeed with arguments', () => {
       const filter = 'name=prod*';
-      const maxResults = 20;
-      const nextPageToken = PAGE_TOKEN;
+      const pageSize = 20;
+      const pageToken = PAGE_TOKEN;
 
       const expectedResult: ListRulesReleasesResponse = {
         releases: [
@@ -226,7 +222,7 @@ describe('FirebaseRulesRequestHandler', () => {
       stubs.push(stub);
 
       return requestHandler
-        .listRulesReleases(filter, maxResults, nextPageToken)
+        .listRulesReleases(filter, pageSize, pageToken)
         .then((result) => {
           expect(result).to.deep.equal(expectedResult);
           expect(stub).to.have.been.calledOnce.and.calledWith({
@@ -234,8 +230,8 @@ describe('FirebaseRulesRequestHandler', () => {
             url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
             data: {
               filter,
-              maxResults,
-              nextPageToken,
+              pageSize,
+              pageToken,
             },
             headers: expectedHeaders,
             timeout: 10000,
@@ -547,10 +543,7 @@ describe('FirebaseRulesRequestHandler', () => {
         expect(stub).to.have.been.calledOnce.and.calledWith({
           method: 'GET',
           url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
-          data: {
-            maxResults: undefined,
-            nextPageToken: undefined,
-          },
+          data: {},
           headers: expectedHeaders,
           timeout: 10000,
         });
@@ -558,8 +551,8 @@ describe('FirebaseRulesRequestHandler', () => {
     });
 
     it('should succeed with arguments', () => {
-      const maxResults = 20;
-      const nextPageToken = PAGE_TOKEN;
+      const pageSize = 20;
+      const pageToken = PAGE_TOKEN;
 
       const expectedResult: ListRulesetsResponse = {
         rulesets: [
@@ -577,15 +570,15 @@ describe('FirebaseRulesRequestHandler', () => {
       stubs.push(stub);
 
       return requestHandler
-        .listRulesets(maxResults, nextPageToken)
+        .listRulesets(pageSize, pageToken)
         .then((result) => {
           expect(result).to.deep.equal(expectedResult);
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: 'GET',
             url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
             data: {
-              maxResults,
-              nextPageToken,
+              pageSize,
+              pageToken,
             },
             headers: expectedHeaders,
             timeout: 10000,

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -27,7 +27,6 @@ import {
   ListRulesReleasesResponse,
   RulesReleaseResponse,
   ListRulesetsResponse,
-  RulesetResponse,
   RulesetWithFilesResponse,
 } from '../../../src/project-management/firebase-rules-api-request';
 import { HttpClient } from '../../../src/utils/api-request';

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -144,6 +144,32 @@ describe('FirebaseRulesRequestHandler', () => {
   describe('listRulesReleases', () => {
     testHttpErrors(() => requestHandler.listRulesReleases());
 
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.listRulesReleases().should.eventually.be.rejected;
+    });
+
+    it('should throw when responseData.releases is not an array', () => {
+      const invalidResult: any = { releases: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .listRulesReleases()
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.releases" field must be an array in listRulesReleases\(\)'s response data/,
+        );
+    });
+
     it('should succeed without arguments', () => {
       const expectedResult: ListRulesReleasesResponse = {
         releases: [
@@ -221,6 +247,33 @@ describe('FirebaseRulesRequestHandler', () => {
   describe('getRulesRelease', () => {
     testHttpErrors(() => requestHandler.getRulesRelease(RELEASE_NAME));
 
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.getRulesRelease(RELEASE_NAME).should.eventually.be
+        .rejected;
+    });
+
+    it('should throw when responseData.name is not a non-empty string', () => {
+      const invalidResult: any = { name: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.name" field must be a non-empty string in getRulesRelease\(\)'s response data/,
+        );
+    });
+
     it('should succeed', () => {
       const expectedResult: RulesReleaseResponse = {
         name: RELEASE_NAME,
@@ -250,6 +303,33 @@ describe('FirebaseRulesRequestHandler', () => {
     testHttpErrors(() =>
       requestHandler.createRulesRelease(RELEASE_NAME, RULESET_UUID),
     );
+
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected;
+    });
+
+    it('should throw when responseData.name is not a non-empty string', () => {
+      const invalidResult: any = { name: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.name" field must be a non-empty string in createRulesRelease\(\)'s response data/,
+        );
+    });
 
     it('should succeed', () => {
       const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
@@ -287,6 +367,33 @@ describe('FirebaseRulesRequestHandler', () => {
     testHttpErrors(() =>
       requestHandler.updateRulesRelease(RELEASE_NAME, RULESET_UUID),
     );
+
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.updateRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected;
+    });
+
+    it('should throw when responseData.name is not a non-empty string', () => {
+      const invalidResult: any = { name: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .updateRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.name" field must be a non-empty string in updateRulesRelease\(\)'s response data/,
+        );
+    });
 
     it('should succeed', () => {
       const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
@@ -350,6 +457,32 @@ describe('FirebaseRulesRequestHandler', () => {
 
   describe('listRulesets', () => {
     testHttpErrors(() => requestHandler.listRulesets());
+
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.listRulesets().should.eventually.be.rejected;
+    });
+
+    it('should throw when responseData.rulesets is not an array', () => {
+      const invalidResult: any = { rulesets: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .listRulesets()
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.rulesets" field must be an array in listRulesets\(\)'s response data/,
+        );
+    });
 
     it('should succeed without arguments', () => {
       const expectedResult: ListRulesetsResponse = {
@@ -422,6 +555,54 @@ describe('FirebaseRulesRequestHandler', () => {
   describe('getRuleset', () => {
     testHttpErrors(() => requestHandler.getRuleset(RULESET_UUID));
 
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.getRuleset(RULESET_UUID).should.eventually.be
+        .rejected;
+    });
+
+    it('should throw when responseData.name is not a non-empty string', () => {
+      const invalidResult: any = { name: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .getRuleset(RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.name" field must be a non-empty string in getRuleset\(\)'s response data/,
+        );
+    });
+
+    it('should throw when responseData.source.files is not an array', () => {
+      const invalidResult: any = {
+        name: RULESET_NAME,
+        source: {
+          files: null,
+        },
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .getRuleset(RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.source\.files" field must be an array in getRuleset\(\)'s response data/,
+        );
+    });
+
     it('should succeed', () => {
       const expectedResult: RulesetWithFilesResponse = {
         name: RULESET_NAME,
@@ -451,6 +632,54 @@ describe('FirebaseRulesRequestHandler', () => {
 
   describe('createRuleset', () => {
     testHttpErrors(() => requestHandler.createRuleset(RULESET_FILES));
+
+    it('should throw with empty response', () => {
+      const invalidResult: any = null;
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler.createRuleset(RULESET_FILES).should.eventually.be
+        .rejected;
+    });
+
+    it('should throw when responseData.name is not a non-empty string', () => {
+      const invalidResult: any = { name: null };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .createRuleset(RULESET_FILES)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.name" field must be a non-empty string in createRuleset\(\)'s response data/,
+        );
+    });
+
+    it('should throw when responseData.source.files is not an array', () => {
+      const invalidResult: any = {
+        name: RULESET_NAME,
+        source: {
+          files: null,
+        },
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .createRuleset(RULESET_FILES)
+        .should.eventually.be.rejected.and.have.property('message')
+        .to.match(
+          /^"responseData\.source\.files" field must be an array in createRuleset\(\)'s response data/,
+        );
+    });
 
     it('should succeed', () => {
       const expectedResult: RulesetWithFilesResponse = {

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -177,6 +177,7 @@ describe('FirebaseRulesRequestHandler', () => {
             name: RELEASE_NAME,
             rulesetName: RULESET_UUID,
             createTime: TIMESTAMP_CREATE,
+            updateTime: TIMESTAMP_UPDATE,
           },
         ],
         nextPageToken: NEXT_PAGE_TOKEN,
@@ -296,6 +297,7 @@ describe('FirebaseRulesRequestHandler', () => {
         name: RELEASE_NAME,
         rulesetName: RULESET_NAME,
         createTime: TIMESTAMP_CREATE,
+        updateTime: TIMESTAMP_UPDATE,
       };
 
       const stub = sinon
@@ -376,6 +378,7 @@ describe('FirebaseRulesRequestHandler', () => {
         name: RELEASE_NAME,
         rulesetName: RULESET_NAME,
         createTime: TIMESTAMP_CREATE,
+        updateTime: TIMESTAMP_UPDATE,
       };
 
       const stub = sinon

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -268,9 +268,30 @@ describe('FirebaseRulesRequestHandler', () => {
 
       return requestHandler
         .getRulesRelease(RELEASE_NAME)
-        .should.eventually.be.rejected.and.have.property('message')
-        .to.match(
-          /^"name" field must be a non-empty string in getRulesRelease\(\)'s response data/,
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"name" field must be a non-empty string in getRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(invalidResult, null, 2),
+        );
+    });
+
+    it('should throw when responseData.rulesetName is not a non-empty string', () => {
+      const invalidResult: any = {
+        name: RELEASE_NAME,
+        rulesetName: null,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"rulesetName" field must be a non-empty string in getRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(invalidResult, null, 2),
         );
     });
 
@@ -325,9 +346,30 @@ describe('FirebaseRulesRequestHandler', () => {
 
       return requestHandler
         .createRulesRelease(RELEASE_NAME, RULESET_UUID)
-        .should.eventually.be.rejected.and.have.property('message')
-        .to.match(
-          /^"name" field must be a non-empty string in createRulesRelease\(\)'s response data/,
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"name" field must be a non-empty string in createRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(invalidResult, null, 2),
+        );
+    });
+
+    it('should throw when responseData.rulesetName is not a non-empty string', () => {
+      const invalidResult: any = {
+        name: RELEASE_NAME,
+        rulesetName: null,
+      };
+
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(invalidResult));
+      stubs.push(stub);
+
+      return requestHandler
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"rulesetName" field must be a non-empty string in createRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(invalidResult, null, 2),
         );
     });
 

--- a/test/unit/project-management/firebase-rules-api-request.spec.ts
+++ b/test/unit/project-management/firebase-rules-api-request.spec.ts
@@ -167,7 +167,11 @@ describe('FirebaseRulesRequestHandler', () => {
         expect(stub).to.have.been.calledOnce.and.calledWith({
           method: 'GET',
           url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
-          data: null,
+          data: {
+            filter: undefined,
+            maxResults: undefined,
+            nextPageToken: undefined,
+          },
           headers: expectedHeaders,
           timeout: 10000,
         });
@@ -268,7 +272,7 @@ describe('FirebaseRulesRequestHandler', () => {
           expect(result).to.deep.equal(expectedResult);
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: 'POST',
-            url: `${BASE_URL}/${releaseName}`,
+            url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/releases`,
             data: {
               name: releaseName,
               rulesetName: RULESET_NAME,
@@ -308,8 +312,10 @@ describe('FirebaseRulesRequestHandler', () => {
             method: 'PATCH',
             url: `${BASE_URL}/${releaseName}`,
             data: {
-              name: releaseName,
-              rulesetName: RULESET_NAME,
+              release: {
+                name: releaseName,
+                rulesetName: RULESET_NAME,
+              },
             },
             headers: expectedHeaders,
             timeout: 10000,
@@ -323,7 +329,7 @@ describe('FirebaseRulesRequestHandler', () => {
 
     it('should succeed', () => {
       const releaseName = `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`;
-      const expectedResult = undefined;
+      const expectedResult = {};
 
       const stub = sinon
         .stub(HttpClient.prototype, 'send')
@@ -367,7 +373,10 @@ describe('FirebaseRulesRequestHandler', () => {
         expect(stub).to.have.been.calledOnce.and.calledWith({
           method: 'GET',
           url: `${BASE_URL}/${PROJECT_RESOURCE_NAME}/rulesets`,
-          data: null,
+          data: {
+            maxResults: undefined,
+            nextPageToken: undefined,
+          },
           headers: expectedHeaders,
           timeout: 10000,
         });
@@ -415,9 +424,12 @@ describe('FirebaseRulesRequestHandler', () => {
     testHttpErrors(() => requestHandler.getRuleset(RULESET_UUID));
 
     it('should succeed', () => {
-      const expectedResult: RulesetResponse = {
+      const expectedResult: RulesetWithFilesResponse = {
         name: RULESET_NAME,
         createTime: TIMESTAMP_CREATE,
+        source: {
+          files: RULESET_FILES,
+        },
       };
 
       const stub = sinon
@@ -474,7 +486,7 @@ describe('FirebaseRulesRequestHandler', () => {
     testHttpErrors(() => requestHandler.deleteRuleset(RULESET_UUID));
 
     it('should succeed', () => {
-      const expectedResult = undefined;
+      const expectedResult = {};
 
       const stub = sinon
         .stub(HttpClient.prototype, 'send')

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -805,9 +805,66 @@ describe('ProjectManagement', () => {
     });
   });
 
-  // describe('getRulesRelease', () => {
+  describe('getRulesRelease', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'getRulesRelease')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should throw with null API response', () => {
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(null));
+      stubs.push(stub);
+
+      return projectManagement
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          "getRulesRelease()'s responseData must be a non-null object. Response data: null",
+        );
+    });
+
+    it('should throw when API response missing "name" field', () => {
+      const partialApiResponse = {};
+
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(partialApiResponse));
+      stubs.push(stub);
+
+      return projectManagement
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"name" field must be a non-empty string in getRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(partialApiResponse, null, 2),
+        );
+    });
+
+    it('should resolve with release object on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'getRulesRelease')
+        .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
+      stubs.push(stub);
+
+      return projectManagement
+        .getRulesRelease(RELEASE_NAME)
+        .should.eventually.deep.equal(VALID_RELEASE);
+    });
+  });
 
   // describe('createRulesRelease', () => {
 

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -55,6 +55,15 @@ const EXPECTED_ERROR = new FirebaseProjectManagementError('internal-error', 'mes
 
 const VALID_SHA_256_HASH = '0123456789abcdefABCDEF01234567890123456701234567890123456789abcd';
 
+const PROJECT_RESOURCE_NAME = 'projects/test-project-id';
+const RELEASE_NAME = 'cloud.firestore';
+const RULESET_UUID = '00000000-0000-0000-0000-000000000000';
+const RULESET_NAME = `${PROJECT_RESOURCE_NAME}/rulesets/${RULESET_UUID}`;
+const PAGE_TOKEN = 'PAGE_TOKEN';
+const NEXT_PAGE_TOKEN = 'NEXT_PAGE_TOKEN';
+const TIMESTAMP_CREATE = '2012-04-13T02:00:00.000000Z';
+const TIMESTAMP_UPDATE = '2014-10-21T16:00:00.000000Z';
+
 const VALID_DATABASE_RULES = `{
   "rules": {
     // My rules
@@ -64,15 +73,6 @@ const VALID_DATABASE_RULES = `{
     },
   },
 }`;
-
-const PROJECT_RESOURCE_NAME = 'projects/test-project-id';
-const RELEASE_NAME = 'cloud.firestore';
-const RULESET_UUID = '00000000-0000-0000-0000-000000000000';
-const RULESET_NAME = `${PROJECT_RESOURCE_NAME}/rulesets/${RULESET_UUID}`;
-const PAGE_TOKEN = 'PAGE_TOKEN';
-const NEXT_PAGE_TOKEN = 'NEXT_PAGE_TOKEN';
-const TIMESTAMP_CREATE = '2012-04-13T02:00:00.000000Z';
-const TIMESTAMP_UPDATE = '2014-10-21T16:00:00.000000Z';
 
 const VALID_RULES_CONTENT = 'Ruleset file content';
 
@@ -841,8 +841,11 @@ describe('ProjectManagement', () => {
         );
     });
 
-    it('should throw when API response missing "name" field', () => {
-      const partialApiResponse = {};
+    it('should throw when API response missing "rulesetName" field', () => {
+      const partialApiResponse: any = {
+        name: RELEASE_NAME,
+        rulesetName: null,
+      };
 
       const stub = sinon
         .stub(
@@ -856,7 +859,7 @@ describe('ProjectManagement', () => {
         .getRulesRelease(RELEASE_NAME)
         .should.eventually.be.rejected.and.have.property(
           'message',
-          `"name" field must be a non-empty string in getRulesRelease()'s response data. Response data: ` +
+          `"rulesetName" field must be a non-empty string in getRulesRelease()'s response data. Response data: ` +
             JSON.stringify(partialApiResponse, null, 2),
         );
     });

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -114,8 +114,9 @@ const VALID_RULESET_WITH_FILES: RulesetWithFiles = {
 };
 
 const VALID_RELEASE: RulesRelease = {
-  ...VALID_RELEASE_RESPONSE,
   name: RELEASE_NAME,
+  rulesetId: RULESET_UUID,
+  createTime: TIMESTAMP_CREATE,
 };
 
 describe('ProjectManagement', () => {
@@ -788,7 +789,7 @@ describe('ProjectManagement', () => {
 
     it('should resolve with list of releases on success with arguments', () => {
       const filter = { releaseName: 'prod*' };
-      const maxResults = 20;
+      const pageSize = 20;
       const nextPageToken = PAGE_TOKEN;
 
       const validReleaseListResponse: ListRulesReleasesResponse = {
@@ -807,7 +808,7 @@ describe('ProjectManagement', () => {
       stubs.push(stub);
 
       return projectManagement
-        .listRulesReleases(filter, maxResults, nextPageToken)
+        .listRulesReleases(filter, pageSize, nextPageToken)
         .should.eventually.deep.equal(validReleaseListResult);
     });
   });
@@ -1072,7 +1073,7 @@ describe('ProjectManagement', () => {
     });
 
     it('should resolve with list of rulesets on success with arguments', () => {
-      const maxResults = 20;
+      const pageSize = 20;
       const nextPageToken = PAGE_TOKEN;
 
       const validRulesetListResponse: ListRulesetsResponse = {
@@ -1091,7 +1092,7 @@ describe('ProjectManagement', () => {
       stubs.push(stub);
 
       return projectManagement
-        .listRulesets(maxResults, nextPageToken)
+        .listRulesets(pageSize, nextPageToken)
         .should.eventually.deep.equal(validRulesetListResult);
     });
   });

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -876,16 +876,19 @@ describe('ProjectManagement', () => {
     });
   });
 
-  describe('createRulesRelease', () => {
+  const createOrUpdateRelease = (
+    methodName: 'createRulesRelease' | 'updateRulesRelease',
+  ) => {
     it('should propagate API errors', () => {
       const stub = sinon
-        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .stub(FirebaseRulesRequestHandler.prototype, methodName)
         .returns(Promise.reject(EXPECTED_ERROR));
       stubs.push(stub);
 
-      return projectManagement
-        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
-        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+      return projectManagement[methodName](
+        RELEASE_NAME,
+        RULESET_UUID,
+      ).should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
     it('should throw when null API response', () => {
@@ -897,12 +900,13 @@ describe('ProjectManagement', () => {
         .returns(Promise.resolve(null));
       stubs.push(stub);
 
-      return projectManagement
-        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
-        .should.eventually.be.rejected.and.have.property(
-          'message',
-          "createRulesRelease()'s responseData must be a non-null object. Response data: null",
-        );
+      return projectManagement[methodName](
+        RELEASE_NAME,
+        RULESET_UUID,
+      ).should.eventually.be.rejected.and.have.property(
+        'message',
+        `${methodName}()'s responseData must be a non-null object. Response data: null`,
+      );
     });
 
     it('should throw when API response missing "rulesetName" field', () => {
@@ -919,30 +923,36 @@ describe('ProjectManagement', () => {
         .returns(Promise.resolve(partialApiResponse));
       stubs.push(stub);
 
-      return projectManagement
-        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
-        .should.eventually.be.rejected.and.have.property(
-          'message',
-          `"rulesetName" field must be a non-empty string in createRulesRelease()'s response data. Response data: ` +
-            JSON.stringify(partialApiResponse, null, 2),
-        );
+      return projectManagement[methodName](
+        RELEASE_NAME,
+        RULESET_UUID,
+      ).should.eventually.be.rejected.and.have.property(
+        'message',
+        `"rulesetName" field must be a non-empty string in ${methodName}()'s response data. Response data: ` +
+          JSON.stringify(partialApiResponse, null, 2),
+      );
     });
 
     it('should resolve with release object on successs', () => {
       const stub = sinon
-        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .stub(FirebaseRulesRequestHandler.prototype, methodName)
         .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
       stubs.push(stub);
 
-      return projectManagement
-        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
-        .should.eventually.deep.equal(VALID_RELEASE);
+      return projectManagement[methodName](
+        RELEASE_NAME,
+        RULESET_UUID,
+      ).should.eventually.deep.equal(VALID_RELEASE);
     });
+  };
+
+  describe('createRulesRelease', () => {
+    return createOrUpdateRelease('createRulesRelease');
   });
 
-  // describe('updateRulesRelease', () => {
-
-  // });
+  describe('updateRulesRelease', () => {
+    return createOrUpdateRelease('updateRulesRelease');
+  });
 
   // describe('deleteRulesRelease', () => {
 

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -26,7 +26,7 @@ import { ProjectManagementRequestHandler } from '../../../src/project-management
 import { FirebaseProjectManagementError } from '../../../src/utils/error';
 import * as mocks from '../../resources/mocks';
 import { IosApp } from '../../../src/project-management/ios-app';
-import { DatabaseRequestHandler } from '../../../src/project-management/database-api-request';
+// import { DatabaseRequestHandler } from '../../../src/project-management/database-api-request';
 
 const expect = chai.expect;
 
@@ -393,55 +393,55 @@ describe('ProjectManagement', () => {
     });
   });
 
-  describe('getDatabaseRules', () => {
-    it('should propagate API errors', () => {
-      const stub = sinon
-          .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-          .returns(Promise.reject(EXPECTED_ERROR));
-      stubs.push(stub);
-      return projectManagement.getDatabaseRules()
-          .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
-    });
+  // describe('getDatabaseRules', () => {
+  //   it('should propagate API errors', () => {
+  //     const stub = sinon
+  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
+  //         .returns(Promise.reject(EXPECTED_ERROR));
+  //     stubs.push(stub);
+  //     return projectManagement.getDatabaseRules()
+  //         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+  //   });
 
-    it('should throw with non-empty API response', () => {
-      const stub = sinon
-          .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-          .returns(Promise.resolve(''));
-      stubs.push(stub);
-      return projectManagement.getDatabaseRules()
-          .should.eventually.be.rejected
-          .and.have.property(
-              'message',
-              "getDatabaseRules()'s response must be a non-empty string.");
-    });
+  //   it('should throw with non-empty API response', () => {
+  //     const stub = sinon
+  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
+  //         .returns(Promise.resolve(''));
+  //     stubs.push(stub);
+  //     return projectManagement.getDatabaseRules()
+  //         .should.eventually.be.rejected
+  //         .and.have.property(
+  //             'message',
+  //             "getDatabaseRules()'s response must be a non-empty string.");
+  //   });
 
-    it('should resolve with database rules string on success', () => {
-      const stub = sinon
-          .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-          .returns(Promise.resolve(VALID_DATABASE_RULES));
-      stubs.push(stub);
-      return projectManagement.getDatabaseRules()
-          .should.eventually.equal(VALID_DATABASE_RULES);
-    });
-  });
+  //   it('should resolve with database rules string on success', () => {
+  //     const stub = sinon
+  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
+  //         .returns(Promise.resolve(VALID_DATABASE_RULES));
+  //     stubs.push(stub);
+  //     return projectManagement.getDatabaseRules()
+  //         .should.eventually.equal(VALID_DATABASE_RULES);
+  //   });
+  // });
 
-  describe('setDatabaseRules', () => {
-    it('should propagate API errors', () => {
-      const stub = sinon
-          .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
-          .returns(Promise.reject(EXPECTED_ERROR));
-      stubs.push(stub);
-      return projectManagement.setDatabaseRules('')
-          .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
-    });
+  // describe('setDatabaseRules', () => {
+  //   it('should propagate API errors', () => {
+  //     const stub = sinon
+  //         .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
+  //         .returns(Promise.reject(EXPECTED_ERROR));
+  //     stubs.push(stub);
+  //     return projectManagement.setDatabaseRules('')
+  //         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+  //   });
 
-    it('should resolve with undefined on success', () => {
-      const stub = sinon
-          .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
-          .returns(Promise.resolve(undefined));
-      stubs.push(stub);
-      return projectManagement.setDatabaseRules(VALID_DATABASE_RULES)
-          .should.eventually.be.undefined;
-    });
-  });
+  //   it('should resolve with undefined on success', () => {
+  //     const stub = sinon
+  //         .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
+  //         .returns(Promise.resolve(undefined));
+  //     stubs.push(stub);
+  //     return projectManagement.setDatabaseRules(VALID_DATABASE_RULES)
+  //         .should.eventually.be.undefined;
+  //   });
+  // });
 });

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -954,9 +954,29 @@ describe('ProjectManagement', () => {
     return createOrUpdateRelease('updateRulesRelease');
   });
 
-  // describe('deleteRulesRelease', () => {
+  describe('deleteRulesRelease', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'deleteRulesRelease')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .deleteRulesRelease(RELEASE_NAME)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should resolve with void on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'deleteRulesRelease')
+        .returns(Promise.resolve(undefined));
+      stubs.push(stub);
+
+      return projectManagement
+        .deleteRulesRelease(RELEASE_NAME)
+        .should.eventually.equal(undefined);
+    });
+  });
 
   describe('listRulesets', () => {
     it('should propagate API errors', () => {
@@ -1158,8 +1178,27 @@ describe('ProjectManagement', () => {
     });
   });
 
-  // describe('deleteRuleset', () => {
+  describe('deleteRuleset', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'deleteRuleset')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .deleteRuleset(RULESET_UUID)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
 
+    it('should resolve with void on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'deleteRuleset')
+        .returns(Promise.resolve(undefined));
+      stubs.push(stub);
+
+      return projectManagement
+        .deleteRuleset(RULESET_UUID)
+        .should.eventually.equal(undefined);
+    });
+  });
 });

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -462,34 +462,6 @@ describe('ProjectManagement', () => {
         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    // TODO: these 2 test shoudl be in the request handler spec
-
-    // it('should throw with empty RTDB API response', () => {
-    //   const stub = sinon
-    //     .stub(DatabaseRequestHandler.prototype, 'getRules')
-    //     .returns(Promise.resolve(''));
-    //   stubs.push(stub);
-    //   return projectManagement
-    //     .getRules('database')
-    //     .should.eventually.be.rejected.and.have.property(
-    //       'message',
-    //       "getRules()'s response must be a non-empty string.",
-    //     );
-    // });
-
-    // it('should throw with empty Rules API response', () => {
-    //   const stub = sinon
-    //     .stub(FirebaseRulesRequestHandler.prototype, 'getRulesRelease')
-    //     .returns(Promise.resolve(''));
-    //   stubs.push(stub);
-    //   return projectManagement
-    //     .getRules('firestore')
-    //     .should.eventually.be.rejected.and.have.property(
-    //       'message',
-    //       "getRulesRelease()'s responseData must be a non-null object.",
-    //     );
-    // });
-
     it('should resolve with RTDB rules string on success', () => {
       const stub = sinon
         .stub(DatabaseRequestHandler.prototype, 'getRules')
@@ -569,96 +541,61 @@ describe('ProjectManagement', () => {
         .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
       stubs.push(stubCreate);
 
-      return projectManagement.setRules('firestore', '').then((result) => {
+      return projectManagement.setRules('firestore', '').then(() => {
         // tslint:disable-next-line: no-unused-expression
         expect(stubCreate).to.have.been.calledOnce;
       });
     });
 
-    // TODO: finish
+    it('should resolve with void on success for RTDB rules', () => {
+      const stub = sinon
+        .stub(DatabaseRequestHandler.prototype, 'setRules')
+        .returns(Promise.resolve(undefined));
+      stubs.push(stub);
+      return projectManagement.setRules('database', VALID_DATABASE_RULES)
+        .should.eventually.equal(undefined);
+    });
 
-    // it('should resolve with RTDB rules string on success', () => {
-    //   const stub = sinon
-    //     .stub(DatabaseRequestHandler.prototype, 'setRules')
-    //     .returns(Promise.resolve(VALID_DATABASE_RULES));
-    //   stubs.push(stub);
-    //   return projectManagement
-    //     .setRules('database')
-    //     .should.eventually.equal(VALID_DATABASE_RULES);
-    // });
+    it('should resolve with void on success for Firestore rules', () => {
+      const stubRuleset = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRuleset')
+        .returns(Promise.resolve(VALID_RULESET_WITH_FILES_RESPONSE));
+      stubs.push(stubRuleset);
 
-    // const successfulRules = (service: RulesService) => {
-    //   const stub1 = sinon
-    //     .stub(FirebaseRulesRequestHandler.prototype, 'setRulesRelease')
-    //     .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
-    //   stubs.push(stub1);
+      const stubUpdate = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'updateRulesRelease')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stubUpdate);
 
-    //   const stub2 = sinon
-    //     .stub(FirebaseRulesRequestHandler.prototype, 'setRuleset')
-    //     .returns(Promise.resolve(VALID_RULESET_WITH_FILES_RESPONSE));
-    //   stubs.push(stub2);
+      const stubCreate = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
+      stubs.push(stubCreate);
 
-    //   return projectManagement
-    //     .setRules(service)
-    //     .should.eventually.equal(VALID_RULES_CONTENT);
-    // };
+      return projectManagement
+        .setRules('firestore', VALID_RULES_CONTENT)
+        .should.eventually.equal(undefined);
+    });
 
-    // it('should resolve with Firestore rules string on success', () =>
-    //   successfulRules('firestore'));
+    it('should resolve with void on success for Storage rules', () => {
+      const stubRuleset = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRuleset')
+        .returns(Promise.resolve(VALID_RULESET_WITH_FILES_RESPONSE));
+      stubs.push(stubRuleset);
 
-    // it('should resolve with Storage rules string on success', () =>
-    //   successfulRules('storage'));
+      const stubUpdate = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'updateRulesRelease')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stubUpdate);
+
+      const stubCreate = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
+      stubs.push(stubCreate);
+
+      return projectManagement
+        .setRules('storage', VALID_RULES_CONTENT)
+        .should.eventually.equal(undefined);
+    });
   });
-
-  // describe('getDatabaseRules', () => {
-  //   it('should propagate API errors', () => {
-  //     const stub = sinon
-  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-  //         .returns(Promise.reject(EXPECTED_ERROR));
-  //     stubs.push(stub);
-  //     return projectManagement.getDatabaseRules()
-  //         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
-  //   });
-
-  //   it('should throw with non-empty API response', () => {
-  //     const stub = sinon
-  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-  //         .returns(Promise.resolve(''));
-  //     stubs.push(stub);
-  //     return projectManagement.getDatabaseRules()
-  //         .should.eventually.be.rejected
-  //         .and.have.property(
-  //             'message',
-  //             "getDatabaseRules()'s response must be a non-empty string.");
-  //   });
-
-  //   it('should resolve with database rules string on success', () => {
-  //     const stub = sinon
-  //         .stub(DatabaseRequestHandler.prototype, 'getDatabaseRules')
-  //         .returns(Promise.resolve(VALID_DATABASE_RULES));
-  //     stubs.push(stub);
-  //     return projectManagement.getDatabaseRules()
-  //         .should.eventually.equal(VALID_DATABASE_RULES);
-  //   });
-  // });
-
-  // describe('setDatabaseRules', () => {
-  //   it('should propagate API errors', () => {
-  //     const stub = sinon
-  //         .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
-  //         .returns(Promise.reject(EXPECTED_ERROR));
-  //     stubs.push(stub);
-  //     return projectManagement.setDatabaseRules('')
-  //         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
-  //   });
-
-  //   it('should resolve with undefined on success', () => {
-  //     const stub = sinon
-  //         .stub(DatabaseRequestHandler.prototype, 'setDatabaseRules')
-  //         .returns(Promise.resolve(undefined));
-  //     stubs.push(stub);
-  //     return projectManagement.setDatabaseRules(VALID_DATABASE_RULES)
-  //         .should.eventually.be.undefined;
-  //   });
-  // });
 });

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -876,9 +876,69 @@ describe('ProjectManagement', () => {
     });
   });
 
-  // describe('createRulesRelease', () => {
+  describe('createRulesRelease', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should throw when null API response', () => {
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(null));
+      stubs.push(stub);
+
+      return projectManagement
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          "createRulesRelease()'s responseData must be a non-null object. Response data: null",
+        );
+    });
+
+    it('should throw when API response missing "rulesetName" field', () => {
+      const partialApiResponse: any = {
+        name: RELEASE_NAME,
+        rulesetName: null,
+      };
+
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(partialApiResponse));
+      stubs.push(stub);
+
+      return projectManagement
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          `"rulesetName" field must be a non-empty string in createRulesRelease()'s response data. Response data: ` +
+            JSON.stringify(partialApiResponse, null, 2),
+        );
+    });
+
+    it('should resolve with release object on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRulesRelease')
+        .returns(Promise.resolve(VALID_RELEASE_RESPONSE));
+      stubs.push(stub);
+
+      return projectManagement
+        .createRulesRelease(RELEASE_NAME, RULESET_UUID)
+        .should.eventually.deep.equal(VALID_RELEASE);
+    });
+  });
 
   // describe('updateRulesRelease', () => {
 

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -87,6 +87,7 @@ const VALID_RELEASE_RESPONSE: RulesReleaseResponse = {
   name: `${PROJECT_RESOURCE_NAME}/releases/${RELEASE_NAME}`,
   rulesetName: RULESET_NAME,
   createTime: TIMESTAMP_CREATE,
+  updateTime: TIMESTAMP_UPDATE,
 };
 
 const VALID_RULESET_RESPONSE: RulesetResponse = {
@@ -117,6 +118,7 @@ const VALID_RELEASE: RulesRelease = {
   name: RELEASE_NAME,
   rulesetId: RULESET_UUID,
   createTime: TIMESTAMP_CREATE,
+  updateTime: TIMESTAMP_UPDATE,
 };
 
 describe('ProjectManagement', () => {

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -43,6 +43,7 @@ import {
   RulesRelease,
   ListRulesetsResult,
   Ruleset,
+  RulesetWithFiles,
 } from '../../../src/project-management/rules';
 
 const expect = chai.expect;
@@ -94,8 +95,8 @@ const VALID_RULESET_RESPONSE: RulesetResponse = {
 };
 
 const VALID_RULESET: Ruleset = {
-  createTime: VALID_RULESET_RESPONSE.createTime,
   id: RULESET_UUID,
+  createTime: VALID_RULESET_RESPONSE.createTime,
 };
 
 const VALID_RULESET_WITH_FILES_RESPONSE: RulesetWithFilesResponse = {
@@ -104,6 +105,12 @@ const VALID_RULESET_WITH_FILES_RESPONSE: RulesetWithFilesResponse = {
   source: {
     files: VALID_RULESET_FILES,
   },
+};
+
+const VALID_RULESET_WITH_FILES: RulesetWithFiles = {
+  id: RULESET_UUID,
+  createTime: VALID_RULESET_RESPONSE.createTime,
+  files: VALID_RULESET_FILES,
 };
 
 const VALID_RELEASE: RulesRelease = {
@@ -190,7 +197,7 @@ describe('ProjectManagement', () => {
           .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw with null API response', () => {
+    it('should throw when null API response', () => {
       const stub = sinon
           .stub(ProjectManagementRequestHandler.prototype, 'listAndroidApps')
           .returns(Promise.resolve(null));
@@ -274,7 +281,7 @@ describe('ProjectManagement', () => {
           .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw with null API response', () => {
+    it('should throw when null API response', () => {
       const stub = sinon
           .stub(ProjectManagementRequestHandler.prototype, 'listIosApps')
           .returns(Promise.resolve(null));
@@ -702,7 +709,7 @@ describe('ProjectManagement', () => {
         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw with null API response', () => {
+    it('should throw when null API response', () => {
       const stub = sinon
         .stub(
           FirebaseRulesRequestHandler.prototype as any,
@@ -817,7 +824,7 @@ describe('ProjectManagement', () => {
         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw with null API response', () => {
+    it('should throw when null API response', () => {
       const stub = sinon
         .stub(
           FirebaseRulesRequestHandler.prototype as any,
@@ -890,7 +897,7 @@ describe('ProjectManagement', () => {
         .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw with null API response', () => {
+    it('should throw when null API response', () => {
       const stub = sinon
         .stub(
           FirebaseRulesRequestHandler.prototype as any,
@@ -996,9 +1003,46 @@ describe('ProjectManagement', () => {
     });
   });
 
-  // describe('getRuleset', () => {
+  describe('getRuleset', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'getRuleset')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .getRuleset(RULESET_UUID)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should throw when null API response', () => {
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(null));
+      stubs.push(stub);
+
+      return projectManagement
+        .getRuleset(RULESET_UUID)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          "getRuleset()'s responseData must be a non-null object. Response data: null",
+        );
+    });
+
+    it('should resolve with ruleset object on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'getRuleset')
+        .returns(Promise.resolve(VALID_RULESET_WITH_FILES_RESPONSE));
+      stubs.push(stub);
+
+      return projectManagement
+        .getRuleset(RULESET_UUID)
+        .should.eventually.deep.equal(VALID_RULESET_WITH_FILES);
+    });
+  });
 
   // describe('createRuleset', () => {
 

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -1107,9 +1107,46 @@ describe('ProjectManagement', () => {
     });
   });
 
-  // describe('createRuleset', () => {
+  describe('createRuleset', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRuleset')
+        .returns(Promise.reject(EXPECTED_ERROR));
+      stubs.push(stub);
 
-  // });
+      return projectManagement
+        .createRuleset(VALID_RULESET_FILES)
+        .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should throw when null API response', () => {
+      const stub = sinon
+        .stub(
+          FirebaseRulesRequestHandler.prototype as any,
+          'invokeRequestHandler',
+        )
+        .returns(Promise.resolve(null));
+      stubs.push(stub);
+
+      return projectManagement
+        .createRuleset(VALID_RULESET_FILES)
+        .should.eventually.be.rejected.and.have.property(
+          'message',
+          "createRuleset()'s responseData must be a non-null object. Response data: null",
+        );
+    });
+
+    it('should resolve with ruleset object on successs', () => {
+      const stub = sinon
+        .stub(FirebaseRulesRequestHandler.prototype, 'createRuleset')
+        .returns(Promise.resolve(VALID_RULESET_WITH_FILES_RESPONSE));
+      stubs.push(stub);
+
+      return projectManagement
+        .createRuleset(VALID_RULESET_FILES)
+        .should.eventually.deep.equal(VALID_RULESET_WITH_FILES);
+    });
+  });
 
   // describe('deleteRuleset', () => {
 

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -198,7 +198,7 @@ describe('ProjectManagement', () => {
           .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw when null API response', () => {
+    it('should throw with null API response', () => {
       const stub = sinon
           .stub(ProjectManagementRequestHandler.prototype, 'listAndroidApps')
           .returns(Promise.resolve(null));
@@ -282,7 +282,7 @@ describe('ProjectManagement', () => {
           .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
     });
 
-    it('should throw when null API response', () => {
+    it('should throw with null API response', () => {
       const stub = sinon
           .stub(ProjectManagementRequestHandler.prototype, 'listIosApps')
           .returns(Promise.resolve(null));


### PR DESCRIPTION
### Discussion

See this issue: https://github.com/firebase/firebase-admin-node/issues/504

### Testing

:heavy_check_mark: All existing tests keep passing.
:heavy_check_mark: Added the necessary tests (unit and integration) for the new features.

### API Changes

As discussed in the linked issue, these new types and methods are introduced to the `admin.projectManagement` namespace:

```ts
type RulesService = 'firestore' | 'storage' | 'database';

interface Ruleset {
  /**
   * The UUID of the ruleset.
   */
  id: string;

  /**
   * Timestamp in ISO 8601 format.
   */
  createTime: string;
}

interface RulesetWithFiles extends Ruleset {
  /**
   * Array of ruleset files.
   */
  files: RulesetFile[];
}

interface RulesetFile {
  /**
   * Name of the file.
   */
  name: string;

  /**
   * The content of the file (the actual rules).
   */
  content: string;
}

/**
 * Possible filters when listing releases. All optional and can be combined.
 */
interface ListRulesReleasesFilter {
  releaseName?: string;
  rulesetName?: string;
  testSuiteName?: string;
}

/**
 * The result of listing rules releases.
 */
interface ListRulesReleasesResult {
  releases: RulesRelease[];
  pageToken?: string;
}

interface RulesRelease {
  /**
   * The name of the release.
   * This will usually be either `firebase.storage` or `cloud.firestore`.
   */
  name: string;

  /**
   * ID of the ruleset associated with the release.
   */
  rulesetId: string;

  /**
   * Timestamp in ISO 8601 format.
   */
  createTime: string;

  /**
   * Timestamp in ISO 8601 format.
   */
  updateTime: string;
}

/**
 * The result of listing rulesets.
 */
interface ListRulesetsResult {
  rulesets: Ruleset[];
  pageToken?: string;
}

interface ProjectManagement {
  /**
   * Gets the current rules for the service:
   *   - For RTDB that's whatever `.settings/rules.json` returns.
   *   - For Firestore/Storage it's the contents of the ruleset for the release
   *     associated with that service.
   */
  getRules(service: admin.projectManagement.RulesService): Promise<string>;

  /**
   * Sets the new rules to be used with the service:
   *   - For RTDB it PUTs them to `.settings/rules.json`.
   *   - For Firestore/Storage it creates a new ruleset with the specified
   *     content and updates/creates the appropriate release for the
   *     service with that ruleset.
   */
  setRules(
    service: admin.projectManagement.RulesService,
    content: string,
  ): Promise<void>;

  /**
   * Like `setRules()` but reads the rules content from a file.
   */
  setRulesFromFile(
    service: admin.projectManagement.RulesService,
    filePath: string,
  ): Promise<void>;

  /**
   * Gets the list of rules releases for the project.
   *
   * It optionally accepts an object specifying filters to use.
   *
   * The maximum number of rulesets to return is determined by the optional
   * `pageSize` argument. Defaults to 10, maximum is 100 (according to API docs).
   */
  listRulesReleases(
    filter?: admin.projectManagement.ListRulesReleasesFilter,
    pageSize?: number,
    pageToken?: string,
  ): Promise<admin.projectManagement.ListRulesReleasesResult>;

  /**
   * Gets the given rules release.
   */
  getRulesRelease(
    name: string,
  ): Promise<admin.projectManagement.RulesRelease>;

  /**
   * Creates a new rules release with the given name and associated to
   * the given ruleset name.
   */
  createRulesRelease(
    name: string,
    rulesetId: string,
  ): Promise<admin.projectManagement.RulesRelease>;

  /**
   * Updates the ruleset name associated with an existing rules release.
   */
  updateRulesRelease(
    name: string,
    rulesetId: string,
  ): Promise<admin.projectManagement.RulesRelease>;

  /**
   * Deletes the given rules release.
   */
  deleteRulesRelease(name: string): Promise<void>;

  /**
   * Gets the list of rulesets for the project. The Rulesets only contain
   * metadata (`name` and `createTime`), not the actual files.
   *
   * The maximum number of rulesets to return is determined by the optional
   * `pageSize` argument. Defaults to 10, maximum is 100 (according to API docs).
   *
   * It optionally accepts a pageToken returned from a previous call, in order
   * to get the next set of results if there's more.
   */
  listRulesets(
    pageSize?: number,
    pageToken?: string,
  ): Promise<admin.projectManagement.ListRulesetsResult>;

  /**
   * Gets the ruleset by its id. The returned Ruleset contains its files.
   */
  getRuleset(
    rulesetId: string,
  ): Promise<admin.projectManagement.RulesetWithFiles>;

  /**
   * Creates a new ruleset with the given files.
   */
  createRuleset(
    files: RulesetFile[],
  ): Promise<admin.projectManagement.RulesetWithFiles>;

  /**
   * Deletes the given rules ruleset.
   */
  deleteRuleset(rulesetId: string): Promise<void>;
}
```