### PR TITLE
Remove (base64) 'REDACTED' passwords from user records.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,9 @@ Then set up your Firebase/GCP project as follows:
    Dashboard" from the main menu, and click the "ENABLE APIS AND SERVICES"
    button. Search for and enable the "Identity and Access Management (IAM)
    API".
-4. Grant your service account the 'Firebase Authentication Admin' role:
+4. Grant your service account the 'Firebase Authentication Admin' role. This is
+   required to ensure that exported user records contain the password hashes of
+   the user accounts:
    1. Go to [Google Cloud Platform Console / IAM & admin](https://console.cloud.google.com/iam-admin).
    2. Find your service account in the list, and click the 'pencil' icon to edit it's permissions.
    3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,13 +153,19 @@ Then set up your Firebase/GCP project as follows:
    to set up Firestore either in the locked mode or in the test mode.
 2. Enable password auth: Select "Authentication" from the "Develop" menu in
    Firebase Console. Select the "Sign-in method" tab, and enable the
-   "Email/Password" sign-in method.
+   "Email/Password" sign-in method, including the Email link (passwordless
+   sign-in) option.
 3. Enable the IAM API: Go to the
    [Google Cloud Platform Console](https://console.cloud.google.com) and make
    sure your Firebase/GCP project is selected. Select "APIs & Services >
    Dashboard" from the main menu, and click the "ENABLE APIS AND SERVICES"
    button. Search for and enable the "Identity and Access Management (IAM)
    API".
+4. Grant your service account the 'Firebase Authentication Admin' role:
+   1. Go to [Google Cloud Platform Console / IAM & admin](https://console.cloud.google.com/iam-admin).
+   2. Find your service account in the list, and click the 'pencil' icon to edit it's permissions.
+   3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
+   4. Click 'SAVE'.
 
 Finally, to run the integration test suite:
 

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -185,7 +185,21 @@ describe('admin.auth', () => {
         expect(typeof listUsersResult.pageToken).to.equal('string');
         // Confirm each user's uid and the hashed passwords.
         expect(listUsersResult.users[0].uid).to.equal(uids[1]);
+
+        expect(
+            listUsersResult.users[0].passwordHash,
+            'Missing passwordHash field. A common cause would be forgetting to '
+            + 'add the "Firebase Authentication Admin" permission. See '
+            + 'instructions in CONTRIBUTING.md',
+        ).to.be.ok;
         expect(listUsersResult.users[0].passwordHash.length).greaterThan(0);
+
+        expect(
+            listUsersResult.users[0].passwordSalt,
+            'Missing passwordSalt field. A common cause would be forgetting to '
+            + 'add the "Firebase Authentication Admin" permission. See '
+            + 'instructions in CONTRIBUTING.md',
+        ).to.be.ok;
         expect(listUsersResult.users[0].passwordSalt.length).greaterThan(0);
 
         expect(listUsersResult.users[1].uid).to.equal(uids[2]);

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -1684,28 +1684,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
           });
       });
 
-      it('should clear "REDACTED" passwordHash values', () => {
-        const downloadAccountStub = sinon
-          .stub(testConfig.RequestHandler.prototype, 'downloadAccount')
-          .resolves({
-            users: [
-              {localId: 'UID1', passwordHash: Buffer.from('REDACTED').toString('base64') },
-              {localId: 'UID2', passwordHash: 'arbitrary value' },
-            ]});
-        stubs.push(downloadAccountStub);
-        return auth.listUsers()
-          .then((response) => {
-            expect(response).to.deep.equal({
-              users: [
-                new UserRecord({localId: 'UID1'}),
-                new UserRecord({localId: 'UID2', passwordHash: 'arbitrary value' }),
-              ]});
-            // Confirm underlying API called with expected parameters.
-            expect(downloadAccountStub)
-              .to.have.been.calledOnce.and.calledWith(undefined, undefined);
-          });
-      });
-
       it('should resolve on downloadAccount request success with no users in response', () => {
         // Stub downloadAccount to return expected response.
         const downloadAccountStub = sinon

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -1684,6 +1684,27 @@ AUTH_CONFIGS.forEach((testConfig) => {
           });
       });
 
+      it('should clear "REDACTED" passwordHash values', () => {
+        const downloadAccountStub = sinon
+          .stub(testConfig.RequestHandler.prototype, 'downloadAccount')
+          .resolves({
+            users: [
+              {localId: 'UID1', passwordHash: Buffer.from('REDACTED').toString('base64') },
+              {localId: 'UID2', passwordHash: 'arbitrary value' },
+            ]});
+        stubs.push(downloadAccountStub);
+        return auth.listUsers()
+          .then((response) => {
+            expect(response).to.deep.equal({
+              users: [
+                new UserRecord({localId: 'UID1'}),
+                new UserRecord({localId: 'UID2', passwordHash: 'arbitrary value' }),
+              ]});
+            // Confirm underlying API called with expected parameters.
+            expect(downloadAccountStub)
+              .to.have.been.calledOnce.and.calledWith(undefined, undefined);
+          });
+      });
 
       it('should resolve on downloadAccount request success with no users in response', () => {
         // Stub downloadAccount to return expected response.

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -486,6 +486,15 @@ describe('UserRecord', () => {
       expect((new UserRecord(resp)).passwordHash).to.be.undefined;
     });
 
+    it('should clear REDACTED passwordHash', () => {
+      const userRecord = new UserRecord({
+        localId: 'uid1',
+        passwordHash: Buffer.from('REDACTED').toString('base64'),
+      });
+
+      expect(userRecord.passwordHash).to.be.undefined;
+    });
+
     it('should return expected empty string passwordHash', () => {
       // This happens for users that were migrated from other Auth systems
       // using different hashing algorithms.
@@ -651,15 +660,6 @@ describe('UserRecord', () => {
         (tenantUserRecord as any).tenantId = 'OTHER-TENANT-ID';
       }).to.throw(Error);
     });
-  });
-
-  describe('clears REDACTED passwordHash', () => {
-    const userRecord = new UserRecord({
-      localId: 'uid1',
-      passwordHash: Buffer.from('REDACTED').toString('base64'),
-    });
-
-    expect(userRecord.passwordHash).to.be.undefined;
   });
 
   describe('toJSON', () => {

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -653,6 +653,15 @@ describe('UserRecord', () => {
     });
   });
 
+  describe('clears REDACTED passwordHash', () => {
+    const userRecord = new UserRecord({
+      localId: 'uid1',
+      passwordHash: Buffer.from('REDACTED').toString('base64'),
+    });
+
+    expect(userRecord.passwordHash).to.be.undefined;
+  });
+
   describe('toJSON', () => {
     const userRecord = new UserRecord(getValidUserResponse());
     const validUserResponseNoValidSince = getValidUserResponse();

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -487,12 +487,12 @@ describe('UserRecord', () => {
     });
 
     it('should clear REDACTED passwordHash', () => {
-      const userRecord = new UserRecord({
+      const user = new UserRecord({
         localId: 'uid1',
         passwordHash: Buffer.from('REDACTED').toString('base64'),
       });
 
-      expect(userRecord.passwordHash).to.be.undefined;
+      expect(user.passwordHash).to.be.undefined;
     });
 
     it('should return expected empty string passwordHash', () => {


### PR DESCRIPTION
These values *look* like passwords hashes, but aren't, leading to
potential confusion.

Additionally, added docs to CONTRIBUTING.md detailing how to add the
permission that causes password hashes to be properly returned as well
as adjusting the test failure message should the developer not add that
permission.

b/141189502