### PR TITLE
Gracefully handling array-like arguments in sendAll()/sendMulticast()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
--
+- [fixed] Gracefully handling array-like objects in `messaging.sendAll()` and
+  `messaging.sendMulticast()` APIs.
+- [fixed] Updated the metadata server URL (used by the application default credentials)
+  to the `v1` endpoint.
 
 # v8.1.0
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -291,6 +291,13 @@ export class Messaging implements FirebaseServiceInterface {
    *     of the send operation.
    */
   public sendAll(messages: Message[], dryRun?: boolean): Promise<BatchResponse> {
+    if (validator.isArray(messages) && messages.constructor !== Array) {
+      // In more recent JS specs, an array-like object might have a constructor that is not of
+      // Array type. Our deepCopy() method doesn't handle them properly. Convert such objects to
+      // a regular array here before calling deepCopy(). See issue #566 for details.
+      messages = Array.from(messages);
+    }
+
     const copy: Message[] = deepCopy(messages);
     if (!validator.isNonEmptyArray(copy)) {
       throw new FirebaseMessagingError(


### PR DESCRIPTION
In  newer JS specs like `es2015`, custom array types can have a constructor that is not `Array`.

```
class CustomArray extends Array { }

const arr = new CustomArray();
console.log(Array.isArray(arr), arr.constructor);
```

ES5 output: true [Function: Array]
ES2015 output: true [Function: CustomArray]

Our `utils.deepCopy()` method does not correctly copy such objects, which sometimes causes unusual behaviors. This fixes the issue for the FCM APIs affected by this problem.

Ideally, we should push this fix down into the `deepCopy()` method. But that would affect all the modules. I'd prefer to test this out with FCM first, and if all looks good move the fix to `deepCopy()` in the future.

Resolves #566  
 