### PR TITLE
Directly initialize properties in UserMetadata

### DIFF
--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -66,16 +66,19 @@ export interface CreateRequest extends UpdateRequest {
  * @constructor
  */
 export class UserMetadata {
-  public readonly creationTime: string;
-  public readonly lastSignInTime: string;
+  public readonly creationTime?: string | null;
+  public readonly lastSignInTime?: string | null;
 
   constructor(response: any) {
     // Creation date should always be available but due to some backend bugs there
     // were cases in the past where users did not have creation date properly set.
     // This included legacy Firebase migrating project users and some anonymous users.
     // These bugs have already been addressed since then.
-    utils.addReadonlyGetter(this, 'creationTime', parseDate(response.createdAt));
-    utils.addReadonlyGetter(this, 'lastSignInTime', parseDate(response.lastLoginAt));
+    this.creationTime = parseDate(response.createdAt);
+    utils.enforceReadonly(this, 'creationTime');
+
+    this.lastSignInTime = parseDate(response.lastLoginAt);
+    utils.enforceReadonly(this, 'lastSignInTime');
   }
 
   /** @return {object} The plain object representation of the user's metadata. */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -491,13 +491,12 @@ declare namespace admin.auth {
     /**
      * The date the user last signed in, formatted as a UTC string.
      */
-    lastSignInTime: string;
+    lastSignInTime?: string | null;
 
     /**
      * The date the user was created, formatted as a UTC string.
-     *
      */
-    creationTime: string;
+    creationTime?: string | null;
 
     /**
      * @return A JSON-serializable representation of this object.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -56,6 +56,20 @@ export function addReadonlyGetter(obj: object, prop: string, value: any): void {
 }
 
 /**
+ * Marks an existing property as readonly. Unlike typescript's "readonly"
+ * modifier, this will take effect at runtime too (generating a TypeError if
+ * violated), including when called from javascript.
+ */
+export function enforceReadonly(obj: object, prop: string): void {
+  Object.defineProperty(obj, prop, {
+    // Make this property read-only.
+    writable: false,
+    // Include this property during enumeration of obj's properties.
+    enumerable: true,
+  });
+}
+
+/**
  * Returns the Google Cloud project ID associated with a Firebase app, if it's explicitly
  * specified in either the Firebase app options, credentials or the local environment.
  * Otherwise returns null.


### PR DESCRIPTION
Prompted by attempting to enable tsconfig options
'strictPropertyInitialization'.

The properties were being indirectly set via Object.defineProperty.
Typescript isn't able to follow that. Setting the properties directly
resolves it. (And also exposed some minor type errors.)