### PR TITLE
Revert "add FIREBASE_DATABASE_EMULATOR_HOST_VAR (#596)"

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -9,14 +9,6 @@ import {Database} from '@firebase/database';
 import * as validator from '../utils/validator';
 import { AuthorizedHttpClient, HttpRequestConfig, HttpError } from '../utils/api-request';
 
-/**
- * This variable is redefined in the firebase-js-sdk. Before modifying this
- * definition, please consult the definition in firebase-js-sdk and ensure that
- * they are consistent.
- *
- * https://github.com/firebase/firebase-js-sdk
- */
-export const FIREBASE_DATABASE_EMULATOR_HOST_VAR = 'FIREBASE_DATABASE_EMULATOR_HOST';
 
 /**
  * Internals of a Database instance.
@@ -110,10 +102,6 @@ export class DatabaseService implements FirebaseServiceInterface {
       return url;
     } else if (typeof this.appInternal.options.databaseURL !== 'undefined') {
       return this.appInternal.options.databaseURL;
-    }
-    const dbEmulatorUrl = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
-    if (dbEmulatorUrl) {
-      return 'http://' + dbEmulatorUrl;
     }
     throw new FirebaseDatabaseError({
       code: 'invalid-argument',

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -41,7 +41,6 @@ import {Database} from '@firebase/database';
 import {InstanceId} from '../../src/instance-id/instance-id';
 import {ProjectManagement} from '../../src/project-management/project-management';
 import { FirebaseAppError, AppErrorCodes } from '../../src/utils/error';
-import { FIREBASE_DATABASE_EMULATOR_HOST_VAR } from '../../src/database/database';
 
 chai.should();
 chai.use(sinonChai);
@@ -435,27 +434,10 @@ describe('FirebaseApp', () => {
     });
 
     it('should throw when databaseURL is not set', () => {
-      delete process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
       const app = firebaseNamespace.initializeApp(mocks.appOptionsNoDatabaseUrl, mocks.appName);
       expect(() => {
         app.database();
       }).to.throw('Can\'t determine Firebase Database URL.');
-    });
-
-    it('should use FIREBASE_DATABASE_EMULATOR_HOST when databaseURL not set', () => {
-      const url = 'localhost.com:9000?ns=test';
-      process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR] = url;
-      const app = firebaseNamespace.initializeApp(mocks.appOptionsNoDatabaseUrl, mocks.appName);
-      const db: Database = app.database();
-      expect(db.ref().toString()).to.equal('http://localhost.com:9000/');
-    });
-
-    it('should prefer databaseURL when FIREBASE_DATABASE_EMULATOR_HOST set', () => {
-      const url = 'localhost.com:9000?ns=test';
-      process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR] = url;
-      const app = firebaseNamespace.initializeApp(mocks.appOptions, mocks.appName);
-      const db: Database = app.database();
-      expect(db.ref().toString()).to.equal('https://databasename.firebaseio.com/');
     });
 
     it('should return a cached version of Database on subsequent calls', () => {

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -29,8 +29,6 @@ import * as mocks from '../resources/mocks';
 import * as firebaseAdmin from '../../src/index';
 import {ApplicationDefaultCredential, CertCredential, RefreshTokenCredential} from '../../src/auth/credential';
 
-import {FIREBASE_DATABASE_EMULATOR_HOST_VAR} from '../../src/database/database';
-
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -170,7 +168,6 @@ describe('Firebase', () => {
     });
 
     it('should throw given no databaseURL key when initializing the app', () => {
-      delete process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
       firebaseAdmin.initializeApp(mocks.appOptionsNoDatabaseUrl);
 
       expect(() => {


### PR DESCRIPTION
This reverts commit e963005658a0e5e24c0af7eb247a5461bc89a6a6. With the new way we're handling this variable in the firebase-js-sdk (https://github.com/firebase/firebase-js-sdk/pull/2016), we won't need to handle it in this repo anymore.