### PR TITLE
fix: Differentiating explicitly loaded vs default credentials

### DIFF
--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -81,6 +81,16 @@ export class ServiceAccountCredential implements Credential {
 
   private readonly httpClient: HttpClient;
 
+  /**
+   * Creates a new ServiceAccountCredential from the given parameters.
+   *
+   * @param serviceAccountPathOrObject Service account json object or path to a service account json file.
+   * @param httpAgent Optional http.Agent to use when calling the remote token server.
+   * @param implicit An optinal boolean indicating whether this credential was implicitly discovered from the
+   *   environment, as opposed to being explicitly specified by the developer.
+   *
+   * @constructor
+   */
   constructor(
     serviceAccountPathOrObject: string | object,
     private readonly httpAgent?: Agent,
@@ -249,6 +259,16 @@ export class RefreshTokenCredential implements Credential {
   private readonly refreshToken: RefreshToken;
   private readonly httpClient: HttpClient;
 
+  /**
+   * Creates a new RefreshTokenCredential from the given parameters.
+   *
+   * @param refreshTokenPathOrObject Refresh token json object or path to a refresh token (user credentials) json file.
+   * @param httpAgent Optional http.Agent to use when calling the remote token server.
+   * @param implicit An optinal boolean indicating whether this credential was implicitly discovered from the
+   *   environment, as opposed to being explicitly specified by the developer.
+   *
+   * @constructor
+   */
   constructor(
     refreshTokenPathOrObject: string | object,
     private readonly httpAgent?: Agent,

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -79,11 +79,13 @@ export class ServiceAccountCredential implements Credential {
   public readonly privateKey: string;
   public readonly clientEmail: string;
 
-
   private readonly httpClient: HttpClient;
-  private readonly httpAgent?: Agent;
 
-  constructor(serviceAccountPathOrObject: string | object, httpAgent?: Agent) {
+  constructor(
+    serviceAccountPathOrObject: string | object,
+    private readonly httpAgent?: Agent,
+    readonly implicit: boolean = false) {
+
     const serviceAccount = (typeof serviceAccountPathOrObject === 'string') ?
       ServiceAccount.fromPath(serviceAccountPathOrObject)
       : new ServiceAccount(serviceAccountPathOrObject);
@@ -91,7 +93,6 @@ export class ServiceAccountCredential implements Credential {
     this.privateKey = serviceAccount.privateKey;
     this.clientEmail = serviceAccount.clientEmail;
     this.httpClient = new HttpClient();
-    this.httpAgent = httpAgent;
   }
 
   public getAccessToken(): Promise<GoogleOAuthAccessToken> {
@@ -247,14 +248,16 @@ export class RefreshTokenCredential implements Credential {
 
   private readonly refreshToken: RefreshToken;
   private readonly httpClient: HttpClient;
-  private readonly httpAgent?: Agent;
 
-  constructor(refreshTokenPathOrObject: string | object, httpAgent?: Agent) {
+  constructor(
+    refreshTokenPathOrObject: string | object,
+    private readonly httpAgent?: Agent,
+    readonly implicit: boolean = false) {
+
     this.refreshToken = (typeof refreshTokenPathOrObject === 'string') ?
       RefreshToken.fromPath(refreshTokenPathOrObject)
       : new RefreshToken(refreshTokenPathOrObject);
     this.httpClient = new HttpClient();
-    this.httpAgent = httpAgent;
   }
 
   public getAccessToken(): Promise<GoogleOAuthAccessToken> {
@@ -331,11 +334,25 @@ export function getApplicationDefault(httpAgent?: Agent): Credential {
   if (GCLOUD_CREDENTIAL_PATH) {
     const refreshToken = readCredentialFile(GCLOUD_CREDENTIAL_PATH, true);
     if (refreshToken) {
-      return new RefreshTokenCredential(refreshToken, httpAgent);
+      return new RefreshTokenCredential(refreshToken, httpAgent, true);
     }
   }
 
   return new ComputeEngineCredential(httpAgent);
+}
+
+/**
+ * Checks if the given credential was loaded via the application default credentials mechanism. This
+ * includes all ComputeEngineCredential instances, and the ServiceAccountCredential and RefreshTokenCredential
+ * instances that were loaded from well-known files or environment variables, rather than being explicitly
+ * instantiated.
+ *
+ * @param credential The credential instance to check.
+ */
+export function isApplicationDefault(credential?: Credential): boolean {
+  return credential instanceof ComputeEngineCredential ||
+    (credential instanceof ServiceAccountCredential && credential.implicit) ||
+    (credential instanceof RefreshTokenCredential && credential.implicit);
 }
 
 /**
@@ -409,11 +426,11 @@ function credentialFromFile(filePath: string, httpAgent?: Agent): Credential {
   }
 
   if (credentialsFile.type === 'service_account') {
-    return new ServiceAccountCredential(credentialsFile, httpAgent);
+    return new ServiceAccountCredential(credentialsFile, httpAgent, true);
   }
 
   if (credentialsFile.type === 'authorized_user') {
-    return new RefreshTokenCredential(credentialsFile, httpAgent);
+    return new RefreshTokenCredential(credentialsFile, httpAgent, true);
   }
 
   throw new FirebaseAppError(

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -17,7 +17,7 @@
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseFirestoreError} from '../utils/error';
 import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
-import {ServiceAccountCredential, ComputeEngineCredential} from '../auth/credential';
+import {ServiceAccountCredential, isApplicationDefault} from '../auth/credential';
 import {Firestore, Settings} from '@google-cloud/firestore';
 
 import * as validator from '../utils/validator';
@@ -85,7 +85,7 @@ export function getFirestoreOptions(app: FirebaseApp): Settings {
       projectId: projectId!,
       firebaseVersion,
     };
-  } else if (app.options.credential instanceof ComputeEngineCredential) {
+  } else if (isApplicationDefault(app.options.credential)) {
     // Try to use the Google application default credentials.
     // If an explicit project ID is not available, let Firestore client discover one from the
     // environment. This prevents the users from having to set GOOGLE_CLOUD_PROJECT in GCP runtimes.

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -17,7 +17,7 @@
 import {FirebaseApp} from '../firebase-app';
 import {FirebaseError} from '../utils/error';
 import {FirebaseServiceInterface, FirebaseServiceInternalsInterface} from '../firebase-service';
-import {ServiceAccountCredential, ComputeEngineCredential} from '../auth/credential';
+import {ServiceAccountCredential, isApplicationDefault} from '../auth/credential';
 import {Bucket, Storage as StorageClient} from '@google-cloud/storage';
 
 import * as utils from '../utils/index';
@@ -83,7 +83,7 @@ export class Storage implements FirebaseServiceInterface {
           client_email: credential.clientEmail,
         },
       });
-    } else if (app.options.credential instanceof ComputeEngineCredential) {
+    } else if (isApplicationDefault(app.options.credential)) {
       // Try to use the Google application default credentials.
       this.storageClient = new storage();
     } else {

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -32,7 +32,7 @@ import * as mocks from '../../resources/mocks';
 
 import {
   GoogleOAuthAccessToken, RefreshTokenCredential, ServiceAccountCredential,
-  ComputeEngineCredential, getApplicationDefault,
+  ComputeEngineCredential, getApplicationDefault, isApplicationDefault, Credential,
 } from '../../../src/auth/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import {Agent} from 'https';
@@ -183,15 +183,17 @@ describe('Credential', () => {
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,
+        implicit: false,
       });
     });
 
-    it('should return a certificate', () => {
-      const c = new ServiceAccountCredential(mockCertificateObject);
+    it('should return an implicit Credential', () => {
+      const c = new ServiceAccountCredential(mockCertificateObject, undefined, true);
       expect(c).to.deep.include({
         projectId: mockCertificateObject.project_id,
         clientEmail: mockCertificateObject.client_email,
         privateKey: mockCertificateObject.private_key,
+        implicit: true,
       });
     });
 
@@ -265,6 +267,20 @@ describe('Credential', () => {
       const invalidCredential = _.omit(mocks.refreshToken, 'type');
       expect(() => new RefreshTokenCredential(invalidCredential as any))
         .to.throw('Refresh token must contain a "type" property');
+    });
+
+    it('should return a Credential', () => {
+      const c = new RefreshTokenCredential(mocks.refreshToken);
+      expect(c).to.deep.include({
+        implicit: false,
+      });
+    });
+
+    it('should return an implicit Credential', () => {
+      const c = new RefreshTokenCredential(mocks.refreshToken, undefined, true);
+      expect(c).to.deep.include({
+        implicit: true,
+      });
     });
 
     it('should create access tokens', () => {
@@ -474,6 +490,72 @@ describe('Credential', () => {
         type: MOCK_REFRESH_TOKEN_CONFIG.type,
       });
       expect(fsStub.alwaysCalledWith(GCLOUD_CREDENTIAL_PATH, 'utf8')).to.be.true;
+    });
+  });
+
+  describe('isApplicationDefault()', () => {
+    let fsStub: sinon.SinonStub;
+
+    afterEach(() => {
+      if (fsStub) {
+        fsStub.restore();
+      }
+    });
+
+    it('should return true for ServiceAccountCredential loaded from GOOGLE_APPLICATION_CREDENTIALS', () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(ServiceAccountCredential);
+      expect(isApplicationDefault(c)).to.be.true;
+    });
+
+    it('should return true for RefreshTokenCredential loaded from GOOGLE_APPLICATION_CREDENTIALS', () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = GCLOUD_CREDENTIAL_PATH;
+      fsStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify(MOCK_REFRESH_TOKEN_CONFIG));
+      const c = getApplicationDefault();
+      expect(c).is.instanceOf(RefreshTokenCredential);
+      expect(isApplicationDefault(c)).to.be.true;
+    });
+
+    it('should return true for credential loaded from gcloud SDK', () => {
+      if (!fs.existsSync(GCLOUD_CREDENTIAL_PATH)) {
+        // tslint:disable-next-line:no-console
+        console.log(
+          'WARNING: Test being skipped because gcloud credentials not found. Run `gcloud beta auth ' +
+          'application-default login`.');
+        return;
+      }
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(RefreshTokenCredential);
+      expect(isApplicationDefault(c)).to.be.true;
+    });
+
+    it('should return true for ComputeEngineCredential', () => {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      fsStub = sinon.stub(fs, 'readFileSync').throws(new Error('no gcloud credential file'));
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(ComputeEngineCredential);
+      expect(isApplicationDefault(c)).to.be.true;
+    });
+
+    it('should return false for explicitly loaded ServiceAccountCredential', () => {
+      const c = new ServiceAccountCredential(mockCertificateObject);
+      expect(isApplicationDefault(c)).to.be.false;
+    });
+
+    it('should return false for explicitly loaded RefreshTokenCredential', () => {
+      const c = new RefreshTokenCredential(mocks.refreshToken);
+      expect(isApplicationDefault(c)).to.be.false;
+    });
+
+    it('should return false for custom credential', () => {
+      const c: Credential = {
+        getAccessToken: () => {
+          throw new Error();
+        },
+      };
+      expect(isApplicationDefault(c)).to.be.false;
     });
   });
 

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -27,7 +27,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../resources/mocks';
 
 import * as firebaseAdmin from '../../src/index';
-import {RefreshTokenCredential, ServiceAccountCredential} from '../../src/auth/credential';
+import {RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault} from '../../src/auth/credential';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -112,6 +112,7 @@ describe('Firebase', () => {
         credential: firebaseAdmin.credential.cert(mocks.certificateObject),
       });
 
+      expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
       return firebaseAdmin.app().INTERNAL.getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
@@ -122,6 +123,7 @@ describe('Firebase', () => {
         credential: firebaseAdmin.credential.cert(keyPath),
       });
 
+      expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
       return firebaseAdmin.app().INTERNAL.getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
@@ -134,6 +136,7 @@ describe('Firebase', () => {
         credential: firebaseAdmin.credential.applicationDefault(),
       });
 
+      expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.true;
       return firebaseAdmin.app().INTERNAL.getToken().then((token) => {
         if (typeof credPath === 'undefined') {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -155,6 +158,7 @@ describe('Firebase', () => {
         credential: firebaseAdmin.credential.refreshToken(mocks.refreshToken),
       });
 
+      expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
       return firebaseAdmin.app().INTERNAL.getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -16,19 +16,17 @@
 
 'use strict';
 
-import path = require('path');
 import * as _ from 'lodash';
 import {expect} from 'chai';
 
 import * as mocks from '../../resources/mocks';
 import {FirebaseApp} from '../../../src/firebase-app';
-import { ComputeEngineCredential } from '../../../src/auth/credential';
+import { ComputeEngineCredential, RefreshTokenCredential } from '../../../src/auth/credential';
 import {FirestoreService, getFirestoreOptions} from '../../../src/firestore/firestore';
 
 describe('Firestore', () => {
   let mockApp: FirebaseApp;
   let mockCredentialApp: FirebaseApp;
-  let defaultCredentialApp: FirebaseApp;
   let projectIdApp: FirebaseApp;
   let firestore: any;
 
@@ -40,8 +38,21 @@ describe('Firestore', () => {
     + 'credentials. Must initialize the SDK with a certificate credential or application default '
     + 'credentials to use Cloud Firestore API.';
 
-  const mockServiceAccount = path.resolve(__dirname, '../../resources/mock.key.json');
   const { version: firebaseVersion } = require('../../../package.json');
+  const defaultCredentialApps = [
+    {
+      name: 'ComputeEngineCredentials',
+      app: mocks.appWithOptions({
+        credential: new ComputeEngineCredential(),
+      }),
+    },
+    {
+      name: 'RefreshTokenCredentials',
+      app: mocks.appWithOptions({
+        credential: new RefreshTokenCredential(mocks.refreshToken, undefined, true),
+      }),
+    },
+  ];
 
   beforeEach(() => {
     appCredentials = process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -51,9 +62,6 @@ describe('Firestore', () => {
 
     mockApp = mocks.app();
     mockCredentialApp = mocks.mockCredentialApp();
-    defaultCredentialApp = mocks.appWithOptions({
-      credential: new ComputeEngineCredential(),
-    });
     projectIdApp = mocks.appWithOptions({
       credential: mocks.credential,
       projectId: 'explicit-project-id',
@@ -121,14 +129,15 @@ describe('Firestore', () => {
       }).not.to.throw();
     });
 
-    it('should not throw given application default credentials without project ID', () => {
-      // Project ID not set in the environment.
-      delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GCLOUD_PROJECT;
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = mockServiceAccount;
-      expect(() => {
-        return new FirestoreService(defaultCredentialApp);
-      }).not.to.throw();
+    defaultCredentialApps.forEach((config) => {
+      it(`should not throw given default ${config.name} without project ID`, () => {
+        // Project ID not set in the environment.
+        delete process.env.GOOGLE_CLOUD_PROJECT;
+        delete process.env.GCLOUD_PROJECT;
+        expect(() => {
+          return new FirestoreService(config.app);
+        }).not.to.throw();
+      });
     });
   });
 
@@ -169,18 +178,18 @@ describe('Firestore', () => {
       expect(options.projectId).to.equal('explicit-project-id');
     });
 
-    it('should return a string when GOOGLE_CLOUD_PROJECT is set', () => {
-      process.env.GOOGLE_CLOUD_PROJECT = 'env-project-id';
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = mockServiceAccount;
-      const options = getFirestoreOptions(defaultCredentialApp);
-      expect(options.projectId).to.equal('env-project-id');
-    });
+    defaultCredentialApps.forEach((config) => {
+      it(`should return a string when GOOGLE_CLOUD_PROJECT is set with ${config.name}`, () => {
+        process.env.GOOGLE_CLOUD_PROJECT = 'env-project-id';
+        const options = getFirestoreOptions(config.app);
+        expect(options.projectId).to.equal('env-project-id');
+      });
 
-    it('should return a string when GCLOUD_PROJECT is set', () => {
-      process.env.GCLOUD_PROJECT = 'env-project-id';
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = mockServiceAccount;
-      const options = getFirestoreOptions(defaultCredentialApp);
-      expect(options.projectId).to.equal('env-project-id');
+      it(`should return a string when GCLOUD_PROJECT is set with ${config.name}`, () => {
+        process.env.GCLOUD_PROJECT = 'env-project-id';
+        const options = getFirestoreOptions(config.app);
+        expect(options.projectId).to.equal('env-project-id');
+      });
     });
   });
 
@@ -190,9 +199,11 @@ describe('Firestore', () => {
       expect(options.firebaseVersion).to.equal(firebaseVersion);
     });
 
-    it('should return firebaseVersion when using credential without service account certificate', () => {
-      const options = getFirestoreOptions(defaultCredentialApp);
-      expect(options.firebaseVersion).to.equal(firebaseVersion);
+    defaultCredentialApps.forEach((config) => {
+      it(`should return firebaseVersion when using default ${config.name}`, () => {
+        const options = getFirestoreOptions(config.app);
+        expect(options.firebaseVersion).to.equal(firebaseVersion);
+      });
     });
   });
 });


### PR DESCRIPTION
Modules like Firestore and Storage used to have the following bit of code:

https://github.com/firebase/firebase-admin-node/blob/00892e0b1f4c2e588834f81522f77387eab2e3c9/src/firestore/firestore.ts#L98-L110

This allowed checking if the SDK was initialized with ADC, and if so delegating the credential loading back to the corresponding GCP library. In other cases (e.g. custom credentials), an error was thrown.

But in the v8.9.1 release this code was refactored into this:

https://github.com/firebase/firebase-admin-node/blob/5ce91759724528dd574c14a4b3637230d691d4a8/src/firestore/firestore.ts#L88-L100

But this is not quite equivalent to the logic we used to have, because:

```
ApplicationDefaultCredential = 
  MetadataServiceCredential |
  RefreshTokenCredential loaded from well-known path |
  CertCredential loaded from environment variable
```

The new `ComputeEngineCredential` only accounts for the `MetadataServiceCredential`. 

In order to cover the remaining 2 cases, we need to differentiate the credentials that were explicitly instantiated by the developer and the credentials that were implicitly loaded by the SDK. This PR implements this capability and updates the rest of the code that depends on this behavior.

Resolves #763 