### PR TITLE
Update docs for RC publish template options

### DIFF
--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -235,3 +235,23 @@ toc:
   section:
   - title: "Storage"
     path: /docs/reference/admin/node/admin.storage.Storage
+
+- title: "admin.remoteConfig"
+  path: /docs/reference/admin/node/admin.remoteConfig
+  section:
+  - title: "RemoteConfig"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfig
+  - title: "RemoteConfigTemplate"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigTemplate
+  - title: "RemoteConfigParameter"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigParameter
+  - title: "RemoteConfigParameterGroup"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigParameterGroup
+  - title: "RemoteConfigCondition"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigCondition
+  - title: "ExplicitParameterValue"
+    path: /docs/reference/admin/node/admin.remoteConfig.ExplicitParameterValue
+  - title: "InAppDefaultValue"
+    path: /docs/reference/admin/node/admin.remoteConfig.InAppDefaultValue
+  - title: "RemoteConfigParameterValue"
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigParameterValue

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -979,7 +979,13 @@ declare namespace admin.remoteConfig {
      * Publishes a Remote Config template.
      *
      * @param template The Remote Config template to be published.
-     * @param options Optional options object when publishing a Remote Config template.
+     * @param options Optional options object when publishing a Remote Config template:
+     *    - {boolean} `force` Setting this to `true` forces the Remote Config template to 
+     *      be updated and circumvent the ETag. This approach is not recommended 
+     *      because it risks causing the loss of updates to your Remote Config 
+     *      template if multiple clients are updating the Remote Config template.
+     *      See {@link https://firebase.google.com/docs/remote-config/use-config-rest#etag_usage_and_forced_updates 
+     *      ETag usage and forced updates}.
      *
      * @return A Promise that fulfills with the published `RemoteConfigTemplate`.
      */


### PR DESCRIPTION
- Add a more descriptive comment explaining what `force` updates are in `publishTempalte()` `options`.
- Add the new types to `toc.yaml`