### PR TITLE
Updating the metadata server URL for Application Default Credentials

### DIFF
--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -29,7 +29,7 @@ const GOOGLE_AUTH_TOKEN_PATH = '/o/oauth2/token';
 
 // NOTE: the Google Metadata Service uses HTTP over a vlan
 const GOOGLE_METADATA_SERVICE_HOST = 'metadata.google.internal';
-const GOOGLE_METADATA_SERVICE_PATH = '/computeMetadata/v1beta1/instance/service-accounts/default/token';
+const GOOGLE_METADATA_SERVICE_PATH = '/computeMetadata/v1/instance/service-accounts/default/token';
 
 const configDir = (() => {
   // Windows has a dedicated low-rights location for apps at ~/Application Data

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -351,6 +351,9 @@ export class MetadataServiceCredential implements Credential {
     const request: HttpRequestConfig = {
       method: 'GET',
       url: `http://${GOOGLE_METADATA_SERVICE_HOST}${GOOGLE_METADATA_SERVICE_PATH}`,
+      headers: {
+        'Metadata-Flavor': 'Google',
+      },
       httpAgent: this.httpAgent,
     };
     return requestAccessToken(this.httpClient, request);

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -337,6 +337,12 @@ describe('Credential', () => {
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.equal('anAccessToken');
         expect(token.expires_in).to.equal(42);
+        expect(httpStub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+          headers: {'Metadata-Flavor': 'Google'},
+          httpAgent: undefined,
+        });
       });
     });
   });


### PR DESCRIPTION
Updating the the v1 URL of the metadata service, and adding the required header.

https://cloud.google.com/compute/docs/storing-retrieving-metadata#transitioning

Resolves #560 