### PR TITLE
Add condition tag colors list

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -815,6 +815,23 @@ declare namespace admin.projectManagement {
 declare namespace admin.remoteConfig {
 
   /**
+  * Colors that are associated with conditions for display purposes.
+  */
+  enum TagColor {
+    BLUE = "Blue",
+    BROWN = "Brown",
+    CYAN = "Cyan",
+    DEEP_ORANGE = "Red Orange",
+    GREEN = "Green",
+    INDIGO = "Indigo",
+    LIME = "Lime",
+    ORANGE = "Orange",
+    PINK = "Pink",
+    PURPLE = "Purple",
+    TEAL = "Teal",
+  }
+
+  /**
   * Interface representing a Remote Config template.
   */
   interface RemoteConfigTemplate {
@@ -885,7 +902,7 @@ declare namespace admin.remoteConfig {
      * Not specifying this value results in the console picking an arbitrary color to associate
      * with the condition.
      */
-    tagColor?: string;
+    tagColor?: TagColor;
   }
 
   /**

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -32,7 +32,7 @@ const FIREBASE_REMOTE_CONFIG_HEADERS = {
   'Accept-Encoding': 'gzip',
 };
 
-export enum RemoteConfigConditionDisplayColor {
+export enum TagColor {
   BLUE = "Blue",
   BROWN = "Brown",
   CYAN = "Cyan",
@@ -69,7 +69,7 @@ export interface RemoteConfigParameter {
 export interface RemoteConfigCondition {
   name: string;
   expression: string;
-  tagColor?: RemoteConfigConditionDisplayColor;
+  tagColor?: TagColor;
 }
 
 /** Interface representing a Remote Config template. */

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -22,7 +22,7 @@ import * as sinon from 'sinon';
 import {
   RemoteConfigApiClient,
   RemoteConfigTemplate,
-  RemoteConfigConditionDisplayColor
+  TagColor,
 } from '../../../src/remote-config/remote-config-api-client';
 import { FirebaseRemoteConfigError } from '../../../src/remote-config/remote-config-utils';
 import { HttpClient } from '../../../src/utils/api-request';
@@ -76,7 +76,7 @@ describe('RemoteConfigApiClient', () => {
     conditions: [{
       name: 'ios',
       expression: 'device.os == \'ios\'',
-      tagColor: RemoteConfigConditionDisplayColor.PINK,
+      tagColor: TagColor.PINK,
     }],
     parameters: {
       // eslint-disable-next-line @typescript-eslint/camelcase

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -26,7 +26,7 @@ import {
   RemoteConfigApiClient,
   RemoteConfigTemplate,
   RemoteConfigCondition,
-  RemoteConfigConditionDisplayColor,
+  TagColor,
 } from '../../../src/remote-config/remote-config-api-client';
 import { FirebaseRemoteConfigError } from '../../../src/remote-config/remote-config-utils';
 import { deepCopy } from '../../../src/utils/deep-copy';
@@ -41,14 +41,14 @@ describe('RemoteConfig', () => {
     // to allow easier use from within the tests. An improvement would be to
     // alter this into a helper that creates customized RemoteConfigTemplateContent based
     // on the needs of the test, as that would ensure type-safety.
-    conditions?: Array<{ name: string; expression: string; tagColor: string }>;
+    conditions?: Array<{ name: string; expression: string; tagColor: TagColor }>;
     parameters?: object | null;
     etag: string;
   } = {
     conditions: [{
       name: 'ios',
       expression: 'device.os == \'ios\'',
-      tagColor: 'BLUE',
+      tagColor: TagColor.BLUE,
     }],
     parameters: {
       // eslint-disable-next-line @typescript-eslint/camelcase
@@ -65,7 +65,7 @@ describe('RemoteConfig', () => {
     conditions: [{
       name: 'ios',
       expression: 'device.os == \'ios\'',
-      tagColor: RemoteConfigConditionDisplayColor.PINK,
+      tagColor: TagColor.PINK,
     }],
     parameters: {
       // eslint-disable-next-line @typescript-eslint/camelcase
@@ -216,7 +216,7 @@ describe('RemoteConfig', () => {
           expect(template.conditions.length).to.equal(1);
           expect(template.conditions[0].name).to.equal('ios');
           expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal('BLUE');
+          expect(template.conditions[0].tagColor).to.equal(TagColor.BLUE);
           expect(template.etag).to.equal('etag-123456789012-5');
           // verify that etag is read-only
           expect(() => {
@@ -234,7 +234,7 @@ describe('RemoteConfig', () => {
           const cond = c as RemoteConfigCondition;
           expect(cond.name).to.equal('ios');
           expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal('BLUE');
+          expect(cond.tagColor).to.equal(TagColor.BLUE);
         });
     });
   });
@@ -306,7 +306,7 @@ describe('RemoteConfig', () => {
           expect(template.conditions.length).to.equal(1);
           expect(template.conditions[0].name).to.equal('ios');
           expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal('Pink');
+          expect(template.conditions[0].tagColor).to.equal(TagColor.PINK);
           // verify that the etag is unchanged
           expect(template.etag).to.equal('etag-123456789012-6');
           // verify that the etag is read-only
@@ -325,7 +325,7 @@ describe('RemoteConfig', () => {
           const cond = c as RemoteConfigCondition;
           expect(cond.name).to.equal('ios');
           expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal('Pink');
+          expect(cond.tagColor).to.equal(TagColor.PINK);
         });
     });
   });
@@ -397,7 +397,7 @@ describe('RemoteConfig', () => {
           expect(template.conditions.length).to.equal(1);
           expect(template.conditions[0].name).to.equal('ios');
           expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal('BLUE');
+          expect(template.conditions[0].tagColor).to.equal(TagColor.BLUE);
           expect(template.etag).to.equal('etag-123456789012-5');
           // verify that the etag is read-only
           expect(() => {
@@ -415,7 +415,7 @@ describe('RemoteConfig', () => {
           const cond = c as RemoteConfigCondition;
           expect(cond.name).to.equal('ios');
           expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal('BLUE');
+          expect(cond.tagColor).to.equal(TagColor.BLUE);
         });
     });
   });
@@ -477,7 +477,7 @@ describe('RemoteConfig', () => {
       expect(newTemplate.conditions.length).to.equal(1);
       expect(newTemplate.conditions[0].name).to.equal('ios');
       expect(newTemplate.conditions[0].expression).to.equal('device.os == \'ios\'');
-      expect(newTemplate.conditions[0].tagColor).to.equal('BLUE');
+      expect(newTemplate.conditions[0].tagColor).to.equal(TagColor.BLUE);
       // verify that the etag is unchanged
       expect(newTemplate.etag).to.equal('etag-123456789012-5');
       // verify that the etag is read-only
@@ -496,7 +496,7 @@ describe('RemoteConfig', () => {
       const cond = c as RemoteConfigCondition;
       expect(cond.name).to.equal('ios');
       expect(cond.expression).to.equal('device.os == \'ios\'');
-      expect(cond.tagColor).to.equal('BLUE');
+      expect(cond.tagColor).to.equal(TagColor.BLUE);
     });
   });
 });


### PR DESCRIPTION
- Add an enum to list all the valid tag colors for conditions

Note: API is still under review. Getting a head start here. Should merge after #826 