### PR TITLE
Internal API for retrying HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 6.0 and higher. Please note that the Admin SDK should only
+We support Node.js 6 and higher. However, we recommend developers to use
+at least Node.js 8. Support for Node.js 6 is currently deprecated and
+will be discontinued in the future.
+
+Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.
 This includes most server and serverless platforms (both on-premise and in
 the cloud). It is not recommended to use the Admin SDK in client-side

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -173,16 +173,16 @@ export interface RetryConfig {
   /** Maximum number of times to retry a given request. */
   maxRetries: number;
 
-  /** HTTP status codes taht should be retried. */
+  /** HTTP status codes that should be retried. */
   statusCodes?: number[];
 
   /** Low-level I/O error codes that should be retried. */
   ioErrorCodes?: string[];
 
   /**
-   * The multiplier for exponential back off. The retry delay is calculated using the formula `(2^n) * backOffFactor`,
-   * where n is the number of retries performed so far. When the backOffFactor is set to 0 retries are not delayed.
-   * When the backOffFactor is 1, retry duration is doubled each iteration.
+   * The multiplier for exponential back off. The retry delay is calculated in seconds using the formula
+   * `(2^n) * backOffFactor`, where n is the number of retries performed so far. When the backOffFactor is set
+   * to 0, retries are not delayed. When the backOffFactor is 1, retry duration is doubled each iteration.
    */
   backOffFactor?: number;
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -321,6 +321,7 @@ export class FirebaseProjectManagementError extends PrefixedFirebaseError {
 export class AppErrorCodes {
   public static APP_DELETED = 'app-deleted';
   public static DUPLICATE_APP = 'duplicate-app';
+  public static INVALID_ARGUMENT = 'invalid-argument';
   public static INTERNAL_ERROR = 'internal-error';
   public static INVALID_APP_NAME = 'invalid-app-name';
   public static INVALID_APP_OPTIONS = 'invalid-app-options';

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -27,7 +27,8 @@ import * as mocks from '../../resources/mocks';
 
 import {FirebaseApp} from '../../../src/firebase-app';
 import {
-  ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig, parseHttpResponse,
+  ApiSettings, HttpClient, HttpError, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig,
+  HttpResponse, parseHttpResponse,
 } from '../../../src/utils/api-request';
 import { deepCopy } from '../../../src/utils/deep-copy';
 import {Agent} from 'http';
@@ -94,6 +95,7 @@ function mockRequestWithError(err: any) {
 describe('HttpClient', () => {
   let mockedRequests: nock.Scope[] = [];
   let transportSpy: sinon.SinonSpy = null;
+  let delayStub: sinon.SinonStub = null;
 
   const sampleMultipartData = '--boundary\r\n'
       + 'Content-type: application/json\r\n\r\n'
@@ -110,6 +112,18 @@ describe('HttpClient', () => {
       transportSpy.restore();
       transportSpy = null;
     }
+    if (delayStub) {
+      delayStub.restore();
+      delayStub = null;
+    }
+  });
+
+  ['string', null, undefined, {}, true, false, NaN, -1].forEach((maxRetries: any) => {
+    it(`should throw when maxRetries is: ${maxRetries}`, () => {
+      expect(() => {
+        new HttpClient({maxRetries} as any);
+      }).to.throw('maxRetries must be a non-negative integer');
+    });
   });
 
   it('should be fulfilled for a 2xx response with a json payload', () => {
@@ -633,6 +647,393 @@ describe('HttpClient', () => {
     }).then((resp) => {
       expect(resp.status).to.equal(200);
       expect(resp.data).to.deep.equal(respData);
+    });
+  });
+
+  it('should not retry when RetryConfig is not set', () => {
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 1', code: 'ECONNRESET'}));
+    const client = new HttpClient(null);
+    const err = 'Error while making request: connection reset 1';
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).should.eventually.be.rejectedWith(err).and.have.property('code', 'app/network-error');
+  });
+
+  it('should not retry when maxRetries is set to 0', () => {
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 1', code: 'ECONNRESET'}));
+    const client = new HttpClient({
+      maxRetries: 0,
+      ioErrorCodes: ['ECONNRESET'],
+      maxDelayInMillis: 10000,
+    });
+    const err = 'Error while making request: connection reset 1';
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).should.eventually.be.rejectedWith(err).and.have.property('code', 'app/network-error');
+  });
+
+  it('should not retry when for error codes that are not configured', () => {
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 1', code: 'ECONNRESET'}));
+    const client = new HttpClient({
+      maxRetries: 1,
+      maxDelayInMillis: 10000,
+    });
+    const err = 'Error while making request: connection reset 1';
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).should.eventually.be.rejectedWith(err).and.have.property('code', 'app/network-error');
+  });
+
+  it('should succeed after a retry on a configured I/O error', () => {
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 1', code: 'ETESTCODE'}));
+    const respData = {foo: 'bar'};
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient({
+      maxRetries: 1,
+      maxDelayInMillis: 1000,
+      ioErrorCodes: ['ETESTCODE'],
+    });
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.data).to.deep.equal(respData);
+    });
+  });
+
+  it('should succeed after a retry on a configured HTTP error', () => {
+    const scope1 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope1);
+    const respData = {foo: 'bar'};
+    const scope2 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope2);
+    const client = new HttpClient({
+      maxRetries: 1,
+      maxDelayInMillis: 1000,
+      statusCodes: [503],
+    });
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.data).to.deep.equal(respData);
+    });
+  });
+
+  it('should not retry more than maxRetries', () => {
+    // simulate 2 low-level errors
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 1', code: 'ECONNRESET'}));
+    mockedRequests.push(mockRequestWithError({message: 'connection reset 2', code: 'ECONNRESET'}));
+
+    // followed by 3 HTTP errors
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .times(3)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+
+    const client = new HttpClient({
+      maxRetries: 4,
+      maxDelayInMillis: 10 * 1000,
+      ioErrorCodes: ['ECONNRESET'],
+      statusCodes: [503],
+    });
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).catch((err: HttpError) => {
+      expect(err.message).to.equal('Server responded with status 503.');
+      const resp = err.response;
+      expect(resp.status).to.equal(503);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal({});
+      expect(resp.isJson()).to.be.true;
+    });
+  });
+
+  it('should not retry when retry-after exceeds maxDelayInMillis', () => {
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+        'retry-after': '61',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient({
+      maxRetries: 1,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).catch((err: HttpError) => {
+      expect(err.message).to.equal('Server responded with status 503.');
+      const resp = err.response;
+      expect(resp.status).to.equal(503);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal({});
+      expect(resp.isJson()).to.be.true;
+    });
+  });
+
+  it('should retry with exponential back off', () => {
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .times(5)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 0.5,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).catch((err: HttpError) => {
+      expect(err.message).to.equal('Server responded with status 503.');
+      const resp = err.response;
+      expect(resp.status).to.equal(503);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal({});
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(4);
+      const delays = delayStub.args.map((args) => args[0]);
+      expect(delays).to.deep.equal([0, 1000, 2000, 4000]);
+    });
+  });
+
+  it('delay should not exceed maxDelayInMillis', () => {
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .times(5)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 1,
+      maxDelayInMillis: 4 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).catch((err: HttpError) => {
+      expect(err.message).to.equal('Server responded with status 503.');
+      const resp = err.response;
+      expect(resp.status).to.equal(503);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal({});
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(4);
+      const delays = delayStub.args.map((args) => args[0]);
+      expect(delays).to.deep.equal([0, 2000, 4000, 4000]);
+    });
+  });
+
+  it('should retry without delays when backOffFactor is not set', () => {
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .times(5)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient({
+      maxRetries: 4,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).catch((err: HttpError) => {
+      expect(err.message).to.equal('Server responded with status 503.');
+      const resp = err.response;
+      expect(resp.status).to.equal(503);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal({});
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(4);
+      const delays = delayStub.args.map((args) => args[0]);
+      expect(delays).to.deep.equal([0, 0, 0, 0]);
+    });
+  });
+
+  it('should wait when retry-after expressed as seconds', () => {
+    const scope1 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+        'retry-after': '30',
+      });
+    mockedRequests.push(scope1);
+    const respData = {foo: 'bar'};
+    const scope2 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope2);
+
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 0.5,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp: HttpResponse) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(1);
+      expect(delayStub.args[0][0]).to.equal(30 * 1000);
+    });
+  });
+
+  it('should wait when retry-after expressed as a timestamp', () => {
+    const timestamp = new Date(Date.now() + 30 * 1000);
+
+    const scope1 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+        'retry-after': timestamp.toUTCString(),
+      });
+    mockedRequests.push(scope1);
+    const respData = {foo: 'bar'};
+    const scope2 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope2);
+
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 0.5,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp: HttpResponse) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(1);
+      expect(delayStub.args[0][0]).to.be.gt(27 * 1000).and.to.be.lte(30 * 1000);
+    });
+  });
+
+  it('should not wait when retry-after timestamp is expired', () => {
+    const timestamp = new Date(Date.now() - 30 * 1000);
+
+    const scope1 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+        'retry-after': timestamp.toUTCString(),
+      });
+    mockedRequests.push(scope1);
+    const respData = {foo: 'bar'};
+    const scope2 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope2);
+
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 0.5,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp: HttpResponse) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(1);
+      expect(delayStub.args[0][0]).to.equal(0);
+    });
+  });
+
+  it('should not wait when retry-after is malformed', () => {
+    const scope1 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(503, {}, {
+        'content-type': 'application/json',
+        'retry-after': 'invalid',
+      });
+    mockedRequests.push(scope1);
+    const respData = {foo: 'bar'};
+    const scope2 = nock('https://' + mockHost)
+      .get(mockPath)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope2);
+
+    const client = new HttpClient({
+      maxRetries: 4,
+      backOffFactor: 0.5,
+      maxDelayInMillis: 60 * 1000,
+      statusCodes: [503],
+    });
+    delayStub = sinon.stub(client as any, 'waitForRetry').resolves();
+    return client.send({
+      method: 'GET',
+      url: mockUrl,
+    }).then((resp: HttpResponse) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson()).to.be.true;
+      expect(delayStub.callCount).to.equal(1);
+      expect(delayStub.args[0][0]).to.equal(0);
     });
   });
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -118,11 +118,48 @@ describe('HttpClient', () => {
     }
   });
 
