### PR TITLE
fix(fcm): Copying fcmOptions when multicasting messages

### DIFF
--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -365,6 +365,7 @@ export class Messaging implements FirebaseServiceInterface {
         data: copy.data,
         notification: copy.notification,
         webpush: copy.webpush,
+        fcmOptions: copy.fcmOptions,
       };
     });
     return this.sendAll(messages, dryRun);

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -897,6 +897,7 @@ describe('Messaging', () => {
         data: {key: 'value'},
         notification: {title: 'test title'},
         webpush: {data: {webKey: 'webValue'}},
+        fcmOptions: {analyticsLabel: 'label'},
       };
       return messaging.sendMulticast(multicast)
         .then((response: BatchResponse) => {
@@ -912,6 +913,7 @@ describe('Messaging', () => {
             expect(message.data).to.be.deep.equal(multicast.data);
             expect(message.notification).to.deep.equal(multicast.notification);
             expect(message.webpush).to.deep.equal(multicast.webpush);
+            expect(message.fcmOptions).to.deep.equal(multicast.fcmOptions);
           });
         });
     });


### PR DESCRIPTION
Resolves #712 

RELEASE NOTE: `sendMulticast()` API now correctly copies the `fcmOptions` when sending a message to multiple recipients.