### PR TITLE
Convert TagColor enum to a union type to fix integration tests

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -817,19 +817,8 @@ declare namespace admin.remoteConfig {
   /**
   * Colors that are associated with conditions for display purposes.
   */
-  enum TagColor {
-    BLUE = "Blue",
-    BROWN = "Brown",
-    CYAN = "Cyan",
-    DEEP_ORANGE = "Red Orange",
-    GREEN = "Green",
-    INDIGO = "Indigo",
-    LIME = "Lime",
-    ORANGE = "Orange",
-    PINK = "Pink",
-    PURPLE = "Purple",
-    TEAL = "Teal",
-  }
+  type TagColor = 'BLUE' | 'BROWN' | 'CYAN' | 'DEEP_ORANGE' | 'GREEN' |
+    'INDIGO' | 'LIME' | 'ORANGE' | 'PINK' | 'PURPLE' | 'TEAL';
 
   /**
   * Interface representing a Remote Config template.

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -40,15 +40,15 @@ const VALID_PARAMETERS = {
   }
 };
 
-const VALID_CONDITIONS = [{
+const VALID_CONDITIONS: admin.remoteConfig.RemoteConfigCondition[] = [{
   name: 'ios',
   expression: 'device.os == \'ios\'',
-  tagColor: 'INDIGO' as admin.remoteConfig.TagColor
+  tagColor: 'INDIGO',
 },
 {
   name: 'andriod',
   expression: 'device.os == \'android\'',
-  tagColor: 'GREEN' as admin.remoteConfig.TagColor
+  tagColor: 'GREEN',
 }];
 
 let currentTemplate: admin.remoteConfig.RemoteConfigTemplate;

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -43,12 +43,12 @@ const VALID_PARAMETERS = {
 const VALID_CONDITIONS = [{
   name: 'ios',
   expression: 'device.os == \'ios\'',
-  tagColor: 'BLUE'
+  tagColor: 'INDIGO' as admin.remoteConfig.TagColor
 },
 {
   name: 'andriod',
   expression: 'device.os == \'android\'',
-  tagColor: 'GREEN'
+  tagColor: 'GREEN' as admin.remoteConfig.TagColor
 }];
 
 let currentTemplate: admin.remoteConfig.RemoteConfigTemplate;


### PR DESCRIPTION
- Convert TagColor enum to a union type to fix integration tests