### PR TITLE
Removing getCertificate() from the Credential interface

### DIFF
--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -15,8 +15,8 @@
  */
 
 import { FirebaseApp } from '../firebase-app';
-import {Certificate} from './credential';
-import {AuthClientErrorCode, FirebaseAuthError, FirebaseError} from '../utils/error';
+import {Certificate, tryGetCertificate} from './credential';
+import {AuthClientErrorCode, FirebaseAuthError } from '../utils/error';
 import { AuthorizedHttpClient, HttpError, HttpRequestConfig, HttpClient } from '../utils/api-request';
 
 import * as validator from '../utils/validator';
@@ -220,7 +220,7 @@ export class IAMSigner implements CryptoSigner {
  * @return {CryptoSigner} A CryptoSigner instance.
  */
 export function cryptoSignerFromApp(app: FirebaseApp): CryptoSigner {
-  const cert = app.options.credential.getCertificate();
+  const cert = tryGetCertificate(app.options.credential);
   if (cert != null && validator.isNonEmptyString(cert.privateKey) && validator.isNonEmptyString(cert.clientEmail)) {
     return new ServiceAccountSigner(cert);
   }

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -17,7 +17,7 @@
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseFirestoreError} from '../utils/error';
 import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
-import {ApplicationDefaultCredential, Certificate} from '../auth/credential';
+import {ApplicationDefaultCredential, Certificate, tryGetCertificate} from '../auth/credential';
 import {Firestore, Settings} from '@google-cloud/firestore';
 
 import * as validator from '../utils/validator';
@@ -72,7 +72,7 @@ export function getFirestoreOptions(app: FirebaseApp): Settings {
   }
 
   const projectId: string = utils.getProjectId(app);
-  const cert: Certificate = app.options.credential.getCertificate();
+  const cert: Certificate = tryGetCertificate(app.options.credential);
   const { version: firebaseVersion } = require('../../package.json');
   if (cert != null) {
     // cert is available when the SDK has been initialized with a service account JSON file,

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -17,7 +17,7 @@
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseError} from '../utils/error';
 import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
-import {ApplicationDefaultCredential, Certificate} from '../auth/credential';
+import {ApplicationDefaultCredential, Certificate, tryGetCertificate} from '../auth/credential';
 import {Bucket, Storage as StorageClient} from '@google-cloud/storage';
 
 import * as validator from '../utils/validator';
@@ -70,7 +70,7 @@ export class Storage implements FirebaseServiceInterface {
       });
     }
 
-    const cert: Certificate = app.options.credential.getCertificate();
+    const cert: Certificate = tryGetCertificate(app.options.credential);
     if (cert != null) {
       // cert is available when the SDK has been initialized with a service account JSON file,
       // or by setting the GOOGLE_APPLICATION_CREDENTIALS envrionment variable.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {FirebaseApp, FirebaseAppOptions} from '../firebase-app';
-import {Certificate} from '../auth/credential';
+import {Certificate, tryGetCertificate} from '../auth/credential';
 
 import * as validator from './validator';
 
@@ -69,7 +69,7 @@ export function getProjectId(app: FirebaseApp): string {
     return options.projectId;
   }
 
-  const cert: Certificate = options.credential.getCertificate();
+  const cert: Certificate = tryGetCertificate(options.credential);
   if (cert != null && validator.isNonEmptyString(cert.projectId)) {
     return cert.projectId;
   }

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -32,7 +32,7 @@ import * as mocks from '../../resources/mocks';
 
 import {
   ApplicationDefaultCredential, CertCredential, Certificate, GoogleOAuthAccessToken,
-  MetadataServiceCredential, RefreshTokenCredential,
+  MetadataServiceCredential, RefreshTokenCredential, tryGetCertificate,
 } from '../../../src/auth/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import {Agent} from 'https';
@@ -255,6 +255,15 @@ describe('Credential', () => {
       });
     });
 
+    it('should return a certificate', () => {
+      const c = new CertCredential(mockCertificateObject);
+      expect(tryGetCertificate(c)).to.deep.equal({
+        projectId: mockCertificateObject.project_id,
+        clientEmail: mockCertificateObject.client_email,
+        privateKey: mockCertificateObject.private_key,
+      });
+    });
+
     it('should create access tokens', () => {
       const c = new CertCredential(mockCertificateObject);
       return c.getAccessToken().then((token) => {
@@ -292,7 +301,7 @@ describe('Credential', () => {
   describe('RefreshTokenCredential', () => {
     it('should not return a certificate', () => {
       const c = new RefreshTokenCredential(MOCK_REFRESH_TOKEN_CONFIG);
-      expect(c.getCertificate()).to.be.null;
+      expect(tryGetCertificate(c)).to.be.null;
     });
 
     it('should create access tokens', () => {
@@ -322,7 +331,7 @@ describe('Credential', () => {
 
     it('should not return a certificate', () => {
       const c = new MetadataServiceCredential();
-      expect(c.getCertificate()).to.be.null;
+      expect(tryGetCertificate(c)).to.be.null;
     });
 
     it('should create access tokens', () => {
@@ -422,6 +431,16 @@ describe('Credential', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
       const c = new ApplicationDefaultCredential();
       expect(c.getCertificate()).to.deep.equal({
+        projectId: mockCertificateObject.project_id,
+        clientEmail: mockCertificateObject.client_email,
+        privateKey: mockCertificateObject.private_key,
+      });
+    });
+
+    it('should return a Certificate', () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
+      const c = new ApplicationDefaultCredential();
+      expect(tryGetCertificate(c)).to.deep.equal({
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,


### PR DESCRIPTION
`Credential` is a public interface and is declared as follows in the typings:

```
interface Credential {
    getAccessToken(): Promise<admin.GoogleOAuthAccessToken>;
}
```

But in the actual implementation (credential.ts), there's an additional method in the interface:

https://github.com/firebase/firebase-admin-node/blob/843df1229405d441fd5e8bd4170e38cd9fd4cbd4/src/auth/credential.ts#L291-L294

This can cause issues if the developer implements the public `Credential` interface, and passes it through `AppOptions`. Internal code that expects to find a `getCertificate()` method will fail.

This PR addresses this issue by separating the `getCertificate()` method from the `Credential` interface.

Resolves #573 
