### PR TITLE
fix(fcm): Increased FCM batch request limit to 500

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5000,7 +5000,7 @@ declare namespace admin.messaging {
      * return value.
      *
      * @param messages A non-empty array
-     *   containing up to 100 messages.
+     *   containing up to 500 messages.
      * @param dryRun Whether to send the messages in the dry-run
      *   (validation only) mode.
      * @return A Promise fulfilled with an object representing the result of the
@@ -5023,7 +5023,7 @@ declare namespace admin.messaging {
      * a `BatchResponse` return value.
      *
      * @param message A multicast message
-     *   containing up to 100 tokens.
+     *   containing up to 500 tokens.
      * @param dryRun Whether to send the message in the dry-run
      *   (validation only) mode.
      * @return A Promise fulfilled with an object representing the result of the

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -40,7 +40,7 @@ const FCM_TOPIC_MANAGEMENT_ADD_PATH = '/iid/v1:batchAdd';
 const FCM_TOPIC_MANAGEMENT_REMOVE_PATH = '/iid/v1:batchRemove';
 
 // Maximum messages that can be included in a batch request.
-const FCM_MAX_BATCH_SIZE = 100;
+const FCM_MAX_BATCH_SIZE = 500;
 
 // Key renames for the messaging notification payload object.
 const CAMELCASED_NOTIFICATION_PAYLOAD_KEYS_MAP = {
@@ -283,7 +283,7 @@ export class Messaging implements FirebaseServiceInterface {
    * An error from this method indicates a total failure -- i.e. none of the messages in the
    * list could be sent. Partial failures are indicated by a BatchResponse return value.
    *
-   * @param {Message[]} messages A non-empty array containing up to 100 messages.
+   * @param {Message[]} messages A non-empty array containing up to 500 messages.
    * @param {boolean=} dryRun Whether to send the message in the dry-run (validation only) mode.
    *
    * @return {Promise<BatchResponse>} A Promise fulfilled with an object representing the result
@@ -335,7 +335,7 @@ export class Messaging implements FirebaseServiceInterface {
    * indicates a total failure -- i.e. none of the tokens in the list could be sent to. Partial
    * failures are indicated by a BatchResponse return value.
    *
-   * @param {MulticastMessage} message A multicast message containing up to 100 tokens.
+   * @param {MulticastMessage} message A multicast message containing up to 500 tokens.
    * @param {boolean=} dryRun Whether to send the message in the dry-run (validation only) mode.
    *
    * @return {Promise<BatchResponse>} A Promise fulfilled with an object representing the result

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -122,9 +122,9 @@ describe('admin.messaging', () => {
       });
   });
 
-  it('sendAll(100)', () => {
+  it('sendAll(500)', () => {
     const messages: admin.messaging.Message[] = [];
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 500; i++) {
       messages.push({topic: `foo-bar-${i % 10}`});
     }
     return admin.messaging().sendAll(messages, true)

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -587,14 +587,14 @@ describe('Messaging', () => {
       }).to.throw('messages must be a non-empty array');
     });
 
-    it('should throw when called with more than 100 messages', () => {
+    it('should throw when called with more than 500 messages', () => {
       const messages: Message[] = [];
-      for (let i = 0; i < 101; i++) {
+      for (let i = 0; i < 501; i++) {
         messages.push(validMessage);
       }
       expect(() => {
         messaging.sendAll(messages);
-      }).to.throw('messages list must not contain more than 100 items');
+      }).to.throw('messages list must not contain more than 500 items');
     });
 
     it('should throw when a message is invalid', () => {
@@ -847,14 +847,14 @@ describe('Messaging', () => {
       }).to.throw('tokens must be a non-empty array');
     });
 
-    it('should throw when called with more than 100 messages', () => {
+    it('should throw when called with more than 500 messages', () => {
       const tokens: string[] = [];
-      for (let i = 0; i < 101; i++) {
+      for (let i = 0; i < 501; i++) {
         tokens.push(`token${i}`);
       }
       expect(() => {
         messaging.sendMulticast({tokens});
-      }).to.throw('tokens list must not contain more than 100 items');
+      }).to.throw('tokens list must not contain more than 500 items');
     });
 
     const invalidDryRun = [null, NaN, 0, 1, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];


### PR DESCRIPTION
RELEASE NOTE: Batch messaging APIs `sendAll()` and `sendMulticast()` now support sending up to 500 messages in a single call.