### PR TITLE
feat(fcm): Add image in notification support

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3924,6 +3924,11 @@ declare namespace admin.messaging {
     tag?: string;
 
     /**
+     * URL of an image to be displayed in the notification.
+     */
+    imageUrl?: string;
+
+    /**
      * Action associated with a user click on the notification. If specified, an
      * activity with a matching Intent Filter is launched when a user clicks on the
      * notification.
@@ -4105,6 +4110,11 @@ declare namespace admin.messaging {
      * The label associated with the message's analytics data.
      */
     analyticsLabel?: string;
+
+    /**
+     * URL of an image to be displayed in the notification.
+     */
+    imageUrl?: string;
   }
 
   /**
@@ -4131,6 +4141,10 @@ declare namespace admin.messaging {
      * The notification body
      */
     body?: string;
+    /**
+     * URL of an image to be displayed in the notification.
+     */
+    imageUrl?: string;
   }
   /**
    * Represents the WebPush protocol options that can be included in an

--- a/src/messaging/messaging-types.ts
+++ b/src/messaging/messaging-types.ts
@@ -59,6 +59,7 @@ export interface MulticastMessage extends BaseMessage {
 export interface Notification {
   title?: string;
   body?: string;
+  image?: string;
 }
 
 export interface FcmOptions {
@@ -143,6 +144,7 @@ export interface ApsAlert {
 
 export interface ApnsFcmOptions {
   analyticsLabel?: string;
+  image?: string;
 }
 
 export interface AndroidConfig {
@@ -162,6 +164,7 @@ export interface AndroidNotification {
   color?: string;
   sound?: string;
   tag?: string;
+  image?: string;
   clickAction?: string;
   bodyLocKey?: string;
   bodyLocArgs?: string[];
@@ -307,6 +310,7 @@ export function validateMessage(message: Message) {
   validateWebpushConfig(message.webpush);
   validateApnsConfig(message.apns);
   validateFcmOptions(message.fcmOptions);
+  validateNotification(message.notification);
 }
 
 /**
@@ -377,6 +381,13 @@ function validateApnsFcmOptions(fcmOptions: ApnsFcmOptions) {
       MessagingClientErrorCode.INVALID_PAYLOAD, 'fcmOptions must be a non-null object');
   }
 
+  if (typeof fcmOptions.image !== 'undefined' &&
+      !validator.isURL(fcmOptions.image)) {
+    throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD,
+        'image must be a valid URL string');
+  }
+
   if (typeof fcmOptions.analyticsLabel !== 'undefined' && !validator.isString(fcmOptions.analyticsLabel)) {
     throw new FirebaseMessagingError(
       MessagingClientErrorCode.INVALID_PAYLOAD, 'analyticsLabel must be a string value');
@@ -402,7 +413,24 @@ function validateFcmOptions(fcmOptions: FcmOptions) {
   }
 }
 
+/**
+ * Checks if the given Notification object is valid.
+ *
+ * @param {Notification} notification An object to be validated.
+ */
+function validateNotification(notification: Notification) {
+  if (typeof notification === 'undefined') {
+    return;
+  } else if (!validator.isNonNullObject(notification)) {
+    throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD, 'notification must be a non-null object');
+  }
 
