### PR TITLE
API for managing RTDB Security Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
--
+- [added] `admin.database().getRules()` method to retrieve the currently
+  applied RTDB rules text.
+- [added] `admin.database().getRulesJSON()` method to retrieve the currently
+  applied RTDB rules as a parsed JSON object.
+- [added] `admin.database().setRules()` method to update the RTDB rules.
 
 # v8.2.0
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -46,7 +46,6 @@ export class DatabaseService implements FirebaseServiceInterface {
   public readonly INTERNAL: DatabaseInternals = new DatabaseInternals();
 
   private readonly appInternal: FirebaseApp;
-  private readonly httpClient: AuthorizedHttpClient;
 
   constructor(app: FirebaseApp) {
     if (!validator.isNonNullObject(app) || !('options' in app)) {
@@ -56,7 +55,6 @@ export class DatabaseService implements FirebaseServiceInterface {
       });
     }
     this.appInternal = app;
-    this.httpClient = new AuthorizedHttpClient(app);
   }
 
   /**

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -113,6 +113,9 @@ export class DatabaseService implements FirebaseServiceInterface {
 
 const RULES_URL_PATH = '.settings/rules.json';
 
+/**
+ * A helper client for managing RTDB security rules.
+ */
 class DatabaseRulesClient {
 
   private readonly httpClient: AuthorizedHttpClient;
@@ -123,6 +126,12 @@ class DatabaseRulesClient {
     this.dbUrl = dbUrl;
   }
 
+  /**
+   * Gets the currently applied security rules as a string. The return value consists of
+   * the rules source including comments.
+   *
+   * @return {Promise<string>} A promise fulfilled with the rules as a raw string.
+   */
   public getRules(): Promise<string> {
     const req: HttpRequestConfig = {
       method: 'GET',
@@ -137,6 +146,12 @@ class DatabaseRulesClient {
       });
   }
 
+  /**
+   * Gets the currently applied security rules as a parsed JSON object. Any comments in
+   * the original source are stripped away.
+   *
+   * @return {Promise<object>} A promise fulfilled with the parsed rules source.
+   */
   public getRulesJSON(): Promise<object> {
     const req: HttpRequestConfig = {
       method: 'GET',
@@ -151,7 +166,24 @@ class DatabaseRulesClient {
       });
   }
 
+  /**
+   * Sets the specified rules on the Firebase Database instance. If the rules source is
+   * specified as a string or a Buffer, it may include comments.
+   *
+   * @param {string|Buffer|object} source Source of the rules to apply. Must not be `null`
+   *  or empty.
+   * @return {Promise<void>} Resolves when the rules are set on the Database.
+   */
   public setRules(source: string | Buffer | object): Promise<void> {
+    if (!validator.isNonEmptyString(source) &&
+      !validator.isBuffer(source)  &&
+      !validator.isNonNullObject(source)) {
+        throw new FirebaseDatabaseError({
+          code: 'invalid-argument',
+          message: 'Source must be a non-empty string, Buffer or an object.',
+        });
+    }
+
     const req: HttpRequestConfig = {
       method: 'PUT',
       url: this.getRulesUrl(),

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -182,10 +182,11 @@ class DatabaseRulesClient {
     if (!validator.isNonEmptyString(source) &&
       !validator.isBuffer(source)  &&
       !validator.isNonNullObject(source)) {
-        throw new FirebaseDatabaseError({
+        const error = new FirebaseDatabaseError({
           code: 'invalid-argument',
           message: 'Source must be a non-empty string, Buffer or an object.',
         });
+        return Promise.reject(error);
     }
 
     const req: HttpRequestConfig = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2065,10 +2065,29 @@ declare namespace admin.database {
      */
     refFromURL(url: string): admin.database.Reference;
 
+    /**
+     * Gets the currently applied security rules as a string. The return value consists of
+     * the rules source including comments.
+     *
+     * @return A promise fulfilled with the rules as a raw string.
+     */
     getRules(): Promise<string>;
 
+    /**
+     * Gets the currently applied security rules as a parsed JSON object. Any comments in
+     * the original source are stripped away.
+     *
+     * @return A promise fulfilled with the parsed rules object.
+     */
     getRulesJSON(): Promise<object>;
 
+    /**
+     * Sets the specified rules on the Firebase Database instance. If the rules source is
+     * specified as a string or a Buffer, it may include comments.
+     *
+     * @param source Source of the rules to apply. Must not be `null` or empty.
+     * @return Resolves when the rules are set on the Database.
+     */
     setRules(source: string | Buffer | object): Promise<void>;
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2064,6 +2064,12 @@ declare namespace admin.database {
      * @return  A `Reference` pointing to the provided Firebase URL.
      */
     refFromURL(url: string): admin.database.Reference;
+
+    getRules(): Promise<string>;
+
+    getRulesJSON(): Promise<object>;
+
+    setRules(source: string | Buffer | object): Promise<void>;
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2082,11 +2082,11 @@ declare namespace admin.database {
     getRulesJSON(): Promise<object>;
 
     /**
-     * Sets the specified rules on the Firebase Database instance. If the rules source is
+     * Sets the specified rules on the Firebase Realtime Database instance. If the rules source is
      * specified as a string or a Buffer, it may include comments.
      *
      * @param source Source of the rules to apply. Must not be `null` or empty.
-     * @return Resolves when the rules are set on the Database.
+     * @return Resolves when the rules are set on the Realtime Database.
      */
     setRules(source: string | Buffer | object): Promise<void>;
   }

--- a/test/integration/database.spec.ts
+++ b/test/integration/database.spec.ts
@@ -21,7 +21,6 @@ import url = require('url');
 import {defaultApp, nullApp, nonNullApp, cmdArgs, databaseUrl} from './setup';
 
 /* tslint:disable:no-var-requires */
-const apiRequest = require('../../lib/utils/api-request');
 const chalk = require('chalk');
 /* tslint:enable:no-var-requires */
 
@@ -43,20 +42,13 @@ describe('admin.database', () => {
     }
     console.log(chalk.yellow('    Updating security rules to defaults.'));
     /* tslint:enable:no-console */
-    const client = new apiRequest.AuthorizedHttpClient(defaultApp);
-    const dbUrl =  url.parse(databaseUrl);
     const defaultRules = {
       rules : {
         '.read': 'auth != null',
         '.write': 'auth != null',
       },
     };
-    return client.send({
-      url: `https://${dbUrl.host}/.settings/rules.json`,
-      method: 'PUT',
-      data: defaultRules,
-      timeout: 10000,
-    });
+    return admin.database().setRules(defaultRules);
   });
 
   it('admin.database() returns a database client', () => {
@@ -164,6 +156,18 @@ describe('admin.database', () => {
 
     it('remove() completes successfully', () => {
       return refWithUrl.remove().should.eventually.be.fulfilled;
+    });
+  });
+
+  it('admin.database().getRules() returns currently defined rules as a string', () => {
+    return admin.database().getRules().then((result) => {
+      return expect(result).to.be.not.empty;
+    });
+  });
+
+  it('admin.database().getRulesJSON() returns currently defined rules as an object', () => {
+    return admin.database().getRulesJSON().then((result) => {
+      return expect(result).to.be.not.undefined;
     });
   });
 });

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -220,6 +220,13 @@ describe('Database', () => {
         return db.getRules().should.eventually.be.rejectedWith(
           'Error while accessing security rules: error text');
       });
+
+      it('should throw in the event of an I/O error', () => {
+        const db: Database = database.getDatabase();
+        const stub = sinon.stub(HttpClient.prototype, 'send').rejects(new Error('network error'));
+        stubs.push(stub);
+        return db.getRules().should.eventually.be.rejectedWith('network error');
+      });
     });
 
     describe('getRulesWithJSON', () => {
@@ -251,6 +258,13 @@ describe('Database', () => {
         stubs.push(stub);
         return db.getRulesJSON().should.eventually.be.rejectedWith(
           'Error while accessing security rules: error text');
+      });
+
+      it('should throw in the event of an I/O error', () => {
+        const db: Database = database.getDatabase();
+        const stub = sinon.stub(HttpClient.prototype, 'send').rejects(new Error('network error'));
+        stubs.push(stub);
+        return db.getRulesJSON().should.eventually.be.rejectedWith('network error');
       });
     });
 
@@ -307,6 +321,13 @@ describe('Database', () => {
         stubs.push(stub);
         return db.setRules(rules).should.eventually.be.rejectedWith(
           'Error while accessing security rules: error text');
+      });
+
+      it('should throw in the event of an I/O error', () => {
+        const db: Database = database.getDatabase();
+        const stub = sinon.stub(HttpClient.prototype, 'send').rejects(new Error('network error'));
+        stubs.push(stub);
+        return db.setRules(rules).should.eventually.be.rejectedWith('network error');
       });
     });
   });

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -17,10 +17,8 @@
 'use strict';
 
 import * as _ from 'lodash';
-import * as chai from 'chai';
+import {expect} from 'chai';
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import {FirebaseApp} from '../../../src/firebase-app';
@@ -28,12 +26,6 @@ import {DatabaseService} from '../../../src/database/database';
 import {Database} from '@firebase/database';
 import * as utils from '../utils';
 import { HttpClient, HttpRequestConfig } from '../../../src/utils/api-request';
-
-chai.should();
-chai.use(sinonChai);
-chai.use(chaiAsPromised);
-
-const expect = chai.expect;
 
 describe('Database', () => {
   let mockApp: FirebaseApp;
@@ -151,7 +143,7 @@ describe('Database', () => {
       },
     };
     const rulesString = JSON.stringify(rules);
-    const rulesPath = '.settings/rules.json'
+    const rulesPath = '.settings/rules.json';
 
     function callParamsForGet(
       strict: boolean = false,
@@ -409,7 +401,7 @@ describe('Database', () => {
         it(`should throw if the source is ${JSON.stringify(invalidSource)}`, () => {
           const db: Database = database.getDatabase();
           return db.setRules(invalidSource).should.eventually.be.rejectedWith(
-            'Source must be a non-empty string, Buffer or an object.')
+            'Source must be a non-empty string, Buffer or an object.');
         });
       });
 

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -123,7 +123,7 @@ describe('Database', () => {
     });
   });
 
-  describe.only('Rules', () => {
+  describe('Rules', () => {
     const mockAccessToken: string = utils.generateRandomAccessToken();
     let getTokenStub: sinon.SinonStub;
     let stubs: sinon.SinonStub[] = [];
@@ -408,9 +408,8 @@ describe('Database', () => {
       invalidSources.forEach((invalidSource) => {
         it(`should throw if the source is ${JSON.stringify(invalidSource)}`, () => {
           const db: Database = database.getDatabase();
-          return expect(() => {
-            db.setRules(invalidSource);
-          }).to.throw('Source must be a non-empty string, Buffer or an object.');
+          return db.setRules(invalidSource).should.eventually.be.rejectedWith(
+            'Source must be a non-empty string, Buffer or an object.')
         });
       });
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -496,6 +496,30 @@ describe('HttpClient', () => {
     });
   });
 
+  it('should merge query parameters in URL with data', () => {
+    const reqData = {key1: 'value1', key2: 'value2'};
+    const mergedData = {...reqData, key3: 'value3'};
+    const respData = {success: true};
+    const scope = nock('https://' + mockHost)
+      .get(mockPath)
+      .query(mergedData)
+      .reply(200, respData, {
+        'content-type': 'application/json',
+      });
+    mockedRequests.push(scope);
+    const client = new HttpClient();
+    return client.send({
+      method: 'GET',
+      url: mockUrl + '?key3=value3',
+      data: reqData,
+    }).then((resp) => {
+      expect(resp.status).to.equal(200);
+      expect(resp.headers['content-type']).to.equal('application/json');
+      expect(resp.data).to.deep.equal(respData);
+      expect(resp.isJson()).to.be.true;
+    });
+  });
+
   it('should default to https when protocol not specified', () => {
     const respData = {foo: 'bar'};
     const scope = nock('https://' + mockHost)


### PR DESCRIPTION
New APIs for getting and setting RTDB rules:

```
getRules(): Promise<string>
getRulesJSON(): Promise<object>
setRules(source: string|Buffer|object): Promise<void>
```

New methods are dynamically injected to the `Database` object returned by the `@firebase/database` package. Type-safety is maintained by defining a new interface with the same name, letting TS declaration merging to take effect.

go/firebase-rules-admin

Related to #504