### PR TITLE
Add getTemplate functionality

### DIFF
--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -114,12 +114,11 @@ export class RemoteConfigApiClient {
             'invalid-argument',
             'ETag header is not present in the server response.');
         }
-        const remoteConfigResponse: RemoteConfigResponse = {
+        return {
           conditions: resp.data.conditions,
           parameters: resp.data.parameters,
           etag: resp.headers['etag'],
-        }
-        return remoteConfigResponse;
+        };
       })
       .catch((err) => {
         throw this.toFirebaseError(err);

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -21,7 +21,8 @@ import { FirebaseApp } from '../firebase-app';
 import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
 
-const REMOTE_CONFIG_V1_API = 'https://firebaseremoteconfig.googleapis.com/v1';
+// Remote Config backend constants
+const FIREBASE_REMOTE_CONFIG_V1_API = 'https://firebaseremoteconfig.googleapis.com/v1';
 const FIREBASE_REMOTE_CONFIG_HEADERS = {
   'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
   // There is a known issue in which the ETag is not properly returned in cases where the request
@@ -128,7 +129,7 @@ export class RemoteConfigApiClient {
   private getUrl(): Promise<string> {
     return this.getProjectIdPrefix()
       .then((projectIdPrefix) => {
-        return `${REMOTE_CONFIG_V1_API}/${projectIdPrefix}`;
+        return `${FIREBASE_REMOTE_CONFIG_V1_API}/${projectIdPrefix}`;
       });
   }
 

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -75,7 +75,7 @@ interface RemoteConfigCondition {
 export interface RemoteConfigResponse {
   readonly conditions?: RemoteConfigCondition[];
   readonly parameters?: { [key: string]: RemoteConfigParameter };
-  readonly eTag: string;
+  readonly etag: string;
 }
 
 /**
@@ -117,7 +117,7 @@ export class RemoteConfigApiClient {
         const remoteConfigResponse: RemoteConfigResponse = {
           conditions: resp.data.conditions,
           parameters: resp.data.parameters,
-          eTag: resp.headers['etag'],
+          etag: resp.headers['etag'],
         }
         return remoteConfigResponse;
       })

--- a/src/remote-config/remote-config-utils.ts
+++ b/src/remote-config/remote-config-utils.ts
@@ -23,8 +23,10 @@ export type RemoteConfigErrorCode =
   | 'invalid-argument'
   | 'invalid-etag'
   | 'invalid-template'
+  | 'not-found'
   | 'obsolete-etag'
   | 'permission-denied'
+  | 'resource-exhausted'
   | 'unauthenticated'
   | 'unknown-error';
 

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -92,8 +92,6 @@ export class RemoteConfigTemplate {
         `Invalid Remote Config template response: ${JSON.stringify(config)}`);
     }
 
-    this.parameters = {};
-    this.conditions = [];
     this.etagInternal = config.etag;
 
     if (typeof config.parameters !== 'undefined') {
@@ -103,6 +101,8 @@ export class RemoteConfigTemplate {
           `Remote Config parameters must be a non-null object`);
       }
       this.parameters = config.parameters;
+    } else {
+      this.parameters = {};
     }
 
     if (typeof config.conditions !== 'undefined') {
@@ -116,6 +116,8 @@ export class RemoteConfigTemplate {
         expression: p.expression,
         color: p.tagColor
       }));
+    } else {
+      this.conditions = [];
     }
   }
 

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -16,6 +16,9 @@
 
 import { FirebaseServiceInterface, FirebaseServiceInternalsInterface } from '../firebase-service';
 import { FirebaseApp } from '../firebase-app';
+import {
+  RemoteConfigApiClient
+} from './remote-config-api-client';
 
 /** Interface representing a Remote Config parameter. */
 export interface RemoteConfigParameter {
@@ -56,11 +59,24 @@ class RemoteConfigInternals implements FirebaseServiceInternalsInterface {
 export class RemoteConfig implements FirebaseServiceInterface {
   public readonly INTERNAL: RemoteConfigInternals = new RemoteConfigInternals();
 
+  private readonly client: RemoteConfigApiClient;
+
   /**
    * @param {FirebaseApp} app The app for this RemoteConfig service.
    * @constructor
    */
-  constructor(readonly app: FirebaseApp) { }
+  constructor(readonly app: FirebaseApp) {
+    this.client = new RemoteConfigApiClient(app);
+  }
+
+  /**
+  * Gets the current active version of the Remote Config template of the project.
+  *
+  * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
+  */
+  public getTemplate(): Promise<RemoteConfigTemplate> {
+    return Promise.resolve<RemoteConfigTemplate>(new RemoteConfigTemplate());
+  }
 }
 
 /**

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -82,11 +82,11 @@ export class RemoteConfigTemplate {
 
   public parameters: { [key: string]: RemoteConfigParameter };
   public conditions: RemoteConfigCondition[];
-  private readonly eTagInternal: string;
+  private readonly etagInternal: string;
 
   constructor(config: RemoteConfigResponse) {
     if (!validator.isNonNullObject(config) ||
-      !validator.isNonEmptyString(config.eTag)) {
+      !validator.isNonEmptyString(config.etag)) {
       throw new FirebaseRemoteConfigError(
         'invalid-argument',
         `Invalid Remote Config template response: ${JSON.stringify(config)}`);
@@ -94,7 +94,7 @@ export class RemoteConfigTemplate {
 
     this.parameters = {};
     this.conditions = [];
-    this.eTagInternal = config.eTag;
+    this.etagInternal = config.etag;
 
     if (typeof config.parameters !== 'undefined') {
       if (!validator.isNonNullObject(config.parameters)) {
@@ -124,8 +124,8 @@ export class RemoteConfigTemplate {
    *
    * @return {string} The ETag of the Remote Config template.
    */
-  get eTag(): string {
-    return this.eTagInternal;
+  get etag(): string {
+    return this.etagInternal;
   }
 
   /**
@@ -144,7 +144,7 @@ export class RemoteConfigTemplate {
     return {
       parameters: this.parameters,
       conditions: this.conditions,
-      eTag: this.eTag,
+      etag: this.etag,
     };
   }
 }

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -111,7 +111,11 @@ export class RemoteConfigTemplate {
           'invalid-argument',
           `Remote Config conditions must be an array`);
       }
-      this.conditions = this.parseConditions(config.conditions);
+      this.conditions = config.conditions.map(p => ({
+        name: p.name,
+        expression: p.expression,
+        color: p.tagColor
+      }));
     }
   }
 
@@ -122,17 +126,6 @@ export class RemoteConfigTemplate {
    */
   get eTag(): string {
     return this.eTagInternal;
-  }
-
-  /**
-   * Find an existing Remote Config parameter by key.
-   *
-   * @param {string} key The key of the Remote Config parameter.
-   *
-   * @return {RemoteConfigParameter} The Remote Config parameter with the provided key.
-   */
-  public getParameter(key: string): RemoteConfigParameter | undefined {
-    return this.parameters[key];
   }
 
   /**
@@ -153,13 +146,5 @@ export class RemoteConfigTemplate {
       conditions: this.conditions,
       eTag: this.eTag,
     };
-  }
-
-  private parseConditions(conditions: any[]): RemoteConfigCondition[] {
-    return conditions.map(p => ({
-      name: p.name,
-      expression: p.expression,
-      color: p.tagColor
-    }));
   }
 }

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -64,3 +64,7 @@ import './project-management/ios-app.spec';
 // SecurityRules
 import './security-rules/security-rules.spec';
 import './security-rules/security-rules-api-client.spec';
+
+// RemoteConfig
+import './remote-config/remote-config.spec';
+import './remote-config/remote-config-api-client.spec';

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -99,7 +99,7 @@ describe('RemoteConfigApiClient', () => {
         .then((resp) => {
           expect(resp.conditions).to.deep.equal(testResponse.conditions);
           expect(resp.parameters).to.deep.equal(testResponse.parameters);
-          expect(resp.eTag).to.equal('etag-123456789012-1');
+          expect(resp.etag).to.equal('etag-123456789012-1');
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: 'GET',
             url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -1,0 +1,161 @@
+/*!
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import * as _ from 'lodash';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import { RemoteConfigApiClient } from '../../../src/remote-config/remote-config-api-client';
+import { FirebaseRemoteConfigError } from '../../../src/remote-config/remote-config-utils';
+import { HttpClient } from '../../../src/utils/api-request';
+import * as utils from '../utils';
+import * as mocks from '../../resources/mocks';
+import { FirebaseAppError } from '../../../src/utils/error';
+import { FirebaseApp } from '../../../src/firebase-app';
+
+const expect = chai.expect;
+
+describe('RemoteConfigApiClient', () => {
+
+  const ERROR_RESPONSE = {
+    error: {
+      code: 404,
+      message: 'Requested entity not found',
+      status: 'NOT_FOUND',
+    },
+  };
+  const EXPECTED_HEADERS = {
+    'Authorization': 'Bearer mock-token',
+    'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'Accept-Encoding': 'gzip',
+  };
+  const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
+    + 'account credentials, or set project ID as an app option. Alternatively, set the '
+    + 'GOOGLE_CLOUD_PROJECT environment variable.';
+
+  const mockOptions = {
+    credential: new mocks.MockCredential(),
+    projectId: 'test-project',
+  };
+
+  const clientWithoutProjectId = new RemoteConfigApiClient(
+    mocks.mockCredentialApp());
+
+  // Stubs used to simulate underlying api calls.
+  let stubs: sinon.SinonStub[] = [];
+  let app: FirebaseApp;
+  let apiClient: RemoteConfigApiClient;
+
+  beforeEach(() => {
+    app = mocks.appWithOptions(mockOptions);
+    apiClient = new RemoteConfigApiClient(app);
+  });
+
+  afterEach(() => {
+    _.forEach(stubs, (stub) => stub.restore());
+    stubs = [];
+    return app.delete();
+  });
+
+  describe('Constructor', () => {
+    it('should throw when the app is null', () => {
+      expect(() => new RemoteConfigApiClient(null as unknown as FirebaseApp))
+        .to.throw('First argument passed to admin.remoteConfig() must be a valid Firebase app instance.');
+    });
+  });
+
+  describe('getTemplate', () => {
+    it(`should reject when project id is not available`, () => {
+      return clientWithoutProjectId.getTemplate()
+        .should.eventually.be.rejectedWith(noProjectId);
+    });
+
+    it('should resolve with the requested template on success', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom({
+          conditions: [{ name: 'ios', expression: 'exp' }],
+          parameters: { param: { defaultValue: { value: 'true' } } },
+          version: {},
+        }, 200, { etag: 'etag-123456789012-1' }));
+      stubs.push(stub);
+      return apiClient.getTemplate()
+        .then((resp) => {
+          expect(resp.conditions).to.deep.equal([{ name: 'ios', expression: 'exp' }]);
+          expect(resp.parameters).to.deep.equal({ param: { defaultValue: { value: 'true' } } });
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'GET',
+            url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',
+            headers: EXPECTED_HEADERS,
+          });
+        });
+    });
+
+    it('should throw when the etag does not present in the headers', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom({
+          conditions: [], parameters: {}, version: {},
+        }));
+      stubs.push(stub);
+      const expected = new FirebaseRemoteConfigError('invalid-argument', 'ETag is unavailable');
+      return apiClient.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(expected);
+    });
+
+    it('should throw when a full platform error response is received', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .rejects(utils.errorFrom(ERROR_RESPONSE, 404));
+      stubs.push(stub);
+      const expected = new FirebaseRemoteConfigError('not-found', 'Requested entity not found');
+      return apiClient.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(expected);
+    });
+
+    it('should throw unknown-error when error code is not present', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .rejects(utils.errorFrom({}, 404));
+      stubs.push(stub);
+      const expected = new FirebaseRemoteConfigError('unknown-error', 'Unknown server error: {}');
+      return apiClient.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(expected);
+    });
+
+    it('should throw unknown-error for non-json response', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .rejects(utils.errorFrom('not json', 404));
+      stubs.push(stub);
+      const expected = new FirebaseRemoteConfigError(
+        'unknown-error', 'Unexpected response with status: 404 and body: not json');
+      return apiClient.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(expected);
+    });
+
+    it('should throw when rejected with a FirebaseAppError', () => {
+      const expected = new FirebaseAppError('network-error', 'socket hang up');
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .rejects(expected);
+      stubs.push(stub);
+      return apiClient.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(expected);
+    });
+  });
+});

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -54,13 +54,6 @@ describe('RemoteConfig', () => {
         description: 'this is a promo',
       },
     },
-    version: {
-      versionNumber: '5',
-      updateTime: '2020-02-26T20:33:43.300Z',
-      updateUser: { email: 'user@user.com' },
-      updateOrigin: 'CONSOLE',
-      updateType: 'INCREMENTAL_UPDATE',
-    },
     eTag: 'etag-123456789012-5',
   };
 
@@ -212,14 +205,8 @@ describe('RemoteConfig', () => {
           expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
           expect(p1.description).equals('this is a promo');
 
-          const p2 = template.getParameter(key);
-          if (p2) {
-            expect(p2.defaultValue).deep.equals({ value: 'true' });
-            expect(p2.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
-            expect(p2.description).equals('this is a promo');
-          }
-
           const c = template.getCondition('ios');
+          expect(c).to.be.not.undefined;
           if (c) {
             expect(c.name).to.equal('ios');
             expect(c.expression).to.equal('device.os == \'ios\'');

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -1,0 +1,231 @@
+/*!
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import * as _ from 'lodash';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import { RemoteConfig } from '../../../src/remote-config/remote-config';
+import { FirebaseApp } from '../../../src/firebase-app';
+import * as mocks from '../../resources/mocks';
+import { RemoteConfigApiClient } from '../../../src/remote-config/remote-config-api-client';
+import { FirebaseRemoteConfigError } from '../../../src/remote-config/remote-config-utils';
+import { deepCopy } from '../../../src/utils/deep-copy';
+
+const expect = chai.expect;
+
+describe('RemoteConfig', () => {
+
+  const INTERNAL_ERROR = new FirebaseRemoteConfigError('internal-error', 'message');
+  const REMOTE_CONFIG_RESPONSE: {
+    // This type is effectively a RemoteConfigResponse, but with non-readonly fields
+    // to allow easier use from within the tests. An improvement would be to
+    // alter this into a helper that creates customized RemoteConfigResponse based
+    // on the needs of the test, as that would ensure type-safety.
+    conditions?: Array<{ name: string; expression: string; tagColor: string }>;
+    parameters?: object | null;
+    version?: object;
+    eTag: string;
+  } = {
+    conditions: [{
+      name: 'ios',
+      expression: 'device.os == \'ios\'',
+      tagColor: 'BLUE',
+    }],
+    parameters: {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      holiday_promo_enabled: {
+        defaultValue: { value: 'true' },
+        conditionalValues: { ios: { useInAppDefault: true } },
+        description: 'this is a promo',
+      },
+    },
+    version: {
+      versionNumber: '5',
+      updateTime: '2020-02-26T20:33:43.300Z',
+      updateUser: { email: 'user@user.com' },
+      updateOrigin: 'CONSOLE',
+      updateType: 'INCREMENTAL_UPDATE',
+    },
+    eTag: 'etag-123456789012-5',
+  };
+
+  let remoteConfig: RemoteConfig;
+  let mockApp: FirebaseApp;
+  let mockCredentialApp: FirebaseApp;
+
+  // Stubs used to simulate underlying api calls.
+  let stubs: sinon.SinonStub[] = [];
+
+  before(() => {
+    mockApp = mocks.app();
+    mockCredentialApp = mocks.mockCredentialApp();
+    remoteConfig = new RemoteConfig(mockApp);
+  });
+
+  after(() => {
+    return mockApp.delete();
+  });
+
+  afterEach(() => {
+    _.forEach(stubs, (stub) => stub.restore());
+    stubs = [];
+  });
+
+  describe('Constructor', () => {
+    const invalidApps = [null, NaN, 0, 1, true, false, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];
+    invalidApps.forEach((invalidApp) => {
+      it('should throw given invalid app: ' + JSON.stringify(invalidApp), () => {
+        expect(() => {
+          const remoteConfigAny: any = RemoteConfig;
+          return new remoteConfigAny(invalidApp);
+        }).to.throw(
+          'First argument passed to admin.remoteConfig() must be a valid Firebase app '
+          + 'instance.');
+      });
+    });
+
+    it('should throw given no app', () => {
+      expect(() => {
+        const remoteConfigAny: any = RemoteConfig;
+        return new remoteConfigAny();
+      }).to.throw(
+        'First argument passed to admin.remoteConfig() must be a valid Firebase app '
+        + 'instance.');
+    });
+
+    it('should reject when initialized without project ID', () => {
+      // Project ID not set in the environment.
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+      delete process.env.GCLOUD_PROJECT;
+      const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
+        + 'account credentials, or set project ID as an app option. Alternatively, set the '
+        + 'GOOGLE_CLOUD_PROJECT environment variable.';
+      const remoteConfigWithoutProjectId = new RemoteConfig(mockCredentialApp);
+      return remoteConfigWithoutProjectId.getTemplate()
+        .should.eventually.rejectedWith(noProjectId);
+    });
+
+    it('should not throw given a valid app', () => {
+      expect(() => {
+        return new RemoteConfig(mockApp);
+      }).not.to.throw();
+    });
+  });
+
+  describe('app', () => {
+    it('returns the app from the constructor', () => {
+      // We expect referential equality here
+      expect(remoteConfig.app).to.equal(mockApp);
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .rejects(INTERNAL_ERROR);
+      stubs.push(stub);
+      return remoteConfig.getTemplate()
+        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
+    });
+
+    it('should reject when API response is invalid', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .resolves(null);
+      stubs.push(stub);
+      return remoteConfig.getTemplate()
+        .should.eventually.be.rejected.and.have.property(
+          'message', 'Invalid Remote Config template response: null');
+    });
+
+    it('should reject when API response does not contain an ETag', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.eTag = '';
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .resolves(response);
+      stubs.push(stub);
+      return remoteConfig.getTemplate()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Invalid Remote Config template response: ${JSON.stringify(response)}`);
+    });
+
+    it('should reject when API response does not contain valid parameters', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.parameters = null;
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .resolves(response);
+      stubs.push(stub);
+      return remoteConfig.getTemplate()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Remote Config parameters must be a non-null object`);
+    });
+
+    it('should reject when API response does not contain valid conditions', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.conditions = Object();
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .resolves(response);
+      stubs.push(stub);
+      return remoteConfig.getTemplate()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Remote Config conditions must be an array`);
+    });
+
+    it('should resolve with Remote Config template on success', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
+        .resolves(REMOTE_CONFIG_RESPONSE);
+      stubs.push(stub);
+
+      return remoteConfig.getTemplate()
+        .then((template) => {
+          expect(template.conditions.length).to.equal(1);
+          expect(template.conditions[0].name).to.equal('ios');
+          expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
+          // verify the property mapping in RemoteConfigCondition from `tagColor` to `color`
+          expect(template.conditions[0].color).to.equal('BLUE');
+
+          expect(template.eTag).to.equal('etag-123456789012-5');
+
+          const key = 'holiday_promo_enabled';
+          const p1 = template.parameters[key];
+          expect(p1.defaultValue).deep.equals({ value: 'true' });
+          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
+          expect(p1.description).equals('this is a promo');
+
+          const p2 = template.getParameter(key);
+          if (p2) {
+            expect(p2.defaultValue).deep.equals({ value: 'true' });
+            expect(p2.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
+            expect(p2.description).equals('this is a promo');
+          }
+
+          const c = template.getCondition('ios');
+          if (c) {
+            expect(c.name).to.equal('ios');
+            expect(c.expression).to.equal('device.os == \'ios\'');
+            expect(c.color).to.equal('BLUE');
+          }
+        });
+    });
+  });
+});


### PR DESCRIPTION
- Implement `getTemplate()`
- Introduce new `RemoteConfigParameterValue` type
- To closely represent the backend REST API, change `parameters` in `RemoteConfigTemplate` to a hashmap
- Add unit tests for `getTemplate`