### PR TITLE
Removes all usage of tenant types.

### DIFF
--- a/src/auth/tenant.ts
+++ b/src/auth/tenant.ts
@@ -21,29 +21,20 @@ import {
   EmailSignInConfig, EmailSignInConfigServerRequest, EmailSignInProviderConfig,
 } from './auth-config';
 
-/** The server side tenant type enum. */
-export type TenantServerType = 'LIGHTWEIGHT' | 'FULL_SERVICE' | 'TYPE_UNSPECIFIED';
-
-/** The client side tenant type enum. */
-export type TenantType = 'lightweight' | 'full_service' | 'type_unspecified';
-
 /** The TenantOptions interface used for create/read/update tenant operations. */
 export interface TenantOptions {
   displayName?: string;
-  type?: TenantType;
   emailSignInConfig?: EmailSignInProviderConfig;
 }
 
 /** The corresponding server side representation of a TenantOptions object. */
 export interface TenantOptionsServerRequest extends EmailSignInConfigServerRequest {
   displayName?: string;
-  type?: TenantServerType;
 }
 
 /** The tenant server response interface. */
 export interface TenantServerResponse {
   name: string;
-  type?: TenantServerType;
   displayName?: string;
   allowPasswordSignup?: boolean;
   enableEmailLinkSignin?: boolean;
@@ -61,7 +52,6 @@ export interface ListTenantsResult {
  */
 export class Tenant {
   public readonly tenantId: string;
-  public readonly type?: TenantType;
   public readonly displayName?: string;
   public readonly emailSignInConfig?: EmailSignInConfig;
 
@@ -81,9 +71,6 @@ export class Tenant {
     }
     if (typeof tenantOptions.displayName !== 'undefined') {
       request.displayName = tenantOptions.displayName;
-    }
-    if (typeof tenantOptions.type !== 'undefined') {
-      request.type = tenantOptions.type.toUpperCase() as TenantServerType;
     }
     return request;
   }
@@ -112,7 +99,6 @@ export class Tenant {
   private static validate(request: any, createRequest: boolean) {
     const validKeys = {
       displayName: true,
-      type: true,
       emailSignInConfig: true,
     };
     const label = createRequest ? 'CreateTenantRequest' : 'UpdateTenantRequest';
@@ -139,21 +125,6 @@ export class Tenant {
         `"${label}.displayName" must be a valid non-empty string.`,
       );
     }
-    // Validate type if provided.
-    if (typeof request.type !== 'undefined' && !createRequest) {
-      throw new FirebaseAuthError(
-        AuthClientErrorCode.INVALID_ARGUMENT,
-        '"Tenant.type" is an immutable property.',
-      );
-    }
-    if (createRequest &&
-        request.type !== 'full_service' &&
-        request.type !== 'lightweight') {
-      throw new FirebaseAuthError(
-        AuthClientErrorCode.INVALID_ARGUMENT,
-        `"${label}.type" must be either "full_service" or "lightweight".`,
-      );
-    }
     // Validate emailSignInConfig type if provided.
     if (typeof request.emailSignInConfig !== 'undefined') {
       // This will throw an error if invalid.
@@ -177,7 +148,6 @@ export class Tenant {
     }
     this.tenantId = tenantId;
     this.displayName = response.displayName;
-    this.type = (response.type && response.type.toLowerCase()) || undefined;
     try {
       this.emailSignInConfig = new EmailSignInConfig(response);
     } catch (e) {
@@ -193,7 +163,6 @@ export class Tenant {
     return {
       tenantId: this.tenantId,
       displayName: this.displayName,
-      type: this.type,
       emailSignInConfig: this.emailSignInConfig && this.emailSignInConfig.toJSON(),
     };
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1064,8 +1064,6 @@ declare namespace admin.auth {
     dynamicLinkDomain?: string;
   }
 
-  type TenantType = 'lightweight' | 'full_service';
-
   /**
    * Interface representing a tenant configuration.
    * 
@@ -1076,8 +1074,8 @@ declare namespace admin.auth {
    * Before multi-tenancy can be used on a Google Cloud Identity Platform project,
    * tenants must be allowed on that project via the Cloud Console UI.
    * 
-   * A tenant configuration provides information such as the type of tenant (lightweight or
-   * full service), display name, tenant identifier and email authentication configuration.
+   * A tenant configuration provides information such as the display name, tenant
+   * identifier and email authentication configuration.
    * For OIDC/SAML provider configuration management, `TenantAwareAuth` instances should
    * be used instead of a `Tenant` to retrieve the list of configured IdPs on a tenant.
    * When configuring these providers, note that tenants will inherit
@@ -1092,18 +1090,6 @@ declare namespace admin.auth {
      * The tenant identifier.
      */
     tenantId: string;
-
-    /**
-     * The tenant type: `lightweight` or `full_service`.
-     * Tenants that use separate billing and quota will require their own project and
-     * must be defined as `full_service`.
-     * `full_service` tenants may be subject to quota creation limits.
-     * For additional project quota increases, refer to
-     * [project quota requests](https://support.google.com/cloud/answer/6330231?hl=en).
-     * In addition, deleted `full_service` tenants may take 30 days after deletion
-     * before they are completely removed.
-     */
-    type?: admin.auth.TenantType;
 
     /**
      * The tenant display name.
@@ -1165,11 +1151,6 @@ declare namespace admin.auth {
    * Interface representing the properties to set on a new tenant.
    */
   interface CreateTenantRequest extends UpdateTenantRequest {
-
-    /**
-     * The newly created tenant type. This can be `lightweight` or `full_service`.
-     */
-    type: admin.auth.TenantType;
   }
 
   /**
@@ -2016,11 +1997,6 @@ declare namespace admin.auth {
 
     /**
      * Updates an existing tenant configuration.
-     * 
-     * Tenant types cannot be modified after creation.
-     * If a tenant type needs to be changed after creation, a new tenant with the expected
-     * type needs to be created and the users/configurations of existing tenant copied to the
-     * new tenant.
      *
      * @param tenantId The `tenantId` corresponding to the tenant to delete.
      * @param tenantOptions The properties to update on the provided tenant.

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -439,7 +439,6 @@ describe('admin.auth', () => {
     const createdTenants: string[] = [];
     const tenantOptions: admin.auth.CreateTenantRequest = {
       displayName: 'testTenant1',
-      type: 'lightweight',
       emailSignInConfig: {
         enabled: true,
         passwordRequired: true,
@@ -451,7 +450,6 @@ describe('admin.auth', () => {
         enabled: true,
         passwordRequired: true,
       },
-      type: 'lightweight',
     };
     const expectedUpdatedTenant: any = {
       displayName: 'testTenantUpdated',
@@ -459,7 +457,6 @@ describe('admin.auth', () => {
         enabled: false,
         passwordRequired: true,
       },
-      type: 'lightweight',
     };
     const expectedUpdatedTenant2: any = {
       displayName: 'testTenantUpdated',
@@ -467,7 +464,6 @@ describe('admin.auth', () => {
         enabled: true,
         passwordRequired: false,
       },
-      type: 'lightweight',
     };
 
     // https://mochajs.org/
@@ -574,7 +570,7 @@ describe('admin.auth', () => {
         });
       });
 
-      // Ignore email action link tests for now as there is a bug for lightweight tenants:
+      // Ignore email action link tests for now as there is a bug in the returned tenant ID:
       // expected '1085102361755-testTenant1-6rjsn' to equal 'testTenant1-6rjsn'
       xit('generateEmailVerificationLink() should generate the link for tenant specific user', () => {
         // Generate email verification link to confirm it is generated in the expected

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -3783,7 +3783,6 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         const tenantId = 'tenant_id';
         const tenantOptions: TenantOptions = {
           displayName: 'TENANT_DISPLAY_NAME',
-          type: 'lightweight',
           emailSignInConfig: {
             enabled: true,
             passwordRequired: true,
@@ -3791,7 +3790,6 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         };
         const expectedRequest = {
           displayName: 'TENANT_DISPLAY_NAME',
-          type: 'LIGHTWEIGHT',
           allowPasswordSignup: true,
           enableEmailLinkSignin: false,
         };
@@ -3808,24 +3806,6 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             .then((actualResult) => {
               expect(actualResult).to.be.deep.equal(expectedResult.data);
               expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, postMethod, expectedRequest));
-            });
-        });
-
-        it('should be rejected given valid parameters with no type', () => {
-          const expectedError = new FirebaseAuthError(
-            AuthClientErrorCode.INVALID_ARGUMENT,
-            '"CreateTenantRequest.type" must be either "full_service" or "lightweight".',
-          );
-          // Initialize CreateTenantRequest with missing type.
-          const invalidOptions = deepCopy(tenantOptions);
-          delete invalidOptions.type;
-
-          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
-          return requestHandler.createTenant(invalidOptions)
-            .then((result) => {
-              throw new Error('Unexpected success');
-            }, (error) => {
-              expect(error).to.deep.equal(expectedError);
             });
         });
 
@@ -4005,23 +3985,6 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           );
           const invalidOptions = deepCopy(tenantOptions);
           invalidOptions.emailSignInConfig = 'invalid' as any;
-
-          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
-          return requestHandler.updateTenant(tenantId, invalidOptions)
-            .then((result) => {
-              throw new Error('Unexpected success');
-            }, (error) => {
-              expect(error).to.deep.equal(expectedError);
-            });
-        });
-
-        it('should be rejected given an unmodifiable property', () => {
-          const expectedError = new FirebaseAuthError(
-            AuthClientErrorCode.INVALID_ARGUMENT,
-            '"Tenant.type" is an immutable property.',
-          );
-          const invalidOptions = deepCopy(tenantOptions);
-          (invalidOptions as TenantOptions).type = 'full_service';
 
           const requestHandler = handler.init(mockApp) as AuthRequestHandler;
           return requestHandler.updateTenant(tenantId, invalidOptions)

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -3058,7 +3058,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
         const tenantId = 'tenant_id';
         const serverResponse: TenantServerResponse = {
           name: 'projects/project_id/tenants/tenant_id',
-          type: 'FULL_SERVICE',
           displayName: 'TENANT_DISPLAY_NAME',
           allowPasswordSignup: true,
           enableEmailLinkSignin: false,
@@ -3343,7 +3342,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
         const tenantId = 'tenant_id';
         const tenantOptions: TenantOptions = {
           displayName: 'TENANT_DISPLAY_NAME',
-          type: 'lightweight',
           emailSignInConfig: {
             enabled: true,
             passwordRequired: true,
@@ -3354,7 +3352,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
           displayName: 'TENANT_DISPLAY_NAME',
           allowPasswordSignup: true,
           enableEmailLinkSignin: false,
-          type: 'LIGHTWEIGHT',
         };
         const expectedTenant = new Tenant(serverResponse);
         const expectedError = new FirebaseAuthError(
@@ -3450,7 +3447,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
         };
         const serverResponse: TenantServerResponse = {
           name: 'projects/project_id/tenants/tenant_id',
-          type: 'FULL_SERVICE',
           displayName: 'TENANT_DISPLAY_NAME',
           allowPasswordSignup: true,
           enableEmailLinkSignin: false,
@@ -3498,9 +3494,9 @@ AUTH_CONFIGS.forEach((testConfig) => {
         });
 
         it('should be rejected given TenantOptions with invalid update property', () => {
-          // Updating the type of an existing tenant will throw an error as type is
+          // Updating the tenantId of an existing tenant will throw an error as tenantId is
           // an immutable property.
-          return (auth as Auth).updateTenant(tenantId, {type: 'lightweight'})
+          return (auth as Auth).updateTenant(tenantId, {tenantId: 'unmodifiable'} as any)
             .then(() => {
               throw new Error('Unexpected success');
             })

--- a/test/unit/auth/tenant.spec.ts
+++ b/test/unit/auth/tenant.spec.ts
@@ -83,13 +83,6 @@ describe('Tenant', () => {
         }).to.throw('"EmailSignInConfig.enabled" must be a boolean.');
       });
 
-      it('should throw when type is specified in an update request', () => {
-        const tenantOptionsClientRequest: TenantOptions = deepCopy(tenantOptions);
-        tenantOptionsClientRequest.type = 'lightweight';
-        expect(() => Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest))
-          .to.throw('"Tenant.type" is an immutable property.');
-      });
-
       it('should not throw on valid client request object', () => {
         const tenantOptionsClientRequest = deepCopy(clientRequest);
         expect(() => {
@@ -129,29 +122,16 @@ describe('Tenant', () => {
     describe('for a create request', () => {
       it('should return the expected server request', () => {
         const tenantOptionsClientRequest: TenantOptions = deepCopy(clientRequest);
-        tenantOptionsClientRequest.type = 'lightweight';
         const tenantOptionsServerRequest: TenantServerResponse = deepCopy(serverRequest);
         delete tenantOptionsServerRequest.name;
-        tenantOptionsServerRequest.type = 'LIGHTWEIGHT';
 
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
           .to.deep.equal(tenantOptionsServerRequest);
       });
 
-      const invalidTypes = [undefined, 'invalid', null, NaN, 0, 1, true, false, '', [], [1, 'a'], {}, { a: 1 }, _.noop];
-      invalidTypes.forEach((invalidType) => {
-        it('should throw on invalid type ' + JSON.stringify(invalidType), () => {
-          const tenantOptionsClientRequest: TenantOptions = deepCopy(tenantOptions);
-          tenantOptionsClientRequest.type = invalidType as any;
-          expect(() => Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
-            .to.throw(`"CreateTenantRequest.type" must be either "full_service" or "lightweight".`);
-        });
-      });
-
       it('should throw on invalid EmailSignInConfig', () => {
         const tenantOptionsClientRequest: TenantOptions = deepCopy(clientRequest);
         tenantOptionsClientRequest.emailSignInConfig = null;
-        tenantOptionsClientRequest.type = 'full_service';
 
         expect(() => Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
           .to.throw('"EmailSignInConfig" must be a non-null object.');
@@ -184,15 +164,6 @@ describe('Tenant', () => {
           }).to.throw('"CreateTenantRequest.displayName" must be a valid non-empty string.');
         });
       });
-
-      invalidTypes.forEach((invalidType) => {
-        it('should throw on creation with invalid type ' + JSON.stringify(invalidType), () => {
-          const tenantOptionsClientRequest: TenantOptions = deepCopy(tenantOptions);
-          tenantOptionsClientRequest.type = invalidType as any;
-          expect(() => Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
-            .to.throw(`"CreateTenantRequest.type" must be either "full_service" or "lightweight".`);
-        });
-      });
     });
   });
 
@@ -214,7 +185,6 @@ describe('Tenant', () => {
 
   describe('constructor', () => {
     const serverRequestCopy: TenantServerResponse = deepCopy(serverRequest);
-    serverRequestCopy.type = 'LIGHTWEIGHT';
     const tenant = new Tenant(serverRequestCopy);
     it('should not throw on valid initialization', () => {
       expect(() => new Tenant(serverRequest)).not.to.throw();
@@ -226,10 +196,6 @@ describe('Tenant', () => {
 
     it('should set readonly property displayName', () => {
       expect(tenant.displayName).to.equal('TENANT_DISPLAY_NAME');
-    });
-
-    it('should set readonly property type', () => {
-      expect(tenant.type).to.equal('lightweight');
     });
 
     it('should set readonly property emailSignInConfig', () => {
@@ -266,11 +232,9 @@ describe('Tenant', () => {
 
   describe('toJSON()', () => {
     const serverRequestCopy: TenantServerResponse = deepCopy(serverRequest);
-    serverRequestCopy.type = 'LIGHTWEIGHT';
     it('should return the expected object representation of a tenant', () => {
       expect(new Tenant(serverRequestCopy).toJSON()).to.deep.equal({
         tenantId: 'TENANT_ID',
-        type: 'lightweight',
         displayName: 'TENANT_DISPLAY_NAME',
         emailSignInConfig: {
           enabled: true,


### PR DESCRIPTION
All tenants are now created in lightweight state by default.
Note the underlying backend change is not yet in production.
