### PR TITLE
Add toJSON method to Remote Config Template implementation

### DIFF
--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -141,7 +141,7 @@ class RemoteConfigTemplateImpl implements RemoteConfigTemplate {
       !validator.isNonEmptyString(config.etag)) {
       throw new FirebaseRemoteConfigError(
         'invalid-argument',
-        `Invalid Remote Config template response: ${JSON.stringify(config)}`);
+        `Invalid Remote Config template: ${JSON.stringify(config)}`);
     }
 
     this.etagInternal = config.etag;
@@ -187,5 +187,17 @@ class RemoteConfigTemplateImpl implements RemoteConfigTemplate {
    */
   get etag(): string {
     return this.etagInternal;
+  }
+
+  /**
+   * @return {RemoteConfigTemplate} A JSON-serializable representation of this object.
+   */
+  public toJSON(): RemoteConfigTemplate {
+    return {
+      etag: this.etagInternal,
+      parameters: this.parameters,
+      parameterGroups: this.parameterGroups,
+      conditions: this.conditions,
+    }
   }
 }

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -197,7 +197,7 @@ class RemoteConfigTemplateImpl implements RemoteConfigTemplate {
       conditions: this.conditions,
       parameters: this.parameters,
       parameterGroups: this.parameterGroups,
-      etag: this.etagInternal,
+      etag: this.etag,
     }
   }
 }

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -194,10 +194,10 @@ class RemoteConfigTemplateImpl implements RemoteConfigTemplate {
    */
   public toJSON(): RemoteConfigTemplate {
     return {
-      etag: this.etagInternal,
+      conditions: this.conditions,
       parameters: this.parameters,
       parameterGroups: this.parameterGroups,
-      conditions: this.conditions,
+      etag: this.etagInternal,
     }
   }
 }

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -179,7 +179,7 @@ describe('admin.remoteConfig', () => {
       const jsonString = JSON.stringify(invalidEtagTemplate);
       it(`should throw if the ETag is ${JSON.stringify(invalidEtag)}`, () => {
         expect(() => admin.remoteConfig().createTemplateFromJSON(jsonString))
-          .to.throw(`Invalid Remote Config template response: ${jsonString}`);
+          .to.throw(`Invalid Remote Config template: ${jsonString}`);
       });
     });
 

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -315,7 +315,8 @@ describe('RemoteConfig', () => {
           expect(cond.expression).to.equal('device.os == \'ios\'');
           expect(cond.tagColor).to.equal(TagColor.BLUE);
 
-          expect(JSON.stringify(template)).equals(JSON.stringify(REMOTE_CONFIG_RESPONSE));
+          const parsed = JSON.parse(JSON.stringify(template));
+          expect(parsed).deep.equals(REMOTE_CONFIG_RESPONSE);
         });
     });
   });

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -186,7 +186,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.getTemplate()
         .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template response: null');
+          'message', 'Invalid Remote Config template: null');
     });
 
     it('should reject when API response does not contain an ETag', () => {
@@ -198,7 +198,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.getTemplate()
         .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template response: ${JSON.stringify(response)}`);
+          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
     });
 
     it('should reject when API response does not contain valid parameters', () => {
@@ -314,6 +314,8 @@ describe('RemoteConfig', () => {
           expect(cond.name).to.equal('ios');
           expect(cond.expression).to.equal('device.os == \'ios\'');
           expect(cond.tagColor).to.equal(TagColor.BLUE);
+
+          expect(JSON.stringify(template)).equals(JSON.stringify(REMOTE_CONFIG_RESPONSE));
         });
     });
   });
@@ -344,7 +346,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template response: null');
+          'message', 'Invalid Remote Config template: null');
     });
 
     it('should reject when API response does not contain an ETag', () => {
@@ -356,7 +358,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template response: ${JSON.stringify(response)}`);
+          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
     });
 
     it('should reject when API response does not contain valid parameters', () => {
@@ -497,7 +499,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template response: null');
+          'message', 'Invalid Remote Config template: null');
     });
 
     it('should reject when API response does not contain an ETag', () => {
@@ -509,7 +511,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template response: ${JSON.stringify(response)}`);
+          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
     });
 
     it('should reject when API response does not contain valid parameters', () => {
@@ -657,7 +659,7 @@ describe('RemoteConfig', () => {
       const jsonString = JSON.stringify(sourceTemplate);
       it(`should throw if the ETag is ${JSON.stringify(invalidEtag)}`, () => {
         expect(() => remoteConfig.createTemplateFromJSON(jsonString))
-          .to.throw(`Invalid Remote Config template response: ${jsonString}`);
+          .to.throw(`Invalid Remote Config template: ${jsonString}`);
       });
     });
 


### PR DESCRIPTION
- Add `toJSON()` method to `RemoteConfigTemplateImpl` to correctly serialize the JSON object