### PR TITLE
Refactored the credentials implementation

### DIFF
--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -141,14 +141,6 @@ class ServiceAccount {
   public readonly clientEmail: string;
 
   public static fromPath(filePath: string): ServiceAccount {
-    // Node bug encountered in v6.x. fs.readFileSync hangs when path is a 0 or 1.
-    if (typeof filePath !== 'string') {
-      throw new FirebaseAppError(
-        AppErrorCodes.INVALID_CREDENTIAL,
-        'Failed to parse service account json file: TypeError: path must be a string',
-      );
-    }
-
     try {
       return new ServiceAccount(JSON.parse(fs.readFileSync(filePath, 'utf8')));
     } catch (error) {
@@ -283,14 +275,6 @@ class RefreshToken {
    * data at the path is invalid.
    */
   public static fromPath(filePath: string): RefreshToken {
-    // Node bug encountered in v6.x. fs.readFileSync hangs when path is a 0 or 1.
-    if (typeof filePath !== 'string') {
-      throw new FirebaseAppError(
-        AppErrorCodes.INVALID_CREDENTIAL,
-        'Failed to parse service account json file: TypeError: path must be a string',
-      );
-    }
-
     try {
       return new RefreshToken(JSON.parse(fs.readFileSync(filePath, 'utf8')));
     } catch (error) {
@@ -415,13 +399,6 @@ function credentialFromFile(filePath: string, httpAgent?: Agent): Credential {
 }
 
 function readCredentialFile(filePath: string, ignoreMissing?: boolean): {[key: string]: any} | null {
-  if (typeof filePath !== 'string') {
-    throw new FirebaseAppError(
-      AppErrorCodes.INVALID_CREDENTIAL,
-      'Failed to parse credentials file: TypeError: path must be a string',
-    );
-  }
-
   let fileText: string;
   try {
     fileText = fs.readFileSync(filePath, 'utf8');

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -70,7 +70,7 @@ export interface Credential {
 }
 
 /**
- * Implementation of Credential that uses a service account certificate.
+ * Implementation of Credential that uses a service account.
  */
 export class ServiceAccountCredential implements Credential {
 
@@ -132,7 +132,7 @@ export class ServiceAccountCredential implements Credential {
 }
 
 /**
- * A struct containing the properties necessary to use service-account JSON credentials.
+ * A struct containing the properties necessary to use service account JSON credentials.
  */
 class ServiceAccount {
 

--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -15,7 +15,7 @@
  */
 
 import { FirebaseApp } from '../firebase-app';
-import {Certificate, tryGetCertificate} from './credential';
+import {ServiceAccountCredential} from './credential';
 import {AuthClientErrorCode, FirebaseAuthError } from '../utils/error';
 import { AuthorizedHttpClient, HttpError, HttpRequestConfig, HttpClient } from '../utils/api-request';
 
@@ -81,28 +81,19 @@ interface JWTBody {
  * sign data. Performs all operations locally, and does not make any RPC calls.
  */
 export class ServiceAccountSigner implements CryptoSigner {
-  private readonly certificate: Certificate;
 
   /**
-   * Creates a new CryptoSigner instance from the given service account certificate.
+   * Creates a new CryptoSigner instance from the given service account credential.
    *
-   * @param {Certificate} certificate A service account certificate.
+   * @param {ServiceAccountCredential} credential A service account credential.
    */
-  constructor(certificate: Certificate) {
-    if (!certificate) {
+  constructor(private readonly credential: ServiceAccountCredential) {
+    if (!credential) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_CREDENTIAL,
-        'INTERNAL ASSERT: Must provide a certificate to initialize ServiceAccountSigner.',
+        'INTERNAL ASSERT: Must provide a service account credential to initialize ServiceAccountSigner.',
       );
     }
-    if (!validator.isNonEmptyString(certificate.clientEmail) || !validator.isNonEmptyString(certificate.privateKey)) {
-      throw new FirebaseAuthError(
-        AuthClientErrorCode.INVALID_CREDENTIAL,
-        'INTERNAL ASSERT: Must provide a certificate with validate clientEmail and privateKey to ' +
-        'initialize ServiceAccountSigner.',
-      );
-    }
-    this.certificate = certificate;
   }
 
   /**
@@ -112,14 +103,14 @@ export class ServiceAccountSigner implements CryptoSigner {
     const crypto = require('crypto');
     const sign = crypto.createSign('RSA-SHA256');
     sign.update(buffer);
-    return Promise.resolve(sign.sign(this.certificate.privateKey));
+    return Promise.resolve(sign.sign(this.credential.privateKey));
   }
 
   /**
    * @inheritDoc
    */
   public getAccountId(): Promise<string> {
-    return Promise.resolve(this.certificate.clientEmail);
+    return Promise.resolve(this.credential.clientEmail);
   }
 }
 
@@ -231,12 +222,11 @@ export class IAMSigner implements CryptoSigner {
  * @return {CryptoSigner} A CryptoSigner instance.
  */
 export function cryptoSignerFromApp(app: FirebaseApp): CryptoSigner {
-  if (app.options.credential) {
-    const cert = tryGetCertificate(app.options.credential);
-    if (cert != null && validator.isNonEmptyString(cert.privateKey) && validator.isNonEmptyString(cert.clientEmail)) {
-      return new ServiceAccountSigner(cert);
-    }
+  const credential = app.options.credential;
+  if (credential instanceof ServiceAccountCredential) {
+    return new ServiceAccountSigner(credential);
   }
+
   return new IAMSigner(new AuthorizedHttpClient(app), app.options.serviceAccountId);
 }
 

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -264,7 +264,7 @@ export class FirebaseApp {
 
     const hasCredential = ('credential' in this.options_);
     if (!hasCredential) {
-      this.options_.credential = getApplicationDefault(this.options.httpAgent);
+      this.options_.credential = getApplicationDefault(this.options_.httpAgent);
     }
 
     const credential = this.options_.credential;

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApplicationDefaultCredential, Credential, GoogleOAuthAccessToken} from './auth/credential';
+import {Credential, GoogleOAuthAccessToken, getApplicationDefault} from './auth/credential';
 import * as validator from './utils/validator';
 import {deepCopy, deepExtend} from './utils/deep-copy';
 import {FirebaseServiceInterface} from './firebase-service';
@@ -264,7 +264,7 @@ export class FirebaseApp {
 
     const hasCredential = ('credential' in this.options_);
     if (!hasCredential) {
-      this.options_.credential = new ApplicationDefaultCredential();
+      this.options_.credential = getApplicationDefault(this.options.httpAgent);
     }
 
     const credential = this.options_.credential;

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -22,9 +22,9 @@ import {AppHook, FirebaseApp, FirebaseAppOptions} from './firebase-app';
 import {FirebaseServiceFactory, FirebaseServiceInterface} from './firebase-service';
 import {
   Credential,
-  CertCredential,
   RefreshTokenCredential,
-  ApplicationDefaultCredential,
+  ServiceAccountCredential,
+  getApplicationDefault,
 } from './auth/credential';
 
 import {Auth} from './auth/auth';
@@ -48,8 +48,8 @@ const DEFAULT_APP_NAME = '[DEFAULT]';
 export const FIREBASE_CONFIG_VAR: string = 'FIREBASE_CONFIG';
 
 
-let globalAppDefaultCred: ApplicationDefaultCredential;
-const globalCertCreds: { [key: string]: CertCredential } = {};
+let globalAppDefaultCred: Credential;
+const globalCertCreds: { [key: string]: ServiceAccountCredential } = {};
 const globalRefreshTokenCreds: { [key: string]: RefreshTokenCredential } = {};
 
 
@@ -85,7 +85,7 @@ export class FirebaseNamespaceInternals {
   public initializeApp(options?: FirebaseAppOptions, appName = DEFAULT_APP_NAME): FirebaseApp {
     if (typeof options === 'undefined') {
       options = this.loadOptionsFromEnvVar();
-      options.credential = new ApplicationDefaultCredential();
+      options.credential = getApplicationDefault();
     }
     if (typeof appName !== 'string' || appName === '') {
       throw new FirebaseAppError(
@@ -275,7 +275,7 @@ const firebaseCredential = {
   cert: (serviceAccountPathOrObject: string | object, httpAgent?: Agent): Credential => {
     const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
     if (!(stringifiedServiceAccount in globalCertCreds)) {
-      globalCertCreds[stringifiedServiceAccount] = new CertCredential(serviceAccountPathOrObject, httpAgent);
+      globalCertCreds[stringifiedServiceAccount] = new ServiceAccountCredential(serviceAccountPathOrObject, httpAgent);
     }
     return globalCertCreds[stringifiedServiceAccount];
   },
@@ -291,7 +291,7 @@ const firebaseCredential = {
 
   applicationDefault: (httpAgent?: Agent): Credential => {
     if (typeof globalAppDefaultCred === 'undefined') {
-      globalAppDefaultCred = new ApplicationDefaultCredential(httpAgent);
+      globalAppDefaultCred = getApplicationDefault(httpAgent);
     }
     return globalAppDefaultCred;
   },

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -75,14 +75,13 @@ export function getFirestoreOptions(app: FirebaseApp): Settings {
   const credential = app.options.credential;
   const { version: firebaseVersion } = require('../../package.json');
   if (credential instanceof ServiceAccountCredential) {
-    // cert is available when the SDK has been initialized with a service account JSON file,
-    // or by setting the GOOGLE_APPLICATION_CREDENTIALS envrionment variable.
-
     return {
       credentials: {
         private_key: credential.privateKey,
         client_email: credential.clientEmail,
       },
+      // When the SDK is initialized with ServiceAccountCredentials projectId is guaranteed to
+      // be available.
       projectId: projectId!,
       firebaseVersion,
     };

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -17,9 +17,10 @@
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseError} from '../utils/error';
 import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
-import {ApplicationDefaultCredential, Certificate, tryGetCertificate} from '../auth/credential';
+import {ServiceAccountCredential, ComputeEngineCredential} from '../auth/credential';
 import {Bucket, Storage as StorageClient} from '@google-cloud/storage';
 
+import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
 
 /**
@@ -70,18 +71,19 @@ export class Storage implements FirebaseServiceInterface {
       });
     }
 
-    const cert: Certificate | null = tryGetCertificate(app.options.credential);
-    if (cert != null) {
+    const projectId: string | null = utils.getProjectId(app);
+    const credential = app.options.credential;
+    if (credential instanceof ServiceAccountCredential) {
       // cert is available when the SDK has been initialized with a service account JSON file,
       // or by setting the GOOGLE_APPLICATION_CREDENTIALS envrionment variable.
       this.storageClient = new storage({
-        projectId: cert.projectId,
+        projectId: projectId!,
         credentials: {
-          private_key: cert.privateKey,
-          client_email: cert.clientEmail,
+          private_key: credential.privateKey,
+          client_email: credential.clientEmail,
         },
       });
-    } else if (app.options.credential instanceof ApplicationDefaultCredential) {
+    } else if (app.options.credential instanceof ComputeEngineCredential) {
       // Try to use the Google application default credentials.
       this.storageClient = new storage();
     } else {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -74,9 +74,9 @@ export class Storage implements FirebaseServiceInterface {
     const projectId: string | null = utils.getProjectId(app);
     const credential = app.options.credential;
     if (credential instanceof ServiceAccountCredential) {
-      // cert is available when the SDK has been initialized with a service account JSON file,
-      // or by setting the GOOGLE_APPLICATION_CREDENTIALS envrionment variable.
       this.storageClient = new storage({
+        // When the SDK is initialized with ServiceAccountCredentials projectId is guaranteed to
+        // be available.
         projectId: projectId!,
         credentials: {
           private_key: credential.privateKey,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {FirebaseApp, FirebaseAppOptions} from '../firebase-app';
-import {Certificate, tryGetCertificate} from '../auth/credential';
+import {ServiceAccountCredential} from '../auth/credential';
 
 import * as validator from './validator';
 
@@ -69,9 +69,9 @@ export function getProjectId(app: FirebaseApp): string | null {
     return options.projectId;
   }
 
-  const cert: Certificate | null = tryGetCertificate(options.credential);
-  if (cert != null && validator.isNonEmptyString(cert.projectId)) {
-    return cert.projectId;
+  const credential = app.options.credential;
+  if (credential instanceof ServiceAccountCredential) {
+    return credential.projectId;
   }
 
   const projectId = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -27,7 +27,7 @@ import * as jwt from 'jsonwebtoken';
 import {FirebaseNamespace} from '../../src/firebase-namespace';
 import {FirebaseServiceInterface} from '../../src/firebase-service';
 import {FirebaseApp, FirebaseAppOptions} from '../../src/firebase-app';
-import {Certificate, Credential, CertCredential, GoogleOAuthAccessToken} from '../../src/auth/credential';
+import {Credential, GoogleOAuthAccessToken, ServiceAccountCredential} from '../../src/auth/credential';
 
 const ALGORITHM = 'RS256';
 const ONE_HOUR_IN_SECONDS = 60 * 60;
@@ -49,7 +49,7 @@ export let databaseAuthVariableOverride = { 'some#string': 'some#val' };
 
 export let storageBucket = 'bucketName.appspot.com';
 
-export let credential = new CertCredential(path.resolve(__dirname, './mock.key.json'));
+export let credential = new ServiceAccountCredential(path.resolve(__dirname, './mock.key.json'));
 
 export let appOptions: FirebaseAppOptions = {
   credential,
@@ -85,10 +85,6 @@ export class MockCredential implements Credential {
       expires_in: 3600,
     });
   }
-
-  public getCertificate(): Certificate | null {
-    return null;
-  }
 }
 
 export function app(): FirebaseApp {
@@ -111,13 +107,13 @@ export function appWithOptions(options: FirebaseAppOptions): FirebaseApp {
 }
 
 export function appReturningNullAccessToken(): FirebaseApp {
-  const nullFn: () => Promise<GoogleOAuthAccessToken>|null = () => null;
+  const nullFn: () => Promise<GoogleOAuthAccessToken> | null = () => null;
   return new FirebaseApp({
     credential: {
       getAccessToken: nullFn,
-      getCertificate: () => credential.getCertificate(),
     } as any,
     databaseURL,
+    projectId,
   }, appName, new FirebaseNamespace().INTERNAL);
 }
 
@@ -125,9 +121,9 @@ export function appReturningMalformedAccessToken(): FirebaseApp {
   return new FirebaseApp({
     credential: {
       getAccessToken: () => 5,
-      getCertificate: () => credential.getCertificate(),
     } as any,
     databaseURL,
+    projectId,
   }, appName, new FirebaseNamespace().INTERNAL);
 }
 
@@ -135,9 +131,9 @@ export function appRejectedWhileFetchingAccessToken(): FirebaseApp {
   return new FirebaseApp({
     credential: {
       getAccessToken: () => Promise.reject(new Error('Promise intentionally rejected.')),
-      getCertificate: () => credential.getCertificate(),
     } as any,
     databaseURL,
+    projectId,
   }, appName, new FirebaseNamespace().INTERNAL);
 }
 

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -43,6 +43,7 @@ import {
 import {deepCopy} from '../../../src/utils/deep-copy';
 import { TenantManager } from '../../../src/auth/tenant-manager';
 import { ServiceAccountCredential } from '../../../src/auth/credential';
+import { HttpClient } from '../../../src/utils/api-request';
 
 chai.should();
 chai.use(sinonChai);
@@ -357,7 +358,9 @@ AUTH_CONFIGS.forEach((testConfig) => {
       }
 
       it('should be eventually rejected if a cert credential is not specified', () => {
-        const mockCredentialAuth = testConfig.init(mocks.appRejectedWhileFetchingAccessToken());
+        const mockCredentialAuth = testConfig.init(mocks.mockCredentialApp());
+        // Force the service account ID discovery to fail.
+        getTokenStub = sinon.stub(HttpClient.prototype, 'send').rejects(utils.errorFrom({}));
         return mockCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims)
           .should.eventually.be.rejected.and.have.property('code', 'auth/invalid-credential');
       });

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -357,7 +357,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       }
 
       it('should be eventually rejected if a cert credential is not specified', () => {
-        const mockCredentialAuth = testConfig.init(mocks.mockCredentialApp());
+        const mockCredentialAuth = testConfig.init(mocks.appRejectedWhileFetchingAccessToken());
         return mockCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims)
           .should.eventually.be.rejected.and.have.property('code', 'auth/invalid-credential');
       });

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -42,6 +42,7 @@ import {
 } from '../../../src/auth/auth-config';
 import {deepCopy} from '../../../src/utils/deep-copy';
 import { TenantManager } from '../../../src/auth/tenant-manager';
+import { ServiceAccountCredential } from '../../../src/auth/credential';
 
 chai.should();
 chai.use(sinonChai);
@@ -377,20 +378,23 @@ AUTH_CONFIGS.forEach((testConfig) => {
         });
 
         it('should be fulfilled given an app which returns null access tokens', () => {
+          getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').resolves(null);
           // createCustomToken() does not rely on an access token and therefore works in this scenario.
-          return nullAccessTokenAuth.createCustomToken(mocks.uid, mocks.developerClaims)
+          return auth.createCustomToken(mocks.uid, mocks.developerClaims)
             .should.eventually.be.fulfilled;
         });
 
         it('should be fulfilled given an app which returns invalid access tokens', () => {
+          getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').resolves('malformed');
           // createCustomToken() does not rely on an access token and therefore works in this scenario.
-          return malformedAccessTokenAuth.createCustomToken(mocks.uid, mocks.developerClaims)
+          return auth.createCustomToken(mocks.uid, mocks.developerClaims)
             .should.eventually.be.fulfilled;
         });
 
         it('should be fulfilled given an app which fails to generate access tokens', () => {
+          getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').rejects('error');
           // createCustomToken() does not rely on an access token and therefore works in this scenario.
-          return rejectedPromiseAccessTokenAuth.createCustomToken(mocks.uid, mocks.developerClaims)
+          return auth.createCustomToken(mocks.uid, mocks.developerClaims)
             .should.eventually.be.fulfilled;
         });
       }

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -31,8 +31,8 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {
-  ApplicationDefaultCredential, CertCredential, Certificate, GoogleOAuthAccessToken,
-  MetadataServiceCredential, RefreshTokenCredential, tryGetCertificate,
+  GoogleOAuthAccessToken, RefreshTokenCredential, ServiceAccountCredential,
+  ComputeEngineCredential, getApplicationDefault,
 } from '../../../src/auth/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import {Agent} from 'https';
@@ -91,167 +91,81 @@ describe('Credential', () => {
     process.env = oldProcessEnv;
   });
 
-
-  describe('Certificate', () => {
-    describe('fromPath', () => {
-      const invalidFilePaths = [null, NaN, 0, 1, true, false, {}, [], { a: 1 }, [1, 'a'], _.noop];
-      invalidFilePaths.forEach((invalidFilePath) => {
-        it('should throw if called with non-string argument: ' + JSON.stringify(invalidFilePath), () => {
-          expect(() => {
-            Certificate.fromPath(invalidFilePath as any);
-          }).to.throw('Failed to parse certificate key file: TypeError: path must be a string');
-        });
-      });
-
-      it('should throw if called with no argument', () => {
-        expect(() => {
-          (Certificate as any).fromPath();
-        }).to.throw('Failed to parse certificate key file: TypeError: path must be a string');
-      });
-
-      it('should throw if called with the path to a non-existent file', () => {
-        expect(() => Certificate.fromPath('invalid-file'))
-          .to.throw('Failed to parse certificate key file: Error: ENOENT: no such file or directory');
-      });
-
-      it('should throw if called with the path to an invalid file', () => {
-        const invalidPath = path.resolve(__dirname, '../../resources/unparesable.json');
-        expect(() => Certificate.fromPath(invalidPath))
-          .to.throw('Failed to parse certificate key file: Error: ENOENT: no such file or directory');
-      });
-
-      it('should throw if called with an empty string path', () => {
-        expect(() => Certificate.fromPath(''))
-          .to.throw('Failed to parse certificate key file: Error: ENOENT: no such file or directory');
-      });
-
-      it('should not throw given a valid path to a key file', () => {
-        const validPath = path.resolve(__dirname, '../../resources/mock.key.json');
-        expect(() => Certificate.fromPath(validPath)).not.to.throw();
-      });
-
-      it('should throw given an object without a "private_key" property', () => {
-        const invalidCertificate = _.omit(mocks.certificateObject, 'private_key');
-        expect(() => {
-          return new Certificate(invalidCertificate as any);
-        }).to.throw('Certificate object must contain a string "private_key" property');
-      });
-
-      it('should throw given an object with an empty string "private_key" property', () => {
-        const invalidCertificate = _.clone(mocks.certificateObject);
-        invalidCertificate.private_key = '';
-        expect(() => {
-          return new Certificate(invalidCertificate as any);
-        }).to.throw('Certificate object must contain a string "private_key" property');
-      });
-
-      it('should throw given an object without a "client_email" property', () => {
-        const invalidCertificate = _.omit(mocks.certificateObject, 'client_email');
-        expect(() => {
-          return new Certificate(invalidCertificate as any);
-        }).to.throw('Certificate object must contain a string "client_email" property');
-      });
-
-      it('should throw given an object with an empty string "client_email" property', () => {
-        const invalidCertificate = _.clone(mocks.certificateObject);
-        invalidCertificate.client_email = '';
-        expect(() => {
-          return new Certificate(invalidCertificate as any);
-        }).to.throw('Certificate object must contain a string "client_email" property');
-      });
-
-      const invalidCredentials = [null, NaN, 0, 1, true, false, '', 'a', [], {}, { a: 1 }, _.noop];
-      invalidCredentials.forEach((invalidCredential) => {
-        it('should throw given invalid Credential: ' + JSON.stringify(invalidCredential), () => {
-          expect(() => {
-            return new Certificate(invalidCredential as any);
-          }).to.throw(Error);
-        });
+  describe('ServiceAccountCredential', () => {
+    const invalidFilePaths = [null, NaN, 0, 1, true, false, undefined, _.noop];
+    invalidFilePaths.forEach((invalidFilePath) => {
+      it('should throw if called with non-string argument: ' + JSON.stringify(invalidFilePath), () => {
+        expect(() => new ServiceAccountCredential(invalidFilePath as any))
+          .to.throw('Service account must be an object');
       });
     });
 
-    describe('constructor', () => {
-      const invalidCertificateObjects = [null, NaN, 0, 1, true, false, _.noop];
-      invalidCertificateObjects.forEach((invalidCertificateObject) => {
-        it('should throw if called with non-object argument: ' + JSON.stringify(invalidCertificateObject), () => {
-          expect(() => {
-            return new Certificate(invalidCertificateObject as any);
-          }).to.throw('Certificate object must be an object.');
-        });
-      });
-
-      it('should throw if called with no argument', () => {
-        expect(() => {
-          return new (Certificate as any)();
-        }).to.throw('Certificate object must be an object.');
-      });
-
-      it('should throw if certificate object does not contain a valid "client_email"', () => {
-        mockCertificateObject.client_email = '';
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).to.throw('Certificate object must contain a string "client_email" property');
-
-        delete mockCertificateObject.client_email;
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).to.throw('Certificate object must contain a string "client_email" property');
-      });
-
-      it('should throw if certificate object does not contain a "private_key"', () => {
-        mockCertificateObject.private_key = '';
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).to.throw('Certificate object must contain a string "private_key" property');
-
-        delete mockCertificateObject.private_key;
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).to.throw('Certificate object must contain a string "private_key" property');
-      });
-
-      it('should throw if certificate object does not contain a valid "private_key"', () => {
-        mockCertificateObject.private_key = 'invalid.key';
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).to.throw('Failed to parse private key: Error: Invalid PEM formatted message.');
-      });
-
-      it('should not throw given a valid certificate object', () => {
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).not.to.throw();
-      });
-
-      it('should accept "clientEmail" in place of "client_email" for the certificate object', () => {
-        mockCertificateObject.clientEmail = mockCertificateObject.client_email;
-        delete mockCertificateObject.client_email;
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).not.to.throw();
-      });
-
-      it('should accept "privateKey" in place of "private_key" for the certificate object', () => {
-        mockCertificateObject.privateKey = mockCertificateObject.private_key;
-        delete mockCertificateObject.private_key;
-
-        expect(() => {
-          return new Certificate(mockCertificateObject);
-        }).not.to.throw();
-      });
+    it('should throw if called with the path to a non-existent file', () => {
+      expect(() => new ServiceAccountCredential('invalid-file'))
+        .to.throw('Failed to parse service account json file: Error: ENOENT: no such file or directory');
     });
-  });
 
-  describe('CertCredential', () => {
+    it('should throw if called with the path to an invalid file', () => {
+      const invalidPath = path.resolve(__dirname, '../../resources/unparesable.json');
+      expect(() => new ServiceAccountCredential(invalidPath))
+        .to.throw('Failed to parse service account json file: Error: ENOENT: no such file or directory');
+    });
+
+    it('should throw if called with an empty string path', () => {
+      expect(() => new ServiceAccountCredential(''))
+        .to.throw('Failed to parse service account json file: Error: ENOENT: no such file or directory');
+    });
+
+    it('should throw given an object without a "private_key" property', () => {
+      const invalidCertificate = _.omit(mocks.certificateObject, 'private_key');
+      expect(() => new ServiceAccountCredential(invalidCertificate as any))
+        .to.throw('Service account object must contain a string "private_key" property');
+    });
+
+    it('should throw given an object with an empty string "private_key" property', () => {
+      const invalidCertificate = _.clone(mocks.certificateObject);
+      invalidCertificate.private_key = '';
+      expect(() => new ServiceAccountCredential(invalidCertificate as any))
+        .to.throw('Service account object must contain a string "private_key" property');
+    });
+
+    it('should throw given an object without a "client_email" property', () => {
+      const invalidCertificate = _.omit(mocks.certificateObject, 'client_email');
+      expect(() => new ServiceAccountCredential(invalidCertificate as any))
+        .to.throw('Service account object must contain a string "client_email" property');
+    });
+
+    it('should throw given an object with an empty string "client_email" property', () => {
+      const invalidCertificate = _.clone(mocks.certificateObject);
+      invalidCertificate.client_email = '';
+      expect(() => new ServiceAccountCredential(invalidCertificate as any))
+        .to.throw('Service account object must contain a string "client_email" property');
+    });
+
+    it('should not throw given a valid path to a key file', () => {
+      const validPath = path.resolve(__dirname, '../../resources/mock.key.json');
+      expect(() => new ServiceAccountCredential(validPath)).not.to.throw();
+    });
+
+    it('should accept "clientEmail" in place of "client_email" for the certificate object', () => {
+      mockCertificateObject.clientEmail = mockCertificateObject.client_email;
+      delete mockCertificateObject.client_email;
+
+      expect(() => new ServiceAccountCredential(mockCertificateObject))
+        .not.to.throw();
+    });
+
+    it('should accept "privateKey" in place of "private_key" for the certificate object', () => {
+      mockCertificateObject.privateKey = mockCertificateObject.private_key;
+      delete mockCertificateObject.private_key;
+
+      expect(() => new ServiceAccountCredential(mockCertificateObject))
+        .not.to.throw();
+    });
+
     it('should return a Credential', () => {
-      const c = new CertCredential(mockCertificateObject);
-      expect(c.getCertificate()).to.deep.equal({
+      const c = new ServiceAccountCredential(mockCertificateObject);
+      expect(c).to.deep.include({
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,
@@ -259,8 +173,8 @@ describe('Credential', () => {
     });
 
     it('should return a certificate', () => {
-      const c = new CertCredential(mockCertificateObject);
-      expect(tryGetCertificate(c)).to.deep.equal({
+      const c = new ServiceAccountCredential(mockCertificateObject);
+      expect(c).to.deep.include({
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,
@@ -268,7 +182,7 @@ describe('Credential', () => {
     });
 
     it('should create access tokens', () => {
-      const c = new CertCredential(mockCertificateObject);
+      const c = new ServiceAccountCredential(mockCertificateObject);
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.be.a('string').and.to.not.be.empty;
         expect(token.expires_in).to.equal(ONE_HOUR_IN_SECONDS);
@@ -287,14 +201,14 @@ describe('Credential', () => {
           error: 'invalid_grant',
           error_description: 'reason',
         }));
-        const c = new CertCredential(mockCertificateObject);
+        const c = new ServiceAccountCredential(mockCertificateObject);
         return expect(c.getAccessToken()).to.be
           .rejectedWith('Error fetching access token: invalid_grant (reason)');
       });
 
       it('should throw an error including error text payload', () => {
         httpStub.rejects(utils.errorFrom('not json'));
-        const c = new CertCredential(mockCertificateObject);
+        const c = new ServiceAccountCredential(mockCertificateObject);
         return expect(c.getAccessToken()).to.be
           .rejectedWith('Error fetching access token: not json');
       });
@@ -302,11 +216,6 @@ describe('Credential', () => {
   });
 
   describe('RefreshTokenCredential', () => {
-    it('should not return a certificate', () => {
-      const c = new RefreshTokenCredential(MOCK_REFRESH_TOKEN_CONFIG);
-      expect(tryGetCertificate(c)).to.be.null;
-    });
-
     it('should create access tokens', () => {
       const scope = nock('https://www.googleapis.com')
         .post('/oauth2/v4/token')
@@ -327,15 +236,10 @@ describe('Credential', () => {
     });
   });
 
-  describe('MetadataServiceCredential', () => {
+  describe('ComputeEngineCredential', () => {
     let httpStub: sinon.SinonStub;
-    before(() => httpStub = sinon.stub(HttpClient.prototype, 'send'));
-    after(() => httpStub.restore());
-
-    it('should not return a certificate', () => {
-      const c = new MetadataServiceCredential();
-      expect(tryGetCertificate(c)).to.be.null;
-    });
+    beforeEach(() => httpStub = sinon.stub(HttpClient.prototype, 'send'));
+    afterEach(() => httpStub.restore());
 
     it('should create access tokens', () => {
       const expected: GoogleOAuthAccessToken = {
@@ -345,7 +249,7 @@ describe('Credential', () => {
       const response = utils.responseFrom(expected);
       httpStub.resolves(response);
 
-      const c = new MetadataServiceCredential();
+      const c = new ComputeEngineCredential();
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.equal('anAccessToken');
         expect(token.expires_in).to.equal(42);
@@ -357,9 +261,26 @@ describe('Credential', () => {
         });
       });
     });
+
+    it('should discover project id', () => {
+      const expected = 'test-project-id';
+      const response = utils.responseFrom(expected);
+      httpStub.resolves(response);
+
+      const c = new ComputeEngineCredential();
+      return c.getProjectId().then((projectId) => {
+        expect(projectId).to.equal(expected);
+        expect(httpStub).to.have.been.calledOnce.and.calledWith({
+          method: 'GET',
+          url: 'http://metadata.google.internal/computeMetadata/v1/project/project-id',
+          headers: {'Metadata-Flavor': 'Google'},
+          httpAgent: undefined,
+        });
+      });
+    });
   });
 
-  describe('ApplicationDefaultCredential', () => {
+  describe('getApplicationDefault()', () => {
     let fsStub: sinon.SinonStub;
 
     afterEach(() => {
@@ -370,23 +291,23 @@ describe('Credential', () => {
 
     it('should return a CertCredential with GOOGLE_APPLICATION_CREDENTIALS set', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
-      const c = new ApplicationDefaultCredential();
-      expect(c.getCredential()).to.be.an.instanceof(CertCredential);
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(ServiceAccountCredential);
     });
 
     it('should throw if explicitly pointing to an invalid path', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = 'invalidpath';
-      expect(() => new ApplicationDefaultCredential()).to.throw(Error);
+      expect(() => getApplicationDefault()).to.throw(Error);
     });
 
     it('should throw if explicitly pointing to an invalid cert file', () => {
       fsStub = sinon.stub(fs, 'readFileSync').returns('invalidjson');
-      expect(() => new ApplicationDefaultCredential()).to.throw(Error);
+      expect(() => getApplicationDefault()).to.throw(Error);
     });
 
     it('should throw error if type not specified on cert file', () => {
       fsStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify({}));
-      expect(() => new ApplicationDefaultCredential())
+      expect(() => getApplicationDefault())
           .to.throw(Error, 'Invalid contents in the credentials file');
     });
 
@@ -394,7 +315,7 @@ describe('Credential', () => {
       fsStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify({
         type: 'foo',
       }));
-      expect(() => new ApplicationDefaultCredential()).to.throw(Error, 'Invalid contents in the credentials file');
+      expect(() => getApplicationDefault()).to.throw(Error, 'Invalid contents in the credentials file');
     });
 
     it('should return a RefreshTokenCredential with gcloud login', () => {
@@ -406,24 +327,24 @@ describe('Credential', () => {
         return;
       }
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-      expect((new ApplicationDefaultCredential()).getCredential()).to.be.an.instanceof(RefreshTokenCredential);
+      expect((getApplicationDefault())).to.be.an.instanceof(RefreshTokenCredential);
     });
 
     it('should throw if a the gcloud login cache is invalid', () => {
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       fsStub = sinon.stub(fs, 'readFileSync').returns('invalidjson');
-      expect(() => new ApplicationDefaultCredential()).to.throw(Error);
+      expect(() => getApplicationDefault()).to.throw(Error);
     });
 
     it('should return a MetadataServiceCredential as a last resort', () => {
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       fsStub = sinon.stub(fs, 'readFileSync').throws(new Error('no gcloud credential file'));
-      expect((new ApplicationDefaultCredential()).getCredential()).to.be.an.instanceof(MetadataServiceCredential);
+      expect(getApplicationDefault()).to.be.an.instanceof(ComputeEngineCredential);
     });
 
     it('should create access tokens', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
-      const c = new ApplicationDefaultCredential();
+      const c = getApplicationDefault();
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.be.a('string').and.to.not.be.empty;
         expect(token.expires_in).to.equal(ONE_HOUR_IN_SECONDS);
@@ -432,18 +353,8 @@ describe('Credential', () => {
 
     it('should return a Credential', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
-      const c = new ApplicationDefaultCredential();
-      expect(c.getCertificate()).to.deep.equal({
-        projectId: mockCertificateObject.project_id,
-        clientEmail: mockCertificateObject.client_email,
-        privateKey: mockCertificateObject.private_key,
-      });
-    });
-
-    it('should return a Certificate', () => {
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
-      const c = new ApplicationDefaultCredential();
-      expect(tryGetCertificate(c)).to.deep.equal({
+      const c = getApplicationDefault();
+      expect(c).to.deep.include({
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,
@@ -456,8 +367,7 @@ describe('Credential', () => {
 
       fsStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify(MOCK_REFRESH_TOKEN_CONFIG));
 
-      const adc = new ApplicationDefaultCredential();
-      const c = adc.getCredential();
+      const c = getApplicationDefault();
       expect(c).is.instanceOf(RefreshTokenCredential);
       expect(c).to.have.property('refreshToken').that.includes({
         clientId: MOCK_REFRESH_TOKEN_CONFIG.client_id,
@@ -485,9 +395,9 @@ describe('Credential', () => {
       stub.restore();
     });
 
-    it('CertCredential should use the provided HTTP Agent', () => {
+    it('ServiceAccountCredential should use the provided HTTP Agent', () => {
       const agent = new Agent();
-      const c = new CertCredential(mockCertificateObject, agent);
+      const c = new ServiceAccountCredential(mockCertificateObject, agent);
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.equal(expectedToken);
         expect(stub).to.have.been.calledOnce;
@@ -505,9 +415,9 @@ describe('Credential', () => {
       });
     });
 
-    it('MetadataServiceCredential should use the provided HTTP Agent', () => {
+    it('ComputeEngineCredential should use the provided HTTP Agent', () => {
       const agent = new Agent();
-      const c = new MetadataServiceCredential(agent);
+      const c = new ComputeEngineCredential(agent);
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.equal(expectedToken);
         expect(stub).to.have.been.calledOnce;
@@ -518,7 +428,7 @@ describe('Credential', () => {
     it('ApplicationDefaultCredential should use the provided HTTP Agent', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
       const agent = new Agent();
-      const c = new ApplicationDefaultCredential(agent);
+      const c = getApplicationDefault(agent);
       return c.getAccessToken().then((token) => {
         expect(token.access_token).to.equal(expectedToken);
         expect(stub).to.have.been.calledOnce;

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -386,7 +386,7 @@ describe('Credential', () => {
       expect(() => getApplicationDefault()).to.throw(Error);
     });
 
-    it('should throw if a the credentials file content is not an object', () => {
+    it('should throw if the credentials file content is not an object', () => {
       process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
       fsStub = sinon.stub(fs, 'readFileSync').returns('2');
       expect(() => getApplicationDefault()).to.throw(Error);

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -28,7 +28,7 @@ import {
   BLACKLISTED_CLAIMS, FirebaseTokenGenerator, ServiceAccountSigner, IAMSigner,
 } from '../../../src/auth/token-generator';
 
-import {Certificate} from '../../../src/auth/credential';
+import { ServiceAccountCredential } from '../../../src/auth/credential';
 import { AuthorizedHttpClient, HttpClient } from '../../../src/utils/api-request';
 import { FirebaseApp } from '../../../src/firebase-app';
 import * as utils from '../utils';
@@ -70,18 +70,18 @@ describe('CryptoSigner', () => {
       expect(() => {
         const anyServiceAccountSigner: any = ServiceAccountSigner;
         return new anyServiceAccountSigner();
-      }).to.throw('Must provide a certificate to initialize ServiceAccountSigner');
+      }).to.throw('Must provide a service account credential to initialize ServiceAccountSigner');
     });
 
     it('should not throw given a valid certificate', () => {
       expect(() => {
-        return new ServiceAccountSigner(new Certificate(mocks.certificateObject));
+        return new ServiceAccountSigner(new ServiceAccountCredential(mocks.certificateObject));
       }).not.to.throw();
     });
 
     it('should sign using the private_key in the certificate', () => {
       const payload = Buffer.from('test');
-      const cert = new Certificate(mocks.certificateObject);
+      const cert = new ServiceAccountCredential(mocks.certificateObject);
 
       const crypto = require('crypto');
       const rsa = crypto.createSign('RSA-SHA256');
@@ -95,7 +95,7 @@ describe('CryptoSigner', () => {
     });
 
     it('should return the client_email from the certificate', () => {
-      const cert = new Certificate(mocks.certificateObject);
+      const cert = new ServiceAccountCredential(mocks.certificateObject);
       const signer = new ServiceAccountSigner(cert);
       return signer.getAccountId().should.eventually.equal(cert.clientEmail);
     });
@@ -257,7 +257,7 @@ describe('FirebaseTokenGenerator', () => {
 
   let clock: sinon.SinonFakeTimers | undefined;
   beforeEach(() => {
-    const cert = new Certificate(mocks.certificateObject);
+    const cert = new ServiceAccountCredential(mocks.certificateObject);
     tokenGenerator = new FirebaseTokenGenerator(new ServiceAccountSigner(cert));
   });
 

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -31,7 +31,7 @@ import * as mocks from '../../resources/mocks';
 import {FirebaseTokenGenerator, ServiceAccountSigner} from '../../../src/auth/token-generator';
 import * as verifier from '../../../src/auth/token-verifier';
 
-import {Certificate} from '../../../src/auth/credential';
+import {ServiceAccountCredential} from '../../../src/auth/credential';
 import { AuthClientErrorCode } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
 
@@ -114,7 +114,7 @@ describe('FirebaseTokenVerifier', () => {
   beforeEach(() => {
     // Needed to generate custom token for testing.
     app = mocks.app();
-    const cert: Certificate = new Certificate(mocks.certificateObject);
+    const cert = new ServiceAccountCredential(mocks.certificateObject);
     tokenGenerator = new FirebaseTokenGenerator(new ServiceAccountSigner(cert));
     tokenVerifier = new verifier.FirebaseTokenVerifier(
       'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -25,7 +25,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from './utils';
 import * as mocks from '../resources/mocks';
 
-import {ApplicationDefaultCredential, CertCredential, GoogleOAuthAccessToken} from '../../src/auth/credential';
+import {GoogleOAuthAccessToken, ServiceAccountCredential} from '../../src/auth/credential';
 import {FirebaseServiceInterface} from '../../src/firebase-service';
 import {FirebaseApp, FirebaseAccessToken} from '../../src/firebase-app';
 import {FirebaseNamespace, FirebaseNamespaceInternals, FIREBASE_CONFIG_VAR} from '../../src/firebase-namespace';
@@ -69,7 +69,7 @@ describe('FirebaseApp', () => {
   let firebaseConfigVar: string | undefined;
 
   beforeEach(() => {
-    getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').resolves({
+    getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').resolves({
       access_token: 'mock-access-token',
       expires_in: 3600,
     });
@@ -243,7 +243,7 @@ describe('FirebaseApp', () => {
     it('should use explicitly specified options when available and ignore the config file', () => {
       process.env[FIREBASE_CONFIG_VAR] = './test/resources/firebase_config.json';
       const app = firebaseNamespace.initializeApp(mocks.appOptions, mocks.appName);
-      expect(app.options.credential).to.be.instanceOf(CertCredential);
+      expect(app.options.credential).to.be.instanceOf(ServiceAccountCredential);
       expect(app.options.databaseAuthVariableOverride).to.be.undefined;
       expect(app.options.databaseURL).to.equal('https://databaseName.firebaseio.com');
       expect(app.options.projectId).to.be.undefined;
@@ -260,7 +260,7 @@ describe('FirebaseApp', () => {
 
     it('should not throw when the config environment variable is not set, and some options are present', () => {
       const app = firebaseNamespace.initializeApp(mocks.appOptionsNoDatabaseUrl, mocks.appName);
-      expect(app.options.credential).to.be.instanceOf(CertCredential);
+      expect(app.options.credential).to.be.instanceOf(ServiceAccountCredential);
       expect(app.options.databaseURL).to.be.undefined;
       expect(app.options.projectId).to.be.undefined;
       expect(app.options.storageBucket).to.be.undefined;
@@ -268,7 +268,7 @@ describe('FirebaseApp', () => {
 
     it('should init with application default creds when no options provided and env variable is not set', () => {
       const app = firebaseNamespace.initializeApp();
-      expect(app.options.credential).to.be.instanceOf(ApplicationDefaultCredential);
+      expect(app.options.credential).to.not.be.undefined;
       expect(app.options.databaseURL).to.be.undefined;
       expect(app.options.projectId).to.be.undefined;
       expect(app.options.storageBucket).to.be.undefined;
@@ -277,7 +277,7 @@ describe('FirebaseApp', () => {
     it('should init with application default creds when no options provided and env variable is an empty json', () => {
       process.env[FIREBASE_CONFIG_VAR] = '{}';
       const app = firebaseNamespace.initializeApp();
-      expect(app.options.credential).to.be.instanceOf(ApplicationDefaultCredential);
+      expect(app.options.credential).to.not.be.undefined;
       expect(app.options.databaseURL).to.be.undefined;
       expect(app.options.projectId).to.be.undefined;
       expect(app.options.storageBucket).to.be.undefined;
@@ -286,7 +286,7 @@ describe('FirebaseApp', () => {
     it('should init when no init arguments are provided and config var points to a file', () => {
       process.env[FIREBASE_CONFIG_VAR] = './test/resources/firebase_config.json';
       const app = firebaseNamespace.initializeApp();
-      expect(app.options.credential).to.be.instanceOf(ApplicationDefaultCredential);
+      expect(app.options.credential).to.not.be.undefined;
       expect(app.options.databaseAuthVariableOverride).to.deep.equal({ 'some#key': 'some#val' });
       expect(app.options.databaseURL).to.equal('https://hipster-chat.firebaseio.mock');
       expect(app.options.projectId).to.equal('hipster-chat-mock');
@@ -301,7 +301,7 @@ describe('FirebaseApp', () => {
         "storageBucket": "hipster-chat.appspot.mock"
       }`;
       const app = firebaseNamespace.initializeApp();
-      expect(app.options.credential).to.be.instanceOf(ApplicationDefaultCredential);
+      expect(app.options.credential).to.not.be.undefined;
       expect(app.options.databaseAuthVariableOverride).to.deep.equal({ 'some#key': 'some#val' });
       expect(app.options.databaseURL).to.equal('https://hipster-chat.firebaseio.mock');
       expect(app.options.projectId).to.equal('hipster-chat-mock');
@@ -760,7 +760,7 @@ describe('FirebaseApp', () => {
 
         // Restore the stubbed getAccessToken() method.
         getTokenStub.restore();
-        getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').resolves({
+        getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').resolves({
           access_token: 'mock-access-token',
           expires_in: 3600,
         });
@@ -944,7 +944,7 @@ describe('FirebaseApp', () => {
       getTokenStub.restore();
       const mockError = new FirebaseAppError(
         AppErrorCodes.INVALID_CREDENTIAL, 'Something went wrong');
-      getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').rejects(mockError);
+      getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').rejects(mockError);
       const detailedMessage = 'Credential implementation provided to initializeApp() via the "credential" property'
         + ' failed to fetch a valid Google OAuth2 access token with the following error: "Something went wrong".';
       expect(mockApp.INTERNAL.getToken(true)).to.be.rejectedWith(detailedMessage);
@@ -954,7 +954,7 @@ describe('FirebaseApp', () => {
       getTokenStub.restore();
       const mockError = new FirebaseAppError(
         AppErrorCodes.INVALID_CREDENTIAL, 'Failed to get credentials: invalid_grant (reason)');
-      getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').rejects(mockError);
+      getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').rejects(mockError);
       const detailedMessage = 'Credential implementation provided to initializeApp() via the "credential" property'
         + ' failed to fetch a valid Google OAuth2 access token with the following error: "Failed to get credentials:'
         + ' invalid_grant (reason)". There are two likely causes: (1) your server time is not properly synced or (2)'

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -27,7 +27,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../resources/mocks';
 
 import * as firebaseAdmin from '../../src/index';
-import {ApplicationDefaultCredential, CertCredential, RefreshTokenCredential} from '../../src/auth/credential';
+import {RefreshTokenCredential, ServiceAccountCredential} from '../../src/auth/credential';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -39,7 +39,7 @@ describe('Firebase', () => {
   let getTokenStub: sinon.SinonStub;
 
   before(() => {
-    getTokenStub = sinon.stub(CertCredential.prototype, 'getAccessToken').resolves({
+    getTokenStub = sinon.stub(ServiceAccountCredential.prototype, 'getAccessToken').resolves({
       access_token: 'mock-access-token',
       expires_in: 3600,
     });
@@ -71,7 +71,7 @@ describe('Firebase', () => {
     it('should use application default credentials when no credentials are explicitly specified', () => {
       const app = firebaseAdmin.initializeApp(mocks.appOptionsNoAuth);
       expect(app.options).to.have.property('credential');
-      expect(app.options.credential).to.be.instanceOf(ApplicationDefaultCredential);
+      expect(app.options.credential).to.not.be.undefined;
     });
 
     it('should not modify the provided options object', () => {

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -22,7 +22,7 @@ import {expect} from 'chai';
 
 import * as mocks from '../../resources/mocks';
 import {FirebaseApp} from '../../../src/firebase-app';
-import {ApplicationDefaultCredential} from '../../../src/auth/credential';
+import { ComputeEngineCredential } from '../../../src/auth/credential';
 import {FirestoreService, getFirestoreOptions} from '../../../src/firestore/firestore';
 
 describe('Firestore', () => {
@@ -52,7 +52,7 @@ describe('Firestore', () => {
     mockApp = mocks.app();
     mockCredentialApp = mocks.mockCredentialApp();
     defaultCredentialApp = mocks.appWithOptions({
-      credential: new ApplicationDefaultCredential(),
+      credential: new ComputeEngineCredential(),
     });
     projectIdApp = mocks.appWithOptions({
       credential: mocks.credential,


### PR DESCRIPTION
Refactoring and simplifying the existing credential implementation for better design and async project ID discovery.

* `CertCredential` class was renamed to `ServiceAccountCredential`.
* `Certificate` type is renamed to `ServiceAccount`, and is no longer exported. Instead the `projectId`, `clientEmail` and `privateKey` properties are directly exposed from the `ServiceAccountCredential` class.
* `MetadataServiceCredential` class was renamed to `ComputeEngineCredential`. This class now also has `getProjectId(): Promise<string>` method to discover the project ID from the Compute Engine environment.
* `ApplicationDefaultCredential` class has been removed. Instead now there's a `getApplicationDefault()` function that returns a `Credential` implementation suitable for the environment.