### PR TITLE
Remove type aliases from toc.yaml

### DIFF
--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -36,8 +36,6 @@ toc:
     path: /docs/reference/admin/node/admin.auth.CreatePhoneMultiFactorInfoRequest
   - title: "CreateRequest"
     path: /docs/reference/admin/node/admin.auth.CreateRequest
-  - title: "CreateTenantRequest"
-    path: /docs/reference/admin/node/admin.auth.CreateTenantRequest
   - title: "ListProviderConfigResults"
     path: /docs/reference/admin/node/admin.auth.ListProviderConfigResults
   - title: "ListTenantsResult"
@@ -273,5 +271,3 @@ toc:
     path: /docs/reference/admin/node/admin.remoteConfig.ExplicitParameterValue
   - title: "InAppDefaultValue"
     path: /docs/reference/admin/node/admin.remoteConfig.InAppDefaultValue
-  - title: "RemoteConfigParameterValue"
-    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigParameterValue


### PR DESCRIPTION
- Remove type aliases from toc.yaml

Type doc complaints about missing files when generating docs. This PR removes the type aliases in `toc.yaml` causing the missing file paths.