-  ['string', null, undefined, {}, true, false, NaN, -1].forEach((maxRetries: any) => {
+  const invalidNumbers: any[] = ['string', null, undefined, {}, [], true, false, NaN, -1];
+  const invalidArrays: any[] = ['string', null, {}, true, false, NaN, 0, 1];
+
+  invalidNumbers.forEach((maxRetries: any) => {
     it(`should throw when maxRetries is: ${maxRetries}`, () => {
       expect(() => {
         new HttpClient({maxRetries} as any);
       }).to.throw('maxRetries must be a non-negative integer');
+    });
+  });
+
+  invalidNumbers.forEach((backOffFactor: any) => {
+    if (typeof backOffFactor !== 'undefined') {
+      it(`should throw when backOffFactor is: ${backOffFactor}`, () => {
+        expect(() => {
+          new HttpClient({maxRetries: 1, backOffFactor} as any);
+        }).to.throw('backOffFactor must be a non-negative number');
+      });
+    }
+  });
+
+  invalidNumbers.forEach((maxDelayInMillis: any) => {
+    it(`should throw when maxDelayInMillis is: ${maxDelayInMillis}`, () => {
+      expect(() => {
+        new HttpClient({maxRetries: 1, maxDelayInMillis} as any);
+      }).to.throw('maxDelayInMillis must be a non-negative integer');
+    });
+  });
+
+  invalidArrays.forEach((ioErrorCodes: any) => {
+    it(`should throw when ioErrorCodes is: ${ioErrorCodes}`, () => {
+      expect(() => {
+        new HttpClient({maxRetries: 1, maxDelayInMillis: 10000, ioErrorCodes} as any);
+      }).to.throw('ioErrorCodes must be an array');
+    });
+  });
+
+  invalidArrays.forEach((statusCodes: any) => {
+    it(`should throw when statusCodes is: ${statusCodes}`, () => {
+      expect(() => {
+        new HttpClient({maxRetries: 1, maxDelayInMillis: 10000, statusCodes} as any);
+      }).to.throw('statusCodes must be an array');
     });
   });
 


### PR DESCRIPTION
The existing `HttpClient` retries all HTTP requests once that are failing due to connection timeout and reset errors. We would like to further extend this retries support to meet the following new requirements:

1. Ability to retry requests on specific HTTP error codes (e.g. 503)
2. Ability to delay subsequent retries according to the `Retry-After` header sent by the server
3. Ability to use exponential backoff
4. Ability to configure retries for individual services in the SDK

In order to meet all the above requirements, this PR introduces a new internal interface called `RetryConfig`. The `HttpClient` optionally takes a `RetryConfig` as a constructor parameter, and retries failing requests based on that. 

For the moment, we use the following as the default `RetryConfig` in order to retain the existing behavior:

```
const DEFAULT_RETRY_CONFIG: RetryConfig = {
  maxRetries: 1,
  ioErrorCodes: ['ECONNRESET', 'ETIMEDOUT'],
  maxDelayInMillis: 60 * 1000,
};
```

We can change this to something more sophisticated in the future (in other Admin SDKs we retry up to 4 times, and also retry on 500 and 503 HTTP errors).