### PR TITLE
 Special handling logic for enum docs

### DIFF
--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -167,6 +167,8 @@ toc:
     path: /docs/reference/admin/node/admin.projectManagement.AndroidAppMetadata
   - title: "AppMetadata"
     path: /docs/reference/admin/node/admin.projectManagement.AppMetadata
+  - title: "AppPlatform"
+    path: /docs/reference/admin/node/admin.projectManagement.AppPlatform
   - title: "IosApp"
     path: /docs/reference/admin/node/admin.projectManagement.IosApp
   - title: "IosAppMetadata"

--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -165,6 +165,8 @@ toc:
     path: /docs/reference/admin/node/admin.projectManagement.AndroidApp
   - title: "AndroidAppMetadata"
     path: /docs/reference/admin/node/admin.projectManagement.AndroidAppMetadata
+  - title: "AppMetadata"
+    path: /docs/reference/admin/node/admin.projectManagement.AppMetadata
   - title: "IosApp"
     path: /docs/reference/admin/node/admin.projectManagement.IosApp
   - title: "IosAppMetadata"

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -96,7 +96,7 @@ function fixLinks(file) {
   return fs.readFile(file, 'utf8').then(data => {
     const flattenedLinks = data
       .replace(/\.\.\//g, '')
-      .replace(/(modules|interfaces|classes)\//g, '');
+      .replace(/(modules|interfaces|classes|enums)\//g, '');
     let caseFixedLinks = flattenedLinks;
     for (const lower in lowerToUpperLookup) {
       const re = new RegExp(lower, 'g');
@@ -347,7 +347,8 @@ Promise.all([
     return Promise.all([
       // moveFilesToRoot('classes'),
       moveFilesToRoot('modules'),
-      moveFilesToRoot('interfaces')
+      moveFilesToRoot('interfaces'),
+      moveFilesToRoot('enums'),
     ]);
   })
   // Check for files listed in TOC that are missing and warn if so.


### PR DESCRIPTION
We have several `enum` types in our public API, and TypeDoc generates their documentation in a `/enums` subdirectory. This modifies the docgen script to move the enum docs to the root.