### PR TITLE
Fix revokeRefreshTokens to round consistently with the other platforms.

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1041,7 +1041,7 @@ export abstract class AbstractAuthRequestHandler {
     const request: any = {
       localId: uid,
       // validSince is in UTC seconds.
-      validSince: Math.ceil(new Date().getTime() / 1000),
+      validSince: Math.floor(new Date().getTime() / 1000),
     };
     return this.invokeRequestHandler(this.getAuthUrlBuilder(), FIREBASE_AUTH_SET_ACCOUNT_INFO, request)
       .then((response: any) => {

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -1955,8 +1955,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should be fulfilled given a valid uid', () => {
         const requestData = {
           localId: uid,
-          // Current time should be passed, rounded up.
-          validSince: Math.ceil((now.getTime() + 5000) / 1000),
+          // Current time should be passed, rounded down.
+          validSince: Math.floor((now.getTime() + 5000) / 1000),
         };
         const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
         stubs.push(stub);
@@ -1995,7 +1995,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         });
         const requestData = {
           localId: uid,
-          validSince: Math.ceil((now.getTime() + 5000) / 1000),
+          validSince: Math.floor((now.getTime() + 5000) / 1000),
         };
         const stub = sinon.stub(HttpClient.prototype, 'send').rejects(expectedServerError);
         stubs.push(stub);


### PR DESCRIPTION
This also makes it consistent with the comments a few lines above, as
well as the integration test.