### PR TITLE
Async API to determine project ID

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -105,11 +105,8 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> {
   constructor(app: FirebaseApp, protected readonly authRequestHandler: T) {
     const cryptoSigner = cryptoSignerFromApp(app);
     this.tokenGenerator = new FirebaseTokenGenerator(cryptoSigner);
-
-    const projectId = utils.getProjectId(app);
-    const httpAgent = app.options.httpAgent;
-    this.sessionCookieVerifier = createSessionCookieVerifier(projectId, httpAgent);
-    this.idTokenVerifier = createIdTokenVerifier(projectId, httpAgent);
+    this.sessionCookieVerifier = createSessionCookieVerifier(app);
+    this.idTokenVerifier = createIdTokenVerifier(app);
   }
 
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -82,6 +82,20 @@ export function getProjectId(app: FirebaseApp): string | null {
 }
 
 /**
+ * Determines the Google Cloud project ID associated with a Firebase app by examining
+ * the Firebase app options, credentials and the local environment in that order. This
+ * is an async wrapper of the getProjectId method. This enables us to migrate the rest
+ * of the SDK into asynchronously determining the current project ID. See b/143090254.
+ *
+ * @param {FirebaseApp} app A Firebase app to get the project ID from.
+ *
+ * @return {Promise<string | null>} A project ID string or null.
+ */
+export function findProjectId(app: FirebaseApp): Promise<string | null> {
+  return Promise.resolve(getProjectId(app));
+}
+
+/**
  * Encodes data using web-safe-base64.
  *
  * @param {Buffer} data The raw data byte input.

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -387,22 +387,20 @@ AUTH_CONFIGS.forEach((testConfig) => {
       }
     });
 
-    it('verifyIdToken() should throw when project ID is not specified', () => {
+    it('verifyIdToken() should reject when project ID is not specified', () => {
       const mockCredentialAuth = testConfig.init(mocks.mockCredentialApp());
       const expected = 'Must initialize app with a cert credential or set your Firebase project ID ' +
         'as the GOOGLE_CLOUD_PROJECT environment variable to call verifyIdToken().';
-      expect(() => {
-        mockCredentialAuth.verifyIdToken(mocks.generateIdToken());
-      }).to.throw(expected);
+      return mockCredentialAuth.verifyIdToken(mocks.generateIdToken())
+        .should.eventually.be.rejectedWith(expected);
     });
 
-    it('verifySessionCookie() should throw when project ID is not specified', () => {
+    it('verifySessionCookie() should reject when project ID is not specified', () => {
       const mockCredentialAuth = testConfig.init(mocks.mockCredentialApp());
       const expected = 'Must initialize app with a cert credential or set your Firebase project ID ' +
         'as the GOOGLE_CLOUD_PROJECT environment variable to call verifySessionCookie().';
-      expect(() => {
-        mockCredentialAuth.verifySessionCookie(mocks.generateSessionCookie());
-      }).to.throw(expected);
+      return mockCredentialAuth.verifySessionCookie(mocks.generateSessionCookie())
+        .should.eventually.be.rejectedWith(expected);
     });
 
     describe('verifyIdToken()', () => {

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -19,7 +19,7 @@ import {expect} from 'chai';
 
 import * as mocks from '../../resources/mocks';
 import {
-  addReadonlyGetter, getProjectId, toWebSafeBase64, formatString, generateUpdateMask,
+  addReadonlyGetter, getProjectId, findProjectId, toWebSafeBase64, formatString, generateUpdateMask,
 } from '../../../src/utils/index';
 import {isNonEmptyString} from '../../../src/utils/validator';
 import {FirebaseApp, FirebaseAppOptions} from '../../../src/firebase-app';
@@ -120,6 +120,63 @@ describe('getProjectId()', () => {
     delete process.env.GCLOUD_PROJECT;
     const app: FirebaseApp = mocks.mockCredentialApp();
     expect(getProjectId(app)).to.be.null;
+  });
+});
+
+describe('findProjectId()', () => {
+  let googleCloudProject: string | undefined;
+  let gcloudProject: string | undefined;
+
+  before(() => {
+    googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
+    gcloudProject = process.env.GCLOUD_PROJECT;
+  });
+
+  after(() => {
+    if (isNonEmptyString(googleCloudProject)) {
+      process.env.GOOGLE_CLOUD_PROJECT = googleCloudProject;
+    } else {
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+    }
+
+    if (isNonEmptyString(gcloudProject)) {
+      process.env.GCLOUD_PROJECT = gcloudProject;
+    } else {
+      delete process.env.GCLOUD_PROJECT;
+    }
+  });
+
+  it('should return the explicitly specified project ID from app options', () => {
+    const options: FirebaseAppOptions = {
+      credential: new mocks.MockCredential(),
+      projectId: 'explicit-project-id',
+    };
+    const app: FirebaseApp = mocks.appWithOptions(options);
+    return findProjectId(app).should.eventually.equal(options.projectId);
+  });
+
+  it('should return the project ID from service account', () => {
+    const app: FirebaseApp = mocks.app();
+    return findProjectId(app).should.eventually.equal('project_id');
+  });
+
+  it('should return the project ID set in GOOGLE_CLOUD_PROJECT environment variable', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'env-var-project-id';
+    const app: FirebaseApp = mocks.mockCredentialApp();
+    return findProjectId(app).should.eventually.equal('env-var-project-id');
+  });
+
+  it('should return the project ID set in GCLOUD_PROJECT environment variable', () => {
+    process.env.GCLOUD_PROJECT = 'env-var-project-id';
+    const app: FirebaseApp = mocks.mockCredentialApp();
+    return findProjectId(app).should.eventually.equal('env-var-project-id');
+  });
+
+  it('should return null when project ID is not set', () => {
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GCLOUD_PROJECT;
+    const app: FirebaseApp = mocks.mockCredentialApp();
+    return findProjectId(app).should.eventually.be.null;
   });
 });
 


### PR DESCRIPTION
Currently the SDK uses the following synchronous procedure to determine the project ID:

1. Get project ID from AppOptions.
2. Get project ID from the service account credentials.
3. Get project ID from the environment variables.

New GCP runtimes like Cloud Run no longer expose the project ID as environment variables. Therefore the SDK does not work in these environments if the project ID is not specified via AppOptions or service account credentials (see b/143090254). 

```
admin.initializeApp();
admin.auth().verifyIdToken(token); // does not work in Cloud Run
```

To support this we need to get the project ID from the local metadata server. This is an async operation, and therefore we need to turn our project ID discovery logic into an async method.

With this PR I'm starting to refactor the SDK so that it can find the project ID via an async method call. I've wrapped the existing `util.getProjectId()` method into a new `util.findProjectId()` method that returns a `Promise`. I'm also updating the ID token verification logic to use the new async method.

I will refactor the rest of the SDK to use the new async method in future PRs. Finally, we will modify the credentials module to discover the project ID by making a call to the local metadata server.