### PR TITLE
Allow FIREBASE_EMULATOR_CREDENTIALS

### DIFF
--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -358,7 +358,7 @@ export function getApplicationDefault(httpAgent?: Agent): Credential {
   if (process.env.FIREBASE_EMULATOR_CREDENTIALS) {
     try {
       const creds = JSON.parse(process.env.FIREBASE_EMULATOR_CREDENTIALS);
-      return new RefreshTokenCredential(creds, httpAgent, false);
+      return new RefreshTokenCredential(creds, httpAgent, true);
     } catch (error) {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_CREDENTIAL, 

--- a/src/auth/credential.ts
+++ b/src/auth/credential.ts
@@ -258,7 +258,7 @@ export class ComputeEngineCredential implements Credential {
  */
 export class RefreshTokenCredential implements Credential {
 
-  readonly refreshToken: RefreshToken;
+  private readonly refreshToken: RefreshToken;
   private readonly httpClient: HttpClient;
 
   /**
@@ -358,7 +358,7 @@ export function getApplicationDefault(httpAgent?: Agent): Credential {
   if (process.env.FIREBASE_EMULATOR_CREDENTIALS) {
     try {
       const creds = JSON.parse(process.env.FIREBASE_EMULATOR_CREDENTIALS);
-      return new RefreshTokenCredential(creds, httpAgent, true);
+      return new RefreshTokenCredential(creds, httpAgent, false);
     } catch (error) {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_CREDENTIAL, 

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -584,7 +584,7 @@ describe('Credential', () => {
       expect(isApplicationDefault(c)).to.be.true;
     });
 
-    describe("FIREBASE_EMULATOR_CREDENTIALS", () => {
+    describe('FIREBASE_EMULATOR_CREDENTIALS', () => {
 
       let oldEnv: any;
 
@@ -596,7 +596,7 @@ describe('Credential', () => {
         process.env = oldEnv;
       });
 
-      it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
+      it('should return true for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
         const firebaseEmulatorCred = {
           client_id: 'fakeclientid',
           client_secret: 'fakeclientsecret',
@@ -609,7 +609,7 @@ describe('Credential', () => {
 
         const c = getApplicationDefault();
         expect(c).is.instanceOf(RefreshTokenCredential);
-        expect(isApplicationDefault(c)).to.be.false;
+        expect(isApplicationDefault(c)).to.be.true;
       });
   
     });

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -448,12 +448,15 @@ describe('Credential', () => {
         refresh_token: "fakerefreshtoken",
         type: "authorized_user",
       };
-      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
 
       const defaultCred = getApplicationDefault();
       expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
-      expect((defaultCred as RefreshTokenCredential).refreshToken.refreshToken).to.eql(firebaseEmulatorCred.refresh_token);
+      expect(defaultCred).to.have.property('refreshToken').that.includes({ 
+        clientId: firebaseEmulatorCred.client_id,
+        clientSecret: firebaseEmulatorCred.client_secret,
+        refreshToken: firebaseEmulatorCred.refresh_token,
+      });
     });
 
     it('should throw if FIREBASE_EMULATOR_CREDENTIALS is invalid', () => {
@@ -481,7 +484,11 @@ describe('Credential', () => {
 
       const defaultCred = getApplicationDefault();
       expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
-      expect((defaultCred as RefreshTokenCredential).refreshToken.refreshToken).to.eql(firebaseEmulatorCred.refresh_token);
+      expect(defaultCred).to.have.property('refreshToken').that.includes({ 
+        clientId: firebaseEmulatorCred.client_id,
+        clientSecret: firebaseEmulatorCred.client_secret,
+        refreshToken: firebaseEmulatorCred.refresh_token,
+      });
     });
 
     it('should throw if a the gcloud login cache is invalid', () => {
@@ -546,6 +553,8 @@ describe('Credential', () => {
       if (fsStub) {
         fsStub.restore();
       }
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
     });
 
     it('should return true for ServiceAccountCredential loaded from GOOGLE_APPLICATION_CREDENTIALS', () => {
@@ -561,6 +570,20 @@ describe('Credential', () => {
       const c = getApplicationDefault();
       expect(c).is.instanceOf(RefreshTokenCredential);
       expect(isApplicationDefault(c)).to.be.true;
+    });
+
+    it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
+      const firebaseEmulatorCred = {
+        client_id: "fakeclientid",
+        client_secret: "fakeclientsecret",
+        refresh_token: "fakerefreshtoken",
+        type: "authorized_user",
+      };
+      process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+
+      const c = getApplicationDefault();
+      expect(c).is.instanceOf(RefreshTokenCredential);
+      expect(isApplicationDefault(c)).to.be.false;
     });
 
     it('should return true for credential loaded from gcloud SDK', () => {

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -397,7 +397,6 @@ describe('Credential', () => {
       if (fsStub) {
         fsStub.restore();
       }
-      delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
     });
 
     it('should return a CertCredential with GOOGLE_APPLICATION_CREDENTIALS set', () => {
@@ -553,8 +552,6 @@ describe('Credential', () => {
       if (fsStub) {
         fsStub.restore();
       }
-      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-      delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
     });
 
     it('should return true for ServiceAccountCredential loaded from GOOGLE_APPLICATION_CREDENTIALS', () => {
@@ -572,18 +569,34 @@ describe('Credential', () => {
       expect(isApplicationDefault(c)).to.be.true;
     });
 
-    it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
-      const firebaseEmulatorCred = {
-        client_id: "fakeclientid",
-        client_secret: "fakeclientsecret",
-        refresh_token: "fakerefreshtoken",
-        type: "authorized_user",
-      };
-      process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+    describe("FIREBASE_EMULATOR_CREDENTIALS", () => {
 
-      const c = getApplicationDefault();
-      expect(c).is.instanceOf(RefreshTokenCredential);
-      expect(isApplicationDefault(c)).to.be.false;
+      let googleCreds: any = undefined;
+
+      before(() => {
+        googleCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      });
+
+      after(() => {
+        process.env.GOOGLE_APPLICATION_CREDENTIALS = googleCreds;
+        delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
+      });
+
+      it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
+        const firebaseEmulatorCred = {
+          client_id: "fakeclientid",
+          client_secret: "fakeclientsecret",
+          refresh_token: "fakerefreshtoken",
+          type: "authorized_user",
+        };
+        process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+
+        const c = getApplicationDefault();
+        expect(c).is.instanceOf(RefreshTokenCredential);
+        expect(isApplicationDefault(c)).to.be.false;
+      });
+  
     });
 
     it('should return true for credential loaded from gcloud SDK', () => {

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -440,53 +440,68 @@ describe('Credential', () => {
       expect((getApplicationDefault())).to.be.an.instanceof(RefreshTokenCredential);
     });
 
-    it('should return a RefreshTokenCredential with FIREBASE_EMULATOR_CREDENTIALS', () => {
-      const firebaseEmulatorCred = {
-        client_id: "fakeclientid",
-        client_secret: "fakeclientsecret",
-        refresh_token: "fakerefreshtoken",
-        type: "authorized_user",
-      };
-      process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+    describe('FIREBASE_EMULATOR_CREDENTIALS', () => {
 
-      const defaultCred = getApplicationDefault();
-      expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
-      expect(defaultCred).to.have.property('refreshToken').that.includes({ 
-        clientId: firebaseEmulatorCred.client_id,
-        clientSecret: firebaseEmulatorCred.client_secret,
-        refreshToken: firebaseEmulatorCred.refresh_token,
+      let oldEnv: any;
+
+      before(() => {
+        oldEnv = process.env;
+      })
+
+      after(() => {
+        process.env = oldEnv;
+      })
+
+      it('should return a RefreshTokenCredential with FIREBASE_EMULATOR_CREDENTIALS', () => {
+        const firebaseEmulatorCred = {
+          client_id: "fakeclientid",
+          client_secret: "fakeclientsecret",
+          refresh_token: "fakerefreshtoken",
+          type: "authorized_user",
+        };
+
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+  
+        const defaultCred = getApplicationDefault();
+        expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
+        expect(defaultCred).to.have.property('refreshToken').that.includes({ 
+          clientId: firebaseEmulatorCred.client_id,
+          clientSecret: firebaseEmulatorCred.client_secret,
+          refreshToken: firebaseEmulatorCred.refresh_token,
+        });
       });
-    });
-
-    it('should throw if FIREBASE_EMULATOR_CREDENTIALS is invalid', () => {
-      process.env.FIREBASE_EMULATOR_CREDENTIALS = "{{}}";
-      expect(() => getApplicationDefault()).to.throw(Error);
-    });
-
-    it('should prefer FIREBASE_EMULATOR_CREDENTIALS to gcloud default', () => {
-      if (!fs.existsSync(GCLOUD_CREDENTIAL_PATH)) {
-        // tslint:disable-next-line:no-console
-        console.log(
-          'WARNING: Test being skipped because gcloud credentials not found. Run `gcloud beta auth ' +
-          'application-default login`.');
-        return;
-      }
-      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-
-      const firebaseEmulatorCred = {
-        client_id: "fakeclientid",
-        client_secret: "fakeclientsecret",
-        refresh_token: "fakerefreshtoken",
-        type: "authorized_user",
-      };
-      process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
-
-      const defaultCred = getApplicationDefault();
-      expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
-      expect(defaultCred).to.have.property('refreshToken').that.includes({ 
-        clientId: firebaseEmulatorCred.client_id,
-        clientSecret: firebaseEmulatorCred.client_secret,
-        refreshToken: firebaseEmulatorCred.refresh_token,
+  
+      it('should throw if FIREBASE_EMULATOR_CREDENTIALS is invalid', () => {
+        process.env.FIREBASE_EMULATOR_CREDENTIALS = "{{}}";
+        expect(() => getApplicationDefault()).to.throw(Error);
+      });
+  
+      it('should prefer FIREBASE_EMULATOR_CREDENTIALS to gcloud default', () => {
+        if (!fs.existsSync(GCLOUD_CREDENTIAL_PATH)) {
+          // tslint:disable-next-line:no-console
+          console.log(
+            'WARNING: Test being skipped because gcloud credentials not found. Run `gcloud beta auth ' +
+            'application-default login`.');
+          return;
+        }
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  
+        const firebaseEmulatorCred = {
+          client_id: "fakeclientid",
+          client_secret: "fakeclientsecret",
+          refresh_token: "fakerefreshtoken",
+          type: "authorized_user",
+        };
+        process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
+  
+        const defaultCred = getApplicationDefault();
+        expect(defaultCred).to.be.an.instanceof(RefreshTokenCredential);
+        expect(defaultCred).to.have.property('refreshToken').that.includes({ 
+          clientId: firebaseEmulatorCred.client_id,
+          clientSecret: firebaseEmulatorCred.client_secret,
+          refreshToken: firebaseEmulatorCred.refresh_token,
+        });
       });
     });
 
@@ -571,16 +586,14 @@ describe('Credential', () => {
 
     describe("FIREBASE_EMULATOR_CREDENTIALS", () => {
 
-      let googleCreds: any = undefined;
+      let oldEnv: any;
 
       before(() => {
-        googleCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        oldEnv = process.env;
       });
 
       after(() => {
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = googleCreds;
-        delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
+        process.env = oldEnv;
       });
 
       it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
@@ -590,6 +603,8 @@ describe('Credential', () => {
           refresh_token: "fakerefreshtoken",
           type: "authorized_user",
         };
+        
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
         process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
 
         const c = getApplicationDefault();
@@ -608,6 +623,7 @@ describe('Credential', () => {
         return;
       }
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
       const c = getApplicationDefault();
       expect(c).to.be.an.instanceof(RefreshTokenCredential);
       expect(isApplicationDefault(c)).to.be.true;
@@ -615,6 +631,7 @@ describe('Credential', () => {
 
     it('should return true for ComputeEngineCredential', () => {
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      delete process.env.FIREBASE_EMULATOR_CREDENTIALS;
       fsStub = sinon.stub(fs, 'readFileSync').throws(new Error('no gcloud credential file'));
       const c = getApplicationDefault();
       expect(c).to.be.an.instanceof(ComputeEngineCredential);

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -454,10 +454,10 @@ describe('Credential', () => {
 
       it('should return a RefreshTokenCredential with FIREBASE_EMULATOR_CREDENTIALS', () => {
         const firebaseEmulatorCred = {
-          client_id: "fakeclientid",
-          client_secret: "fakeclientsecret",
-          refresh_token: "fakerefreshtoken",
-          type: "authorized_user",
+          client_id: 'fakeclientid',
+          client_secret: 'fakeclientsecret',
+          refresh_token: 'fakerefreshtoken',
+          type: 'authorized_user',
         };
 
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -473,7 +473,7 @@ describe('Credential', () => {
       });
   
       it('should throw if FIREBASE_EMULATOR_CREDENTIALS is invalid', () => {
-        process.env.FIREBASE_EMULATOR_CREDENTIALS = "{{}}";
+        process.env.FIREBASE_EMULATOR_CREDENTIALS = '{{}}';
         expect(() => getApplicationDefault()).to.throw(Error);
       });
   
@@ -488,10 +488,10 @@ describe('Credential', () => {
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   
         const firebaseEmulatorCred = {
-          client_id: "fakeclientid",
-          client_secret: "fakeclientsecret",
-          refresh_token: "fakerefreshtoken",
-          type: "authorized_user",
+          client_id: 'fakeclientid',
+          client_secret: 'fakeclientsecret',
+          refresh_token: 'fakerefreshtoken',
+          type: 'authorized_user',
         };
         process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
   
@@ -598,10 +598,10 @@ describe('Credential', () => {
 
       it('should return false for RefreshTokenCredential loaded from FIREBASE_EMULATOR_CREDENTIALS', () => {
         const firebaseEmulatorCred = {
-          client_id: "fakeclientid",
-          client_secret: "fakeclientsecret",
-          refresh_token: "fakerefreshtoken",
-          type: "authorized_user",
+          client_id: 'fakeclientid',
+          client_secret: 'fakeclientsecret',
+          refresh_token: 'fakerefreshtoken',
+          type: 'authorized_user',
         };
         
         delete process.env.GOOGLE_APPLICATION_CREDENTIALS;

--- a/test/unit/auth/credential.spec.ts
+++ b/test/unit/auth/credential.spec.ts
@@ -448,6 +448,7 @@ describe('Credential', () => {
         refresh_token: "fakerefreshtoken",
         type: "authorized_user",
       };
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       process.env.FIREBASE_EMULATOR_CREDENTIALS = JSON.stringify(firebaseEmulatorCred);
 
       const defaultCred = getApplicationDefault();


### PR DESCRIPTION
See: https://github.com/firebase/firebase-tools/pull/2214

This change will allow the Firebase emulators to pass the credentials from `firebase login` to the Admin SDK as a JSON environment variable.

Currently the emulators rely on picking up `gcloud auth application-default login` credentials on the machine which is at best annoying and at worst means that the emulators are authorized as the wrong user.
