### PR TITLE
[chore] Release 8.10.0 (take 2)

### DIFF
--- a/.github/scripts/publish_package.sh
+++ b/.github/scripts/publish_package.sh
@@ -20,4 +20,4 @@ set -u
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
 
 readonly UNPREFIXED_VERSION=`echo ${VERSION} | cut -c 2-`
-npm publish dist/firebase-admin-${UNPREFIXED_VERSION}.tgz --registry https://wombat-dressing-room.appspot.com
+npm publish ./dist/firebase-admin-${UNPREFIXED_VERSION}.tgz --registry https://wombat-dressing-room.appspot.com


### PR DESCRIPTION
Using relative path in `npm publish` command.