### PR TITLE
fix(auth): Mark UserMetadata::lastRefreshTime as optional.

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -24,7 +24,7 @@ export namespace admin.auth {
      * formatted as a UTC Date string (eg 'Sat, 03 Feb 2001 04:05:06 GMT').
      * Returns null if the user was never active.
      */
-    lastRefreshTime: string|null;
+    lastRefreshTime?: string|null;
 
     /**
      * @return A JSON-serializable representation of this object.


### PR DESCRIPTION
While it's always present (even if null), having it optional allows
existing code that implements this interface to not break.

Fixes: #880