### PR TITLE
docs(readme): tag realtime db + add firestore db

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ environments.
 ## Documentation
 
 * [Setup Guide](https://firebase.google.com/docs/admin/setup/)
-* [Database Guide](https://firebase.google.com/docs/database/admin/start/)
+* [Realtime Database Guide](https://firebase.google.com/docs/database/admin/start/)
+* [Firestore Guide](https://googleapis.dev/nodejs/firestore/latest/index.html)
 * [Authentication Guide](https://firebase.google.com/docs/auth/admin/)
 * [Cloud Messaging Guide](https://firebase.google.com/docs/cloud-messaging/admin/)
 * [API Reference](https://firebase.google.com/docs/reference/admin/node/)


### PR DESCRIPTION
The docs for the database point to the realtime database. There doesn't seem to be any mention of Firestore in the docs, but looking in the source code, it exists and just passes it through to the `@google-cloud/firestore` package.