### PR TITLE
Fixing Android notification options descriptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4709,6 +4709,15 @@ declare namespace admin.messaging {
      *
      * **Platforms:** Android
      */
+    tag?: string
+
+    /**
+     * The sound to play when the device receives the notification. Supports
+     * "default" or the filename of a sound resource bundled in the app. Sound files
+     * must reside in `/res/raw/`.
+     * 
+     * **Platforms:** Android
+     */
     sound?: string;
 
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4616,14 +4616,7 @@ declare namespace admin.messaging {
     silent?: boolean;
 
     /**
-     * Identifier used to replace existing notifications in the notification drawer.
-     *
-     * If not specified, each request creates a new notification.
-     *
-     * If specified and a notification with the same tag is already being shown,
-     * the new notification replaces the existing one in the notification drawer.
-     *
-     * **Platforms:** Android
+     * An identifying tag for the notification.
      */
     tag?: string;
 
@@ -4666,7 +4659,6 @@ declare namespace admin.messaging {
    * for code samples and detailed documentation.
    */
   interface NotificationMessagePayload {
-    tag?: string;
 
     /**
      * The notification's body text.
@@ -4714,6 +4706,18 @@ declare namespace admin.messaging {
      * **Platforms:** Android
      */
     sound?: string;
+
+    /**
+     * Identifier used to replace existing notifications in the notification drawer.
+     *
+     * If not specified, each request creates a new notification.
+     *
+     * If specified and a notification with the same tag is already being shown,
+     * the new notification replaces the existing one in the notification drawer.
+     *
+     * **Platforms:** Android
+     */ 
+    tag?: string;
 
     /**
      * The notification's title.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4616,7 +4616,14 @@ declare namespace admin.messaging {
     silent?: boolean;
 
     /**
-     * An identifying tag for the notification.
+     * Identifier used to replace existing notifications in the notification drawer.
+     *
+     * If not specified, each request creates a new notification.
+     *
+     * If specified and a notification with the same tag is already being shown,
+     * the new notification replaces the existing one in the notification drawer.
+     *
+     * **Platforms:** Android
      */
     tag?: string;
 
@@ -4698,18 +4705,6 @@ declare namespace admin.messaging {
      * **Platforms:** Android
      */
     color?: string;
-
-    /**
-     * Identifier used to replace existing notifications in the notification drawer.
-     *
-     * If not specified, each request creates a new notification.
-     *
-     * If specified and a notification with the same tag is already being shown,
-     * the new notification replaces the existing one in the notification drawer.
-     *
-     * **Platforms:** Android
-     */
-    tag?: string
 
     /**
      * The sound to play when the device receives the notification. Supports


### PR DESCRIPTION
Per internal bug report 149696213.

Staged internally at https://firebase.devsite.corp.google.com/docs/reference/admin/node/admin.messaging.NotificationMessagePayload#sound

Thanks!