### PR TITLE
Check for null resourceName before attempted to delete a cert

### DIFF
--- a/src/project-management/android-app.ts
+++ b/src/project-management/android-app.ts
@@ -103,6 +103,12 @@ export class AndroidApp {
   }
 
   public deleteShaCertificate(certificateToDelete: ShaCertificate): Promise<void> {
+    if (!certificateToDelete.resourceName) {
+      throw new FirebaseProjectManagementError(
+          'invalid-argument',
+          'Specified certificate does not include a resourceName. (Use AndroidApp.getShaCertificates() to retrieve ' +
+              'certificates with a resourceName.');
+    }
     return this.requestHandler.deleteResource(certificateToDelete.resourceName);
   }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -312,6 +312,12 @@ export class FirebaseMessagingError extends PrefixedFirebaseError {
 export class FirebaseProjectManagementError extends PrefixedFirebaseError {
   constructor(code: ProjectManagementErrorCode, message: string) {
     super('project-management', code, message);
+
+    /* tslint:disable:max-line-length */
+    // Set the prototype explicitly. See the following link for more details:
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    /* tslint:enable:max-line-length */
+    (this as any).__proto__ = FirebaseProjectManagementError.prototype;
   }
 }
 

--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -175,6 +175,14 @@ describe('admin.projectManagement', () => {
             expect(certs.length).to.equal(0);
           });
     });
+
+    it('add a cert and then remove it fails', () => {
+      const shaCertificate =
+          admin.projectManagement().shaCertificate(SHA_256_HASH);
+      return androidApp.addShaCertificate(shaCertificate)
+          .then(() => androidApp.deleteShaCertificate(shaCertificate))
+          .should.eventually.be.rejected;
+    });
   });
 
   describe('androidApp.getConfig()', () => {

--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -176,13 +176,17 @@ describe('admin.projectManagement', () => {
           });
     });
 
-    it('add a cert and then remove it fails', () => {
-      const shaCertificate =
-          admin.projectManagement().shaCertificate(SHA_256_HASH);
-      return androidApp.addShaCertificate(shaCertificate)
-          .then(() => androidApp.deleteShaCertificate(shaCertificate))
-          .should.eventually.be.rejected;
-    });
+    it('add a cert and then remove it fails due to missing resourceName',
+       () => {
+         const shaCertificate =
+             admin.projectManagement().shaCertificate(SHA_256_HASH);
+         return androidApp.addShaCertificate(shaCertificate)
+             .then(() => androidApp.deleteShaCertificate(shaCertificate))
+             .should.eventually.be
+             .rejectedWith(
+                 'Specified certificate does not include a resourceName')
+             .with.property('code', 'project-management/invalid-argument');
+       });
   });
 
   describe('androidApp.getConfig()', () => {

--- a/test/unit/project-management/android-app.spec.ts
+++ b/test/unit/project-management/android-app.spec.ts
@@ -289,14 +289,23 @@ describe('AndroidApp', () => {
 
   describe('deleteShaCertificate', () => {
     const certificateToDelete = new ShaCertificate(VALID_SHA_1_HASH);
+    const certificateToDeleteWithResourceName =
+        new ShaCertificate(VALID_SHA_1_HASH, 'resource/name');
 
     it('should propagate API errors', () => {
       const stub = sinon
           .stub(ProjectManagementRequestHandler.prototype, 'deleteResource')
           .returns(Promise.reject(EXPECTED_ERROR));
       stubs.push(stub);
-      return androidApp.deleteShaCertificate(certificateToDelete)
+      return androidApp
+          .deleteShaCertificate(certificateToDeleteWithResourceName)
           .should.eventually.be.rejected.and.equal(EXPECTED_ERROR);
+    });
+
+    it('should fail on certificate without resourceName', () => {
+      expect(() => androidApp.deleteShaCertificate(certificateToDelete))
+          .to.throw(FirebaseProjectManagementError)
+          .with.property('code', 'project-management/invalid-argument');
     });
 
     it('should resolve on success', () => {
@@ -304,7 +313,9 @@ describe('AndroidApp', () => {
           .stub(ProjectManagementRequestHandler.prototype, 'deleteResource')
           .returns(Promise.resolve());
       stubs.push(stub);
-      return androidApp.deleteShaCertificate(certificateToDelete).should.eventually.be.fulfilled;
+      return androidApp
+          .deleteShaCertificate(certificateToDeleteWithResourceName)
+          .should.eventually.be.fulfilled;
     });
   });
 


### PR DESCRIPTION
Without this, the sdk will send a null resourceName to the server,
resulting in a somewhat misleading 404 error being returned.