### PR TITLE
fix: Fixing a response parse error in IID delete API

### DIFF
--- a/src/instance-id/instance-id-request.ts
+++ b/src/instance-id/instance-id-request.ts
@@ -62,7 +62,7 @@ export class FirebaseInstanceIdRequestHandler {
     this.path = FIREBASE_IID_PATH + `project/${projectId}/instanceId/`;
   }
 
-  public deleteInstanceId(instanceId: string): Promise<object> {
+  public deleteInstanceId(instanceId: string): Promise<void> {
     if (!validator.isNonEmptyString(instanceId)) {
       return Promise.reject(new FirebaseInstanceIdError(
         InstanceIdClientErrorCode.INVALID_INSTANCE_ID,
@@ -76,9 +76,9 @@ export class FirebaseInstanceIdRequestHandler {
    * Invokes the request handler based on the API settings object passed.
    *
    * @param {ApiSettings} apiSettings The API endpoint settings to apply to request and response.
-   * @return {Promise<object>} A promise that resolves with the response.
+   * @return {Promise<void>} A promise that resolves when the request is complete.
    */
-  private invokeRequestHandler(apiSettings: ApiSettings): Promise<object> {
+  private invokeRequestHandler(apiSettings: ApiSettings): Promise<void> {
     const path: string = this.path + apiSettings.getEndpoint();
     return Promise.resolve()
       .then(() => {
@@ -90,7 +90,7 @@ export class FirebaseInstanceIdRequestHandler {
         return this.httpClient.send(req);
       })
       .then((response) => {
-        return response.data;
+        // return nothing on success
       })
       .catch((err) => {
         if (err instanceof HttpError) {

--- a/test/unit/instance-id/instance-id-request.spec.ts
+++ b/test/unit/instance-id/instance-id-request.spec.ts
@@ -80,15 +80,13 @@ describe('FirebaseInstanceIdRequestHandler', () => {
     const timeout = 10000;
 
     it('should be fulfilled given a valid instance ID', () => {
-      const expectedResult = {};
       const stub = sinon.stub(HttpClient.prototype, 'send')
-        .resolves(utils.responseFrom(expectedResult));
+        .resolves(utils.responseFrom(''));
       stubs.push(stub);
 
       const requestHandler = new FirebaseInstanceIdRequestHandler(mockApp, projectId);
       return requestHandler.deleteInstanceId('test-iid')
-        .then((result) => {
-          expect(result).to.deep.equal(expectedResult);
+        .then(() => {
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: httpMethod,
             url: `https://${host}${path}`,


### PR DESCRIPTION
RELEASE NOTE: Fixed a bug in the `admin.instanceId().deleteInstanceId()` API that caused errors even when the operation completed successfully in the backend.

b/139957032