### PR TITLE
Fixing a flaky auth test case

### DIFF
--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -42,6 +42,7 @@ import {
 } from '../../../src/auth/auth-config';
 import {deepCopy} from '../../../src/utils/deep-copy';
 import { TenantManager } from '../../../src/auth/tenant-manager';
+import { HttpClient } from '../../../src/utils/api-request';
 
 chai.should();
 chai.use(sinonChai);
@@ -357,7 +358,8 @@ AUTH_CONFIGS.forEach((testConfig) => {
 
       it('should be eventually rejected if a cert credential is not specified', () => {
         const mockCredentialAuth = testConfig.init(mocks.mockCredentialApp());
-
+        // Force the service account ID discovery to fail.
+        getTokenStub = sinon.stub(HttpClient.prototype, 'send').rejects(utils.errorFrom({}));
         return mockCredentialAuth.createCustomToken(mocks.uid, mocks.developerClaims)
           .should.eventually.be.rejected.and.have.property('code', 'auth/invalid-credential');
       });


### PR DESCRIPTION
Following 2 test failures have been observed in the master branch in some environments (mainly Google Cloud Build).

```
Step #3:   2 failing
Step #3: 
Step #3:   1) Auth
Step #3:        createCustomToken()
Step #3:          should be eventually rejected if a cert credential is not specified:
Step #3:      AssertionError: expected [Error: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.; Please refer to https://firebase.google.com/docs/auth/admin/create-custom-tokens for more details on how to use and troubleshoot this feature. Raw server response: "{"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}"] to have a property 'code' of 'auth/invalid-credential', but got 'auth/internal-error'
Step #3:   
Step #3: 
Step #3:   2) TenantAwareAuth
Step #3:        createCustomToken()
Step #3:          should be eventually rejected if a cert credential is not specified:
Step #3:      AssertionError: expected [Error: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.; Please refer to https://firebase.google.com/docs/auth/admin/create-custom-tokens for more details on how to use and troubleshoot this feature. Raw server response: "{"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}"] to have a property 'code' of 'auth/invalid-credential', but got 'auth/internal-error'
```

The test case assumes that `createCustomToken()` will fail when a service account is not available. But in GCP managed environments, this will discover a service account ID and try to call  the IAM service. This operation fails with a permission error (UNAUTHENTICATED), which causes the test to fail.

This PR fixes the test case by forcing the service account discovery to fail via a sinon stub.