### PR TITLE
Discovering project ID from the local metadata service

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -71,7 +71,7 @@ export function getFirestoreOptions(app: FirebaseApp): Settings {
     });
   }
 
-  const projectId: string | null = utils.getProjectId(app);
+  const projectId: string | null = utils.getExplicitProjectId(app);
   const credential = app.options.credential;
   const { version: firebaseVersion } = require('../../package.json');
   if (credential instanceof ServiceAccountCredential) {
@@ -80,8 +80,8 @@ export function getFirestoreOptions(app: FirebaseApp): Settings {
         private_key: credential.privateKey,
         client_email: credential.clientEmail,
       },
-      // When the SDK is initialized with ServiceAccountCredentials projectId is guaranteed to
-      // be available.
+      // When the SDK is initialized with ServiceAccountCredentials an explicit projectId is
+      // guaranteed to be available.
       projectId: projectId!,
       firebaseVersion,
     };

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -71,12 +71,12 @@ export class Storage implements FirebaseServiceInterface {
       });
     }
 
-    const projectId: string | null = utils.getProjectId(app);
+    const projectId: string | null = utils.getExplicitProjectId(app);
     const credential = app.options.credential;
     if (credential instanceof ServiceAccountCredential) {
       this.storageClient = new storage({
-        // When the SDK is initialized with ServiceAccountCredentials projectId is guaranteed to
-        // be available.
+        // When the SDK is initialized with ServiceAccountCredentials an explicit projectId is
+        // guaranteed to be available.
         projectId: projectId!,
         credentials: {
           private_key: credential.privateKey,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -56,7 +56,7 @@ export function addReadonlyGetter(obj: object, prop: string, value: any): void {
 }
 
 /**
- * Returns the Google Cloud project ID associated with a Firebase app, if its explicitly
+ * Returns the Google Cloud project ID associated with a Firebase app, if it's explicitly
  * specified in either the Firebase app options, credentials or the local environment.
  * Otherwise returns null.
  *

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {FirebaseApp, FirebaseAppOptions} from '../firebase-app';
-import {ServiceAccountCredential} from '../auth/credential';
+import {ServiceAccountCredential, ComputeEngineCredential} from '../auth/credential';
 
 import * as validator from './validator';
 
@@ -56,14 +56,15 @@ export function addReadonlyGetter(obj: object, prop: string, value: any): void {
 }
 
 /**
- * Determines the Google Cloud project ID associated with a Firebase app by examining
- * the Firebase app options, credentials and the local environment in that order.
+ * Returns the Google Cloud project ID associated with a Firebase app, if its explicitly
+ * specified in either the Firebase app options, credentials or the local environment.
+ * Otherwise returns null.
  *
  * @param {FirebaseApp} app A Firebase app to get the project ID from.
  *
  * @return {string} A project ID string or null.
  */
-export function getProjectId(app: FirebaseApp): string | null {
+export function getExplicitProjectId(app: FirebaseApp): string | null {
   const options: FirebaseAppOptions = app.options;
   if (validator.isNonEmptyString(options.projectId)) {
     return options.projectId;
@@ -82,17 +83,28 @@ export function getProjectId(app: FirebaseApp): string | null {
 }
 
 /**
- * Determines the Google Cloud project ID associated with a Firebase app by examining
- * the Firebase app options, credentials and the local environment in that order. This
- * is an async wrapper of the getProjectId method. This enables us to migrate the rest
- * of the SDK into asynchronously determining the current project ID. See b/143090254.
+ * Determines the Google Cloud project ID associated with a Firebase app. This method
+ * first checks if a project ID is explicitly specified in either the Firebase app options,
+ * credentials or the local environment in that order. If no explicit project ID is
+ * configured, but the SDK has been initialized with ComputeEngineCredentials, this
+ * method attempts to discover the project ID from the local metadata service.
  *
  * @param {FirebaseApp} app A Firebase app to get the project ID from.
  *
  * @return {Promise<string | null>} A project ID string or null.
  */
 export function findProjectId(app: FirebaseApp): Promise<string | null> {
-  return Promise.resolve(getProjectId(app));
+  const projectId = getExplicitProjectId(app);
+  if (projectId) {
+    return Promise.resolve(projectId);
+  }
+
+  const credential = app.options.credential;
+  if (credential instanceof ComputeEngineCredential) {
+    return credential.getProjectId();
+  }
+
+  return Promise.resolve(null);
 }
 
 /**

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../src/auth/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import {Agent} from 'https';
+import { FirebaseAppError } from '../../../src/utils/error';
 
 chai.should();
 chai.use(sinonChai);
@@ -327,6 +328,47 @@ describe('Credential', () => {
           httpAgent: undefined,
         });
       });
+    });
+
+    it('should cache discovered project id', () => {
+      const expected = 'test-project-id';
+      const response = utils.responseFrom(expected);
+      httpStub.resolves(response);
+
+      const c = new ComputeEngineCredential();
+      return c.getProjectId()
+        .then((projectId) => {
+          expect(projectId).to.equal(expected);
+          return c.getProjectId();
+        })
+        .then((projectId) => {
+          expect(projectId).to.equal(expected);
+          expect(httpStub).to.have.been.calledOnce.and.calledWith({
+            method: 'GET',
+            url: 'http://metadata.google.internal/computeMetadata/v1/project/project-id',
+            headers: {'Metadata-Flavor': 'Google'},
+            httpAgent: undefined,
+          });
+        });
+    });
+
+    it('should reject when the metadata service is not available', () => {
+      httpStub.rejects(new FirebaseAppError('network-error', 'Failed to connect'));
+
+      const c = new ComputeEngineCredential();
+      return c.getProjectId().should.eventually
+        .rejectedWith('Failed to determine project ID: Failed to connect')
+        .and.have.property('code', 'app/invalid-credential');
+    });
+
+    it('should reject when the metadata service responds with an error', () => {
+      const response = utils.errorFrom('Unexpected error');
+      httpStub.rejects(response);
+
+      const c = new ComputeEngineCredential();
+      return c.getProjectId().should.eventually
+        .rejectedWith('Failed to determine project ID: Unexpected error')
+        .and.have.property('code', 'app/invalid-credential');
     });
   });
 

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -314,13 +314,13 @@ describe('Credential', () => {
     });
 
     it('should discover project id', () => {
-      const expected = 'test-project-id';
-      const response = utils.responseFrom(expected);
+      const expectedProjectId = 'test-project-id';
+      const response = utils.responseFrom(expectedProjectId);
       httpStub.resolves(response);
 
       const c = new ComputeEngineCredential();
       return c.getProjectId().then((projectId) => {
-        expect(projectId).to.equal(expected);
+        expect(projectId).to.equal(expectedProjectId);
         expect(httpStub).to.have.been.calledOnce.and.calledWith({
           method: 'GET',
           url: 'http://metadata.google.internal/computeMetadata/v1/project/project-id',
@@ -331,18 +331,18 @@ describe('Credential', () => {
     });
 
     it('should cache discovered project id', () => {
-      const expected = 'test-project-id';
-      const response = utils.responseFrom(expected);
+      const expectedProjectId = 'test-project-id';
+      const response = utils.responseFrom(expectedProjectId);
       httpStub.resolves(response);
 
       const c = new ComputeEngineCredential();
       return c.getProjectId()
         .then((projectId) => {
-          expect(projectId).to.equal(expected);
+          expect(projectId).to.equal(expectedProjectId);
           return c.getProjectId();
         })
         .then((projectId) => {
-          expect(projectId).to.equal(expected);
+          expect(projectId).to.equal(expectedProjectId);
           expect(httpStub).to.have.been.calledOnce.and.calledWith({
             method: 'GET',
             url: 'http://metadata.google.internal/computeMetadata/v1/project/project-id',

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -72,7 +72,7 @@ describe('toWebSafeBase64()', () => {
   });
 });
 
-describe('getProjectId()', () => {
+describe('getExplicitProjectId()', () => {
   let googleCloudProject: string | undefined;
   let gcloudProject: string | undefined;
 
@@ -190,13 +190,13 @@ describe('findProjectId()', () => {
   });
 
   it('should return the project ID discovered from the metadata service', () => {
-    const expected = 'test-project-id';
-    const response = utils.responseFrom(expected);
+    const expectedProjectId = 'test-project-id';
+    const response = utils.responseFrom(expectedProjectId);
     httpStub.resolves(response);
     const app: FirebaseApp = mocks.appWithOptions({
       credential: new ComputeEngineCredential(),
     });
-    return findProjectId(app).should.eventually.equal(expected);
+    return findProjectId(app).should.eventually.equal(expectedProjectId);
   });
 
   it('should reject when the metadata service is not available', () => {

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -16,13 +16,19 @@
 
 import * as _ from 'lodash';
 import {expect} from 'chai';
+import * as sinon from 'sinon';
 
 import * as mocks from '../../resources/mocks';
 import {
-  addReadonlyGetter, getProjectId, findProjectId, toWebSafeBase64, formatString, generateUpdateMask,
+  addReadonlyGetter, getExplicitProjectId, findProjectId,
+  toWebSafeBase64, formatString, generateUpdateMask,
 } from '../../../src/utils/index';
 import {isNonEmptyString} from '../../../src/utils/validator';
 import {FirebaseApp, FirebaseAppOptions} from '../../../src/firebase-app';
+import { ComputeEngineCredential } from '../../../src/auth/credential';
+import { HttpClient } from '../../../src/utils/api-request';
+import * as utils from '../utils';
+import { FirebaseAppError } from '../../../src/utils/error';
 
 interface Obj {
   [key: string]: any;
@@ -95,37 +101,38 @@ describe('getProjectId()', () => {
       projectId: 'explicit-project-id',
     };
     const app: FirebaseApp = mocks.appWithOptions(options);
-    expect(getProjectId(app)).to.equal(options.projectId);
+    expect(getExplicitProjectId(app)).to.equal(options.projectId);
   });
 
   it('should return the project ID from service account', () => {
     const app: FirebaseApp = mocks.app();
-    expect(getProjectId(app)).to.equal('project_id');
+    expect(getExplicitProjectId(app)).to.equal('project_id');
   });
 
   it('should return the project ID set in GOOGLE_CLOUD_PROJECT environment variable', () => {
     process.env.GOOGLE_CLOUD_PROJECT = 'env-var-project-id';
     const app: FirebaseApp = mocks.mockCredentialApp();
-    expect(getProjectId(app)).to.equal('env-var-project-id');
+    expect(getExplicitProjectId(app)).to.equal('env-var-project-id');
   });
 
   it('should return the project ID set in GCLOUD_PROJECT environment variable', () => {
     process.env.GCLOUD_PROJECT = 'env-var-project-id';
     const app: FirebaseApp = mocks.mockCredentialApp();
-    expect(getProjectId(app)).to.equal('env-var-project-id');
+    expect(getExplicitProjectId(app)).to.equal('env-var-project-id');
   });
 
   it('should return null when project ID is not set', () => {
     delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GCLOUD_PROJECT;
     const app: FirebaseApp = mocks.mockCredentialApp();
-    expect(getProjectId(app)).to.be.null;
+    expect(getExplicitProjectId(app)).to.be.null;
   });
 });
 
 describe('findProjectId()', () => {
   let googleCloudProject: string | undefined;
   let gcloudProject: string | undefined;
+  let httpStub: sinon.SinonStub;
 
   before(() => {
     googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
@@ -144,6 +151,16 @@ describe('findProjectId()', () => {
     } else {
       delete process.env.GCLOUD_PROJECT;
     }
+  });
+
+  beforeEach(() => {
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GCLOUD_PROJECT;
+    httpStub = sinon.stub(HttpClient.prototype, 'send');
+  });
+
+  afterEach(() => {
+    httpStub.restore();
   });
 
   it('should return the explicitly specified project ID from app options', () => {
@@ -172,9 +189,26 @@ describe('findProjectId()', () => {
     return findProjectId(app).should.eventually.equal('env-var-project-id');
   });
 
-  it('should return null when project ID is not set', () => {
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GCLOUD_PROJECT;
+  it('should return the project ID discovered from the metadata service', () => {
+    const expected = 'test-project-id';
+    const response = utils.responseFrom(expected);
+    httpStub.resolves(response);
+    const app: FirebaseApp = mocks.appWithOptions({
+      credential: new ComputeEngineCredential(),
+    });
+    return findProjectId(app).should.eventually.equal(expected);
+  });
+
+  it('should reject when the metadata service is not available', () => {
+    httpStub.rejects(new FirebaseAppError('network-error', 'Failed to connect'));
+    const app: FirebaseApp = mocks.appWithOptions({
+      credential: new ComputeEngineCredential(),
+    });
+    return findProjectId(app).should.eventually
+      .rejectedWith('Failed to determine project ID: Failed to connect');
+  });
+
+  it('should return null when project ID is not set and discoverable', () => {
     const app: FirebaseApp = mocks.mockCredentialApp();
     return findProjectId(app).should.eventually.be.null;
   });


### PR DESCRIPTION
Support for auto discovering the project ID when running on Compute Engine, Cloud Run etc.

Verified by running a build on a Compute Engine instance.

