### PR TITLE
Rectified issues in comments for NotificationMessagePayload

### DIFF
--- a/src/messaging.d.ts
+++ b/src/messaging.d.ts
@@ -684,8 +684,12 @@ export namespace admin.messaging {
     color?: string;
 
     /**
-     * The sound to be played when the device receives the
-     * notification.
+     * The sound to be played when device receives a notification. Supports
+     * "default" for default notification sounf of device or the filename of a 
+     * sound resource bundled in the app. 
+     * Sound files must reside in `/res/raw/`.
+     * 
+     * **Platforms:** Android
      */
     sound?: string;
 

--- a/src/messaging.d.ts
+++ b/src/messaging.d.ts
@@ -685,7 +685,7 @@ export namespace admin.messaging {
 
     /**
      * The sound to be played when device receives a notification. Supports
-     * "default" for default notification sounf of device or the filename of a 
+     * "default" for default notification sound of device or the filename of a 
      * sound resource bundled in the app. 
      * Sound files must reside in `/res/raw/`.
      * 

--- a/src/messaging.d.ts
+++ b/src/messaging.d.ts
@@ -632,6 +632,17 @@ export namespace admin.messaging {
    * for code samples and detailed documentation.
    */
   interface NotificationMessagePayload {
+    
+    /**
+     * Identifier used to replace existing notifications in the notification drawer.
+     *
+     * If not specified, each request creates a new notification.
+     *
+     * If specified and a notification with the same tag is already being shown,
+     * the new notification replaces the existing one in the notification drawer.
+     *
+     * **Platforms:** Android
+     */
     tag?: string;
 
     /**
@@ -673,14 +684,8 @@ export namespace admin.messaging {
     color?: string;
 
     /**
-     * Identifier used to replace existing notifications in the notification drawer.
-     *
-     * If not specified, each request creates a new notification.
-     *
-     * If specified and a notification with the same tag is already being shown,
-     * the new notification replaces the existing one in the notification drawer.
-     *
-     * **Platforms:** Android
+     * The sound to be played when the device receives the
+     * notification.
      */
     sound?: string;
 

--- a/src/messaging.d.ts
+++ b/src/messaging.d.ts
@@ -684,8 +684,8 @@ export namespace admin.messaging {
     color?: string;
 
     /**
-     * The sound to be played when device receives a notification. Supports
-     * "default" for default notification sound of device or the filename of a 
+     * The sound to be played when the device receives a notification. Supports
+     * "default" for the default notification sound of the device or the filename of a 
      * sound resource bundled in the app. 
      * Sound files must reside in `/res/raw/`.
      * 


### PR DESCRIPTION
The comments regarding the `NotificationMessagePayload` were not correct. They were placed with different options.  
The comment related to `tag` was attached to `sound` and `tag` did not have any comment attached.  

Had an issue understanding the payload the first time I opened the installed directory to go through the payload of `sendToDevice`
