### PR TITLE
Extends createUser to support multi-factor user creation.

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1164,8 +1164,8 @@ export abstract class AbstractAuthRequestHandler {
     }
     // Construct mfa related user data.
     if (validator.isNonNullObject(request.multiFactor)) {
-      if (validator.isArray(request.multiFactor.enrolledFactors)) {
-        request.mfaInfo = [];
+      if (validator.isNonEmptyArray(request.multiFactor.enrolledFactors)) {
+        const mfaInfo: AuthFactorInfo[] = [];
         try {
           request.multiFactor.enrolledFactors.forEach((multiFactorInfo: any) => {
             // Enrollment time and uid are not allowed for signupNewUser endpoint.
@@ -1179,14 +1179,12 @@ export abstract class AbstractAuthRequestHandler {
                 AuthClientErrorCode.INVALID_ARGUMENT,
                 '"uid" is not supported when adding second factors via "createUser()"');
             }
-            request.mfaInfo.push(convertMultiFactorInfoToServerFormat(multiFactorInfo));
+            mfaInfo.push(convertMultiFactorInfoToServerFormat(multiFactorInfo));
           });
         } catch (e) {
           return Promise.reject(e);
         }
-        if (request.mfaInfo.length === 0) {
-          delete request.mfaInfo;
-        }
+        request.mfaInfo = mfaInfo;
       }
       delete request.multiFactor;
     }

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -86,6 +86,16 @@ const FIREBASE_AUTH_TENANT_URL_FORMAT = FIREBASE_AUTH_BASE_URL_FORMAT.replace(
 const MAX_LIST_TENANT_PAGE_SIZE = 1000;
 
 
+/**
+ * Enum for the user write operation type.
+ */
+enum WriteOperationType {
+  Create = 'create',
+  Update = 'update',
+  Upload = 'upload',
+}
+
+
 /** Defines a base utility to help with resource URL construction. */
 class AuthResourceUrlBuilder {
   protected urlFormat: string;
@@ -157,8 +167,9 @@ class TenantAwareAuthResourceUrlBuilder extends AuthResourceUrlBuilder {
  * an error is thrown.
  *
  * @param request The AuthFactorInfo request object.
+ * @param writeOperationType The write operation type.
  */
-function validateAuthFactorInfo(request: AuthFactorInfo) {
+function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: WriteOperationType) {
   const validKeys = {
     mfaEnrollmentId: true,
     displayName: true,
@@ -171,7 +182,12 @@ function validateAuthFactorInfo(request: AuthFactorInfo) {
       delete request[key];
     }
   }
-  if (!validator.isNonEmptyString(request.mfaEnrollmentId)) {
+  // No enrollment ID is available for signupNewUser. User another identifier.
+  const authFactorInfoIdentifier =
+      request.mfaEnrollmentId || request.phoneInfo || JSON.stringify(request);
+  const uidRequired = writeOperationType !== WriteOperationType.Create;
+  if ((typeof request.mfaEnrollmentId !== 'undefined' || uidRequired) &&
+      !validator.isNonEmptyString(request.mfaEnrollmentId)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_UID,
       `The second factor "uid" must be a valid non-empty string.`,
@@ -181,7 +197,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo) {
       !validator.isString(request.displayName)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_DISPLAY_NAME,
-      `The second factor "displayName" for "${request.mfaEnrollmentId}" must be a valid string.`,
+      `The second factor "displayName" for "${authFactorInfoIdentifier}" must be a valid string.`,
     );
   }
   // enrolledAt must be a valid UTC date string.
@@ -189,7 +205,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo) {
       !validator.isISODateString(request.enrolledAt)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
-      `The second factor "enrollmentTime" for "${request.mfaEnrollmentId}" must be a valid ` +
+      `The second factor "enrollmentTime" for "${authFactorInfoIdentifier}" must be a valid ` +
       `UTC date string.`);
   }
   // Validate required fields depending on second factor type.
@@ -198,7 +214,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo) {
     if (!validator.isPhoneNumber(request.phoneInfo)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_PHONE_NUMBER,
-        `The second factor "phoneNumber" for "${request.mfaEnrollmentId}" must be a non-empty ` +
+        `The second factor "phoneNumber" for "${authFactorInfoIdentifier}" must be a non-empty ` +
         `E.164 standard compliant identifier string.`);
     }
   } else {
@@ -275,10 +291,11 @@ function validateProviderUserInfo(request: any) {
  * are removed from the original request. If an invalid field is passed
  * an error is thrown.
  *
- * @param {any} request The create/edit request object.
- * @param {boolean=} uploadAccountRequest Whether to validate as an uploadAccount request.
+ * @param request The create/edit request object.
+ * @param writeOperationType The write operation type.
  */
-function validateCreateEditRequest(request: any, uploadAccountRequest: boolean = false) {
+function validateCreateEditRequest(request: any, writeOperationType: WriteOperationType) {
+  const uploadAccountRequest = writeOperationType === WriteOperationType.Upload;
   // Hash set of whitelisted parameters.
   const validKeys = {
     displayName: true,
@@ -458,7 +475,7 @@ function validateCreateEditRequest(request: any, uploadAccountRequest: boolean =
       throw new FirebaseAuthError(AuthClientErrorCode.INVALID_ENROLLED_FACTORS);
     }
     enrollments.forEach((authFactorInfoEntry: AuthFactorInfo) => {
-      validateAuthFactorInfo(authFactorInfoEntry);
+      validateAuthFactorInfo(authFactorInfoEntry, writeOperationType);
     });
   }
 }
@@ -559,7 +576,7 @@ export const FIREBASE_AUTH_SET_ACCOUNT_INFO = new ApiSettings('/accounts:update'
           AuthClientErrorCode.INVALID_ARGUMENT,
           '"tenantId" is an invalid "UpdateRequest" property.');
     }
-    validateCreateEditRequest(request);
+    validateCreateEditRequest(request, WriteOperationType.Update);
   })
   // Set response validator.
   .setResponseValidator((response: any) => {
@@ -596,7 +613,7 @@ export const FIREBASE_AUTH_SIGN_UP_NEW_USER = new ApiSettings('/accounts', 'POST
           AuthClientErrorCode.INVALID_ARGUMENT,
           '"tenantId" is an invalid "CreateRequest" property.');
     }
-    validateCreateEditRequest(request);
+    validateCreateEditRequest(request, WriteOperationType.Create);
   })
   // Set response validator.
   .setResponseValidator((response: any) => {
@@ -912,7 +929,7 @@ export abstract class AbstractAuthRequestHandler {
     // No need to validate raw request or raw response as this is done in UserImportBuilder.
     const userImportBuilder = new UserImportBuilder(users, options, (userRequest: any) => {
       // Pass true to validate the uploadAccount specific fields.
-      validateCreateEditRequest(userRequest, true);
+      validateCreateEditRequest(userRequest, WriteOperationType.Upload);
     });
     const request = userImportBuilder.buildRequest();
     // Fail quickly if more users than allowed are to be imported.
@@ -1144,6 +1161,34 @@ export abstract class AbstractAuthRequestHandler {
     if (typeof request.uid !== 'undefined') {
       request.localId = request.uid;
       delete request.uid;
+    }
+    // Construct mfa related user data.
+    if (validator.isNonNullObject(request.multiFactor)) {
+      if (validator.isArray(request.multiFactor.enrolledFactors)) {
+        request.mfaInfo = [];
+        try {
+          request.multiFactor.enrolledFactors.forEach((multiFactorInfo: any) => {
+            // Enrollment time and uid are not allowed for signupNewUser endpoint.
+            // They will automatically be provisioned server side.
+            if (multiFactorInfo.enrollmentTime) {
+              throw new FirebaseAuthError(
+                AuthClientErrorCode.INVALID_ARGUMENT,
+                '"enrollmentTime" is not supported when adding second factors via "createUser()"');
+            } else if (multiFactorInfo.uid) {
+              throw new FirebaseAuthError(
+                AuthClientErrorCode.INVALID_ARGUMENT,
+                '"uid" is not supported when adding second factors via "createUser()"');
+            }
+            request.mfaInfo.push(convertMultiFactorInfoToServerFormat(multiFactorInfo));
+          });
+        } catch (e) {
+          return Promise.reject(e);
+        }
+        if (request.mfaInfo.length === 0) {
+          delete request.mfaInfo;
+        }
+      }
+      delete request.multiFactor;
     }
     return this.invokeRequestHandler(this.getAuthUrlBuilder(), FIREBASE_AUTH_SIGN_UP_NEW_USER, request)
       .then((response: any) => {

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -182,7 +182,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: Wri
       delete request[key];
     }
   }
-  // No enrollment ID is available for signupNewUser. User another identifier.
+  // No enrollment ID is available for signupNewUser. Use another identifier.
   const authFactorInfoIdentifier =
       request.mfaEnrollmentId || request.phoneInfo || JSON.stringify(request);
   const uidRequired = writeOperationType !== WriteOperationType.Create;

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -79,7 +79,8 @@ export interface UserImportRecord {
 
 /** Interface representing an Auth second factor in Auth server format. */
 export interface AuthFactorInfo {
-  mfaEnrollmentId: string;
+  // Not required for signupNewUser endpoint.
+  mfaEnrollmentId?: string;
   displayName?: string;
   phoneInfo?: string;
   enrolledAt?: string;

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -43,7 +43,7 @@ function parseDate(time: any): string {
 }
 
 interface SecondFactor {
-  uid: string;
+  uid?: string;
   phoneNumber: string;
   displayName?: string;
   enrollmentTime?: string;
@@ -67,6 +67,9 @@ export interface UpdateRequest {
 /** Parameters for create user operation */
 export interface CreateRequest extends UpdateRequest {
   uid?: string;
+  multiFactor?: {
+    enrolledFactors: SecondFactor[];
+  };
 }
 
 export interface AuthFactorInfo {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -698,7 +698,7 @@ declare namespace admin.auth {
 
     multiFactor?: {
       enrolledFactors: Array<{
-        uid: string;
+        uid?: string;
         phoneNumber: string;
         displayName?: string;
         enrollmentTime?: string;
@@ -717,6 +717,14 @@ declare namespace admin.auth {
      * The user's `uid`.
      */
     uid?: string;
+
+    multiFactor?: {
+      enrolledFactors: Array<{
+        phoneNumber: string;
+        displayName?: string;
+        factorId: string;
+      }>;
+    };
   }
 
   /**

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -166,25 +166,19 @@ describe('admin.auth', () => {
         // Confirm second factors added to user.
         expect(userRecord.multiFactor.enrolledFactors.length).to.equal(2);
         // Confirm first enrolled second factor.
-        expect(userRecord.multiFactor.enrolledFactors[0].uid).not.to.be.undefined;
-        expect(userRecord.multiFactor.enrolledFactors[0].enrollmentTime)
-          .not.to.be.undefined;
-        expect(userRecord.multiFactor.enrolledFactors[0].phoneNumber)
-          .to.equal(enrolledFactors[0].phoneNumber);
-        expect(userRecord.multiFactor.enrolledFactors[0].displayName)
-          .to.equal(enrolledFactors[0].displayName);
-        expect(userRecord.multiFactor.enrolledFactors[0].factorId)
-          .to.equal(enrolledFactors[0].factorId);
+        const firstMultiFactor = userRecord.multiFactor.enrolledFactors[0];
+        expect(firstMultiFactor.uid).not.to.be.undefined;
+        expect(firstMultiFactor.enrollmentTime).not.to.be.undefined;
+        expect(firstMultiFactor.phoneNumber).to.equal(enrolledFactors[0].phoneNumber);
+        expect(firstMultiFactor.displayName).to.equal(enrolledFactors[0].displayName);
+        expect(firstMultiFactor.factorId).to.equal(enrolledFactors[0].factorId);
         // Confirm second enrolled second factor.
-        expect(userRecord.multiFactor.enrolledFactors[1].uid).not.to.be.undefined;
-        expect(userRecord.multiFactor.enrolledFactors[1].enrollmentTime)
-          .not.to.be.undefined;
-        expect(userRecord.multiFactor.enrolledFactors[1].phoneNumber)
-          .to.equal(enrolledFactors[1].phoneNumber);
-        expect(userRecord.multiFactor.enrolledFactors[1].displayName)
-          .to.equal(enrolledFactors[1].displayName);
-        expect(userRecord.multiFactor.enrolledFactors[1].factorId)
-          .to.equal(enrolledFactors[1].factorId);
+        const secondMultiFactor = userRecord.multiFactor.enrolledFactors[1];
+        expect(secondMultiFactor.uid).not.to.be.undefined;
+        expect(secondMultiFactor.enrollmentTime).not.to.be.undefined;
+        expect(secondMultiFactor.phoneNumber).to.equal(enrolledFactors[1].phoneNumber);
+        expect(secondMultiFactor.displayName).to.equal(enrolledFactors[1].displayName);
+        expect(secondMultiFactor.factorId).to.equal(enrolledFactors[1].factorId);
       });
   });
 

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -165,7 +165,7 @@ describe('admin.auth', () => {
         expect(userRecord.email).to.equal(newUserData.email);
         // Confirm second factors added to user.
         expect(userRecord.multiFactor.enrolledFactors.length).to.equal(2);
-        // Confirm first factor.
+        // Confirm first enrolled second factor.
         expect(userRecord.multiFactor.enrolledFactors[0].uid).not.to.be.undefined;
         expect(userRecord.multiFactor.enrolledFactors[0].enrollmentTime)
           .not.to.be.undefined;
@@ -175,7 +175,7 @@ describe('admin.auth', () => {
           .to.equal(enrolledFactors[0].displayName);
         expect(userRecord.multiFactor.enrolledFactors[0].factorId)
           .to.equal(enrolledFactors[0].factorId);
-        // Confirm second factor.
+        // Confirm second enrolled second factor.
         expect(userRecord.multiFactor.enrolledFactors[1].uid).not.to.be.undefined;
         expect(userRecord.multiFactor.enrolledFactors[1].enrollmentTime)
           .not.to.be.undefined;

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -2426,53 +2426,35 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             });
         });
 
-        it('should be fulfilled given null enrolled factors', () => {
-          // Successful result server response.
-          const expectedResult = utils.responseFrom({
-            localId: uid,
-          });
-
-          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
-          stubs.push(stub);
-
-          const requestHandler = handler.init(mockApp);
-          // Send create new account request with null enrolled factors.
-          return requestHandler.createNewAccount({uid, multiFactor: {enrolledFactors: null}})
-            .then((returnedUid: string) => {
-              // uid should be returned.
-              expect(returnedUid).to.be.equal(uid);
-              // Confirm expected rpc request parameters sent. In this case, no mfa info should
-              // be sent.
-              expect(stub).to.have.been.calledOnce.and.calledWith(
-                callParams(path, method, emptyRequest));
+        const noEnrolledFactors: any[] = [[], null];
+        noEnrolledFactors.forEach((arg) => {
+          it(`should be fulfilled given "${JSON.stringify(arg)}" enrolled factors`, () => {
+            // Successful result server response.
+            const expectedResult = utils.responseFrom({
+              localId: uid,
             });
-        });
 
-        it('should be fulfilled given empty enrolled factors array', () => {
-          // Successful result server response.
-          const expectedResult = utils.responseFrom({
-            localId: uid,
+            const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
+            stubs.push(stub);
+
+            const requestHandler = handler.init(mockApp);
+            // Send create new account request with no enrolled factors.
+            return requestHandler.createNewAccount({uid, multiFactor: {enrolledFactors: null}})
+              .then((returnedUid: string) => {
+                // uid should be returned.
+                expect(returnedUid).to.be.equal(uid);
+                // Confirm expected rpc request parameters sent. In this case, no mfa info should
+                // be sent.
+                expect(stub).to.have.been.calledOnce.and.calledWith(
+                  callParams(path, method, emptyRequest));
+              });
           });
-
-          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
-          stubs.push(stub);
-
-          const requestHandler = handler.init(mockApp);
-          // Send create new account request with empty enrolled factors.
-          return requestHandler.createNewAccount({uid, multiFactor: {enrolledFactors: []}})
-            .then((returnedUid: string) => {
-              // uid should be returned.
-              expect(returnedUid).to.be.equal(uid);
-              // Confirm expected rpc request parameters sent. In this case, no mfa info should
-              // be sent.
-              expect(stub).to.have.been.calledOnce.and.calledWith(
-                callParams(path, method, emptyRequest));
-            });
         });
 
         const unsupportedSecondFactor = {
           secret: 'SECRET',
           displayName: 'Google Authenticator on personal phone',
+          // TOTP is not yet supported.
           factorId: 'totp',
         };
         const invalidSecondFactorTests: InvalidMultiFactorUpdateTest[] = [


### PR DESCRIPTION
Extends createUser to support multi-factor user creation.

Note that only phoneNumber and displayName are allowed to be passed in this operation.

Adds relevant unit and integration tests.

This capability is only available in staging.
