### PR TITLE
chore: Adding a .npmrc file to the root of the repo

### DIFF
--- a/.github/scripts/publish_package.sh
+++ b/.github/scripts/publish_package.sh
@@ -17,5 +17,7 @@
 set -e
 set -u
 
+echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
+
 readonly UNPREFIXED_VERSION=`echo ${VERSION} | cut -c 2-`
 npm publish dist/firebase-admin-${UNPREFIXED_VERSION}.tgz --registry https://wombat-dressing-room.appspot.com

--- a/.github/scripts/publish_package.sh
+++ b/.github/scripts/publish_package.sh
@@ -17,7 +17,5 @@
 set -e
 set -u
 
-echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
-
 readonly UNPREFIXED_VERSION=`echo ${VERSION} | cut -c 2-`
 npm publish dist/firebase-admin-${UNPREFIXED_VERSION}.tgz --registry https://wombat-dressing-room.appspot.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//wombat-dressing-room.appspot.com:_authToken=${NPM_AUTH_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//wombat-dressing-room.appspot.com:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
Creating the .npmrc file at the root of the repo as instructed in https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server