### PR TITLE
fix(auth): Properly parse the lastRefreshTime.

### DIFF
--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -326,7 +326,8 @@ export class UserMetadata {
     // These bugs have already been addressed since then.
     utils.addReadonlyGetter(this, 'creationTime', parseDate(response.createdAt));
     utils.addReadonlyGetter(this, 'lastSignInTime', parseDate(response.lastLoginAt));
-    utils.addReadonlyGetter(this, 'lastRefreshTime', parseDate(response.lastRefreshAt));
+    const lastRefreshAt = response.lastRefreshAt ? new Date(response.lastRefreshAt).toUTCString() : null;
+    utils.addReadonlyGetter(this, 'lastRefreshTime', lastRefreshAt);
   }
 
   /** @return The plain object representation of the user's metadata. */

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -336,6 +336,12 @@ describe('admin.auth', () => {
           .then((userRecord) => {
             expect(userRecord.metadata.lastRefreshTime).to.exist;
             expect(isUTCString(userRecord.metadata.lastRefreshTime!));
+            expect(new Date(userRecord.metadata.creationTime).getTime())
+              .lte(new Date(userRecord.metadata.lastRefreshTime!).getTime());
+            const creationTimePlus1Hour = new Date(userRecord.metadata.creationTime);
+            creationTimePlus1Hour.setHours(creationTimePlus1Hour.getHours()+1);
+            expect(new Date(userRecord.metadata.lastRefreshTime!).getTime())
+              .lte(creationTimePlus1Hour.getTime());
           });
       } finally {
         admin.auth().deleteUser('lastRefreshTimeUser');

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -336,12 +336,10 @@ describe('admin.auth', () => {
           .then((userRecord) => {
             expect(userRecord.metadata.lastRefreshTime).to.exist;
             expect(isUTCString(userRecord.metadata.lastRefreshTime!));
-            expect(new Date(userRecord.metadata.creationTime).getTime())
-              .lte(new Date(userRecord.metadata.lastRefreshTime!).getTime());
-            const creationTimePlus1Hour = new Date(userRecord.metadata.creationTime);
-            creationTimePlus1Hour.setHours(creationTimePlus1Hour.getHours()+1);
-            expect(new Date(userRecord.metadata.lastRefreshTime!).getTime())
-              .lte(creationTimePlus1Hour.getTime());
+            const creationTime = new Date(userRecord.metadata.creationTime).getTime();
+            const lastRefreshTime = new Date(userRecord.metadata.lastRefreshTime).getTime();
+            expect(creationTime).lte(lastRefreshTime);
+            expect(lastRefreshTime).lte(creationTime + 3600*1000);
           });
       } finally {
         admin.auth().deleteUser('lastRefreshTimeUser');

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -339,7 +339,7 @@ describe('admin.auth', () => {
             const creationTime = new Date(userRecord.metadata.creationTime).getTime();
             const lastRefreshTime = new Date(userRecord.metadata.lastRefreshTime!).getTime();
             expect(creationTime).lte(lastRefreshTime);
-            expect(lastRefreshTime).lte(creationTime + 3600*1000);
+            expect(lastRefreshTime).lte(creationTime + 3600 * 1000);
           });
       } finally {
         admin.auth().deleteUser('lastRefreshTimeUser');

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -337,7 +337,7 @@ describe('admin.auth', () => {
             expect(userRecord.metadata.lastRefreshTime).to.exist;
             expect(isUTCString(userRecord.metadata.lastRefreshTime!));
             const creationTime = new Date(userRecord.metadata.creationTime).getTime();
-            const lastRefreshTime = new Date(userRecord.metadata.lastRefreshTime).getTime();
+            const lastRefreshTime = new Date(userRecord.metadata.lastRefreshTime!).getTime();
             expect(creationTime).lte(lastRefreshTime);
             expect(lastRefreshTime).lte(creationTime + 3600*1000);
           });

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -616,7 +616,7 @@ describe('UserInfo', () => {
 describe('UserMetadata', () => {
   const expectedLastLoginAt = 1476235905000;
   const expectedCreatedAt = 1476136676000;
-  const expectedLastRefreshAt = "2016-10-12T01:31:45.000Z"
+  const expectedLastRefreshAt = '2016-10-12T01:31:45.000Z';
   const actualMetadata: UserMetadata = new UserMetadata({
     localId: 'uid123',
     lastLoginAt: expectedLastLoginAt.toString(),

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -616,10 +616,12 @@ describe('UserInfo', () => {
 describe('UserMetadata', () => {
   const expectedLastLoginAt = 1476235905000;
   const expectedCreatedAt = 1476136676000;
+  const expectedLastRefreshAt = "2016-10-12T01:31:45.000Z"
   const actualMetadata: UserMetadata = new UserMetadata({
     localId: 'uid123',
     lastLoginAt: expectedLastLoginAt.toString(),
     createdAt: expectedCreatedAt.toString(),
+    lastRefreshAt: expectedLastRefreshAt,
   });
   const expectedMetadataJSON = {
     lastSignInTime: new Date(expectedLastLoginAt).toUTCString(),
@@ -675,6 +677,10 @@ describe('UserMetadata', () => {
       expect(() => {
         (actualMetadata as any).creationTime = new Date();
       }).to.throw(Error);
+    });
+
+    it('should return expected lastRefreshTime', () => {
+      expect(actualMetadata.lastRefreshTime).to.equal(new Date(expectedLastRefreshAt).toUTCString())
     });
   });
 


### PR DESCRIPTION
It's returned from the server in a different format than the other timestamps.

Fixes #887