### PR TITLE
Documentation update (Node 6 deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 6.0 and higher. Please note that the Admin SDK should only
+We support Node.js 6 and higher. However, we recommend developers to use
+at least Node.js 8. Support for Node.js 6 is currently deprecated and
+will be discontinued in the future.
+
+Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.
 This includes most server and serverless platforms (both on-premise and in
 the cloud). It is not recommended to use the Admin SDK in client-side


### PR DESCRIPTION
Recommending developers to use Node 8+.