+  if (typeof notification.image !== 'undefined' && !validator.isURL(notification.image)) {
+    throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD, 'notification.image must be a valid URL string');
+  }
+}
 
 /**
  * Checks if the given ApnsPayload object is valid. The object must have a valid aps value.
@@ -631,6 +659,12 @@ function validateAndroidNotification(notification: AndroidNotification) {
     throw new FirebaseMessagingError(
       MessagingClientErrorCode.INVALID_PAYLOAD,
       'android.notification.titleLocKey is required when specifying titleLocArgs');
+  }
+  if (typeof notification.image !== 'undefined' &&
+      !validator.isURL(notification.image)) {
+    throw new FirebaseMessagingError(
+        MessagingClientErrorCode.INVALID_PAYLOAD,
+        'android.notification.image must be a valid URL string');
   }
 
   const propertyMappings = {

--- a/src/messaging/messaging-types.ts
+++ b/src/messaging/messaging-types.ts
@@ -59,7 +59,7 @@ export interface MulticastMessage extends BaseMessage {
 export interface Notification {
   title?: string;
   body?: string;
-  image?: string;
+  imageUrl?: string;
 }
 
 export interface FcmOptions {
@@ -144,7 +144,7 @@ export interface ApsAlert {
 
 export interface ApnsFcmOptions {
   analyticsLabel?: string;
-  image?: string;
+  imageUrl?: string;
 }
 
 export interface AndroidConfig {
@@ -164,7 +164,7 @@ export interface AndroidNotification {
   color?: string;
   sound?: string;
   tag?: string;
-  image?: string;
+  imageUrl?: string;
   clickAction?: string;
   bodyLocKey?: string;
   bodyLocArgs?: string[];
@@ -381,11 +381,11 @@ function validateApnsFcmOptions(fcmOptions: ApnsFcmOptions) {
       MessagingClientErrorCode.INVALID_PAYLOAD, 'fcmOptions must be a non-null object');
   }
 
-  if (typeof fcmOptions.image !== 'undefined' &&
-      !validator.isURL(fcmOptions.image)) {
+  if (typeof fcmOptions.imageUrl !== 'undefined' &&
+      !validator.isURL(fcmOptions.imageUrl)) {
     throw new FirebaseMessagingError(
         MessagingClientErrorCode.INVALID_PAYLOAD,
-        'image must be a valid URL string');
+        'imageUrl must be a valid URL string');
   }
 
   if (typeof fcmOptions.analyticsLabel !== 'undefined' && !validator.isString(fcmOptions.analyticsLabel)) {
@@ -426,9 +426,9 @@ function validateNotification(notification: Notification) {
         MessagingClientErrorCode.INVALID_PAYLOAD, 'notification must be a non-null object');
   }
 
-  if (typeof notification.image !== 'undefined' && !validator.isURL(notification.image)) {
+  if (typeof notification.imageUrl !== 'undefined' && !validator.isURL(notification.imageUrl)) {
     throw new FirebaseMessagingError(
-        MessagingClientErrorCode.INVALID_PAYLOAD, 'notification.image must be a valid URL string');
+        MessagingClientErrorCode.INVALID_PAYLOAD, 'notification.imageUrl must be a valid URL string');
   }
 }
 
@@ -660,11 +660,11 @@ function validateAndroidNotification(notification: AndroidNotification) {
       MessagingClientErrorCode.INVALID_PAYLOAD,
       'android.notification.titleLocKey is required when specifying titleLocArgs');
   }
-  if (typeof notification.image !== 'undefined' &&
-      !validator.isURL(notification.image)) {
+  if (typeof notification.imageUrl !== 'undefined' &&
+      !validator.isURL(notification.imageUrl)) {
     throw new FirebaseMessagingError(
         MessagingClientErrorCode.INVALID_PAYLOAD,
-        'android.notification.image must be a valid URL string');
+        'android.notification.imageUrl must be a valid URL string');
   }
 
   const propertyMappings = {

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -45,6 +45,7 @@ const message: admin.messaging.Message = {
   notification: {
     title: 'Message title',
     body: 'Message body',
+    image: 'https://example.com/image.png',
   },
   android: {
     restrictedPackageName: 'com.google.firebase.testing',

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -45,7 +45,7 @@ const message: admin.messaging.Message = {
   notification: {
     title: 'Message title',
     body: 'Message body',
-    image: 'https://example.com/image.png',
+    imageUrl: 'https://example.com/image.png',
   },
   android: {
     restrictedPackageName: 'com.google.firebase.testing',

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -2334,6 +2334,37 @@ describe('Messaging', () => {
       });
     });
 
+    const invalidImages = ['a', 'foo', 'image.jpg'];
+    invalidImages.forEach((image) => {
+      it(`should throw given an invalid image: ${ image }`, () => {
+        const message: Message = {
+          condition: 'topic-name',
+          android: {
+            notification: {
+              image,
+            },
+          },
+        };
+        expect(() => {
+          messaging.send(message);
+        }).to.throw('android.notification.image must be a valid URL string');
+      });
+    });
+
+    invalidImages.forEach((image) => {
+      it(`should throw given an invalid image: ${image}`, () => {
+        const message: Message = {
+          condition: 'topic-name',
+          notification: {
+            image,
+          },
+        };
+        expect(() => {
+          messaging.send(message);
+        }).to.throw('notification.image must be a valid URL string');
+      });
+    });
+
     it('should throw given android titleLocArgs without titleLocKey', () => {
       const message: Message = {
         condition: 'topic-name',
@@ -2486,6 +2517,14 @@ describe('Messaging', () => {
         expect(() => {
           messaging.send({apns: {fcmOptions: arg}, topic: 'test'});
         }).to.throw('fcmOptions must be a non-null object');
+      });
+    });
+
+    invalidImages.forEach((image) => {
+      it(`should throw given invalid URL string for image`, () => {
+        expect(() => {
+          messaging.send({apns: {fcmOptions: {image}}, topic: 'test'});
+        }).to.throw('image must be a valid URL string');
       });
     });
 
@@ -2765,6 +2804,7 @@ describe('Messaging', () => {
           notification: {
             title: 'test.title',
             body: 'test.body',
+            image: 'https://example.com/image.png',
           },
         },
       },
@@ -2798,6 +2838,7 @@ describe('Messaging', () => {
               color: '#112233',
               sound: 'test.sound',
               tag: 'test.tag',
+              image: 'https://example.com/image.png',
             },
           },
         },
@@ -2871,6 +2912,7 @@ describe('Messaging', () => {
               color: '#112233',
               sound: 'test.sound',
               tag: 'test.tag',
+              image: 'https://example.com/image.png',
               clickAction: 'test.click.action',
               titleLocKey: 'title.loc.key',
               titleLocArgs: ['arg1', 'arg2'],
@@ -2900,6 +2942,7 @@ describe('Messaging', () => {
               color: '#112233',
               sound: 'test.sound',
               tag: 'test.tag',
+              image: 'https://example.com/image.png',
               click_action: 'test.click.action',
               title_loc_key: 'title.loc.key',
               title_loc_args: ['arg1', 'arg2'],
@@ -3033,6 +3076,7 @@ describe('Messaging', () => {
             },
             fcmOptions: {
               analyticsLabel: 'test.analytics',
+              image: 'https://example.com/image.png',
             },
           },
         },
@@ -3069,6 +3113,7 @@ describe('Messaging', () => {
             },
             fcmOptions: {
               analyticsLabel: 'test.analytics',
+              image: 'https://example.com/image.png',
             },
           },
         },

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -2302,6 +2302,21 @@ describe('Messaging', () => {
       });
     });
 
+    const invalidImages = ['', 'a', 'foo', 'image.jpg'];
+    invalidImages.forEach((imageUrl) => {
+      it(`should throw given an invalid imageUrl: ${imageUrl}`, () => {
+        const message: Message = {
+          condition: 'topic-name',
+          notification: {
+            imageUrl,
+          },
+        };
+        expect(() => {
+          messaging.send(message);
+        }).to.throw('notification.imageUrl must be a valid URL string');
+      });
+    });
+
     const invalidTtls = ['', 'abc', '123', '-123s', '1.2.3s', 'As', 's', '1s', -1];
     invalidTtls.forEach((ttl) => {
       it(`should throw given an invalid ttl: ${ ttl }`, () => {
@@ -2334,34 +2349,19 @@ describe('Messaging', () => {
       });
     });
 
-    const invalidImages = ['a', 'foo', 'image.jpg'];
-    invalidImages.forEach((image) => {
-      it(`should throw given an invalid image: ${ image }`, () => {
+    invalidImages.forEach((imageUrl) => {
+      it(`should throw given an invalid imageUrl: ${ imageUrl }`, () => {
         const message: Message = {
           condition: 'topic-name',
           android: {
             notification: {
-              image,
+              imageUrl,
             },
           },
         };
         expect(() => {
           messaging.send(message);
-        }).to.throw('android.notification.image must be a valid URL string');
-      });
-    });
-
-    invalidImages.forEach((image) => {
-      it(`should throw given an invalid image: ${image}`, () => {
-        const message: Message = {
-          condition: 'topic-name',
-          notification: {
-            image,
-          },
-        };
-        expect(() => {
-          messaging.send(message);
-        }).to.throw('notification.image must be a valid URL string');
+        }).to.throw('android.notification.imageUrl must be a valid URL string');
       });
     });
 
@@ -2520,11 +2520,11 @@ describe('Messaging', () => {
       });
     });
 
-    invalidImages.forEach((image) => {
-      it(`should throw given invalid URL string for image`, () => {
+    invalidImages.forEach((imageUrl) => {
+      it(`should throw given invalid URL string for imageUrl`, () => {
         expect(() => {
-          messaging.send({apns: {fcmOptions: {image}}, topic: 'test'});
-        }).to.throw('image must be a valid URL string');
+          messaging.send({apns: {fcmOptions: {imageUrl}}, topic: 'test'});
+        }).to.throw('imageUrl must be a valid URL string');
       });
     });
 


### PR DESCRIPTION
### Discussion

  * Add image in notification support

### Testing

  * Add unit tests and modified integration test to reflect this change

### API Changes

  * In Firebase Cloud Messaging, added 'image' field in the general Notification class, the AndroidNotification class, and the ApnsFcmOptions class.

RELEASE NOTE: Added new APIs for specifying an image URL in notifications.

Resolves #598 
