### PR TITLE
Changes saltSeparator type from string to Buffer

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -863,7 +863,7 @@ declare namespace admin.auth {
        * The salt separator in buffer bytes which is appended to salt when
        * verifying a password. This is only used by the `SCRYPT` algorithm.
        */
-      saltSeparator?: string;
+      saltSeparator?: Buffer;
 
       /**
        * The number of rounds for hashing calculation.


### PR DESCRIPTION
Fix an inconsistency where `hash.saltSeparator` on `UserImportOptions` is expecting a `Buffer` but its type on Typescript module was specified as a `string`