### PR TITLE
Add a separate function for getting a Template with version number

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1112,11 +1112,19 @@ declare namespace admin.remoteConfig {
      * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
      * 
-     * @param versionNumber Version number of the Remote Config template to look up.
-     *    If not specified, the latest Remote Config template is returned. Optional.
      * @return A promise that fulfills with a `RemoteConfigTemplate`.
      */
-    getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate>;
+    getTemplate(): Promise<RemoteConfigTemplate>;
+
+    /**
+     * Gets the requested version of the {@link admin.remoteConfig.RemoteConfigTemplate
+     * `RemoteConfigTemplate`} of the project.
+     * 
+     * @param versionNumber Version number of the Remote Config template to look up.
+     * 
+     * @return A promise that fulfills with a `RemoteConfigTemplate`.
+     */
+    getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
 
     /**
      * Validates a {@link admin.remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -143,18 +143,33 @@ export class RemoteConfigApiClient {
     this.httpClient = new AuthorizedHttpClient(app);
   }
 
-  public getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate> {
-    const requestData: { [k: string]: any } = {};
-    if (typeof versionNumber !== 'undefined') {
-      requestData['versionNumber'] = this.validateVersionNumber(versionNumber);
-    }
+  public getTemplate(): Promise<RemoteConfigTemplate> {
+    return this.getUrl()
+      .then((url) => {
+        const request: HttpRequestConfig = {
+          method: 'GET',
+          url: `${url}/remoteConfig`,
+          headers: FIREBASE_REMOTE_CONFIG_HEADERS
+        };
+        return this.httpClient.send(request);
+      })
+      .then((resp) => {
+        return this.toRemoteConfigTemplate(resp);
+      })
+      .catch((err) => {
+        throw this.toFirebaseError(err);
+      });
+  }
+
+  public getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate> {
+    const data = { versionNumber: this.validateVersionNumber(versionNumber) };
     return this.getUrl()
       .then((url) => {
         const request: HttpRequestConfig = {
           method: 'GET',
           url: `${url}/remoteConfig`,
           headers: FIREBASE_REMOTE_CONFIG_HEADERS,
-          data: requestData
+          data
         };
         return this.httpClient.send(request);
       })

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -64,12 +64,24 @@ export class RemoteConfig implements FirebaseServiceInterface {
   /**
   * Gets the current active version of the Remote Config template of the project.
   *
-  * @param {number | string} versionNumber Version number of the Remote Config template to look up.
-  *    If not specified, the latest Remote Config template will be returned. Optional.
   * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
   */
-  public getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate> {
-    return this.client.getTemplate(versionNumber)
+  public getTemplate(): Promise<RemoteConfigTemplate> {
+    return this.client.getTemplate()
+      .then((templateResponse) => {
+        return new RemoteConfigTemplateImpl(templateResponse);
+      });
+  }
+
+  /**
+  * Gets the requested version of the Remote Config template of the project.
+  *
+  * @param {number | string} versionNumber Version number of the Remote Config template to look up.
+  * 
+  * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
+  */
+  public getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate> {
+    return this.client.getTemplateAtVersion(versionNumber)
       .then((templateResponse) => {
         return new RemoteConfigTemplateImpl(templateResponse);
       });

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -165,9 +165,6 @@ describe('RemoteConfigApiClient', () => {
         .should.eventually.be.rejectedWith(noProjectId);
     });
 
-    // test for version number validations
-    runTemplateVersionNumberTests((v: string | number) => { apiClient.getTemplate(v); });
-
     // tests for api response validations
     runEtagHeaderTests(() => apiClient.getTemplate());
     runErrorResponseTests(() => apiClient.getTemplate());
@@ -187,17 +184,30 @@ describe('RemoteConfigApiClient', () => {
             method: 'GET',
             url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',
             headers: EXPECTED_HEADERS,
-            data: {},
           });
         });
     });
+  });
+
+  describe('getTemplateAtVersion', () => {
+    it(`should reject when project id is not available`, () => {
+      return clientWithoutProjectId.getTemplateAtVersion(65)
+        .should.eventually.be.rejectedWith(noProjectId);
+    });
+
+    // test for version number validations
+    runTemplateVersionNumberTests((v: string | number) => { apiClient.getTemplateAtVersion(v); });
+
+    // tests for api response validations
+    runEtagHeaderTests(() => apiClient.getTemplateAtVersion(65));
+    runErrorResponseTests(() => apiClient.getTemplateAtVersion(65));
 
     it('should convert version number to string', () => {
       const stub = sinon
         .stub(HttpClient.prototype, 'send')
         .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-60' }));
       stubs.push(stub);
-      return apiClient.getTemplate(60)
+      return apiClient.getTemplateAtVersion(60)
         .then(() => {
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: 'GET',
@@ -213,7 +223,7 @@ describe('RemoteConfigApiClient', () => {
         .stub(HttpClient.prototype, 'send')
         .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-60' }));
       stubs.push(stub);
-      return apiClient.getTemplate('60')
+      return apiClient.getTemplateAtVersion('60')
         .then((resp) => {
           expect(resp.conditions).to.deep.equal(TEST_RESPONSE.conditions);
           expect(resp.parameters).to.deep.equal(TEST_RESPONSE.parameters);

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -203,6 +203,11 @@ describe('RemoteConfig', () => {
     runValidResponseTests(() => remoteConfig.getTemplate(), 'getTemplate');
   });
 
+  describe('getTemplateAtVersion', () => {
+    runInvalidResponseTests(() => remoteConfig.getTemplateAtVersion(65), 'getTemplateAtVersion');
+    runValidResponseTests(() => remoteConfig.getTemplateAtVersion(65), 'getTemplateAtVersion');
+  });
+
   describe('validateTemplate', () => {
     runInvalidResponseTests(() => remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE),
       'validateTemplate');


### PR DESCRIPTION
- Add `getTemplateAtVersion()` for getting a RC template with a version number
- Revert `getTemplate()` to only access the active RC template of a project
- Add unit tests for `getTemplateAtVersion`

Note: All integration tests for go/admin-sdk-remote-config-change-history will be added in a separate PR