### PR TITLE
fix(auth): Add interfaces for UserProviderRequest and Metadata used in UserImportRecord

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -704,13 +704,6 @@ export namespace admin.auth {
      * The date the user was created, formatted as a UTC string.
      */
     creationTime?: string;
-
-    /**
-     * The time at which the user was last active (ID token refreshed),
-     * formatted as a UTC Date string (eg 'Sat, 03 Feb 2001 04:05:06 GMT').
-     * Null implies the user was never active.
-     */
-    lastRefreshTime?: string|null;
   }
 
   /**

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -59,7 +59,6 @@ interface UserProviderRequest {
 interface UserMetadataRequest {
   lastSignInTime?: string;
   creationTime?: string;
-  lastRefreshTime?: string|null;
 }
 
 /** User import record as accepted from developer. */

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -47,6 +47,14 @@ interface SecondFactor {
   factorId: string;
 }
 
+interface UserProviderRequest {
+  uid: string;
+  displayName?: string;
+  email?: string;
+  phoneNumber?: string;
+  photoURL?: string;
+  providerId: string;
+}
 
 /** User import record as accepted from developer. */
 export interface UserImportRecord {
@@ -61,13 +69,7 @@ export interface UserImportRecord {
     lastSignInTime?: string;
     creationTime?: string;
   };
-  providerData?: Array<{
-    uid: string;
-    displayName?: string;
-    email?: string;
-    photoURL?: string;
-    providerId: string;
-  }>;
+  providerData?: Array<UserProviderRequest>;
   multiFactor?: {
     enrolledFactors: SecondFactor[];
   };

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -56,6 +56,12 @@ interface UserProviderRequest {
   providerId: string;
 }
 
+interface UserMetadataRequest {
+  lastSignInTime?: string;
+  creationTime?: string;
+  lastRefreshTime?: string|null;
+}
+
 /** User import record as accepted from developer. */
 export interface UserImportRecord {
   uid: string;
@@ -65,10 +71,7 @@ export interface UserImportRecord {
   phoneNumber?: string;
   photoURL?: string;
   disabled?: boolean;
-  metadata?: {
-    lastSignInTime?: string;
-    creationTime?: string;
-  };
+  metadata?: UserMetadataRequest;
   providerData?: Array<UserProviderRequest>;
   multiFactor?: {
     enrolledFactors: SecondFactor[];

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -239,7 +239,6 @@ describe('admin.auth', () => {
       metadata: {
         lastSignInTime: 'Thu, 01 Jan 1970 00:00:00 UTC',
         creationTime: 'Thu, 01 Jan 1970 00:00:00 UTC',
-        lastRefreshTime: null,
       },
       providerData: [{
         displayName: 'User Four',


### PR DESCRIPTION
I think there is an inconsistency with the defined `auth.d.ts` file [here](https://github.com/firebase/firebase-admin-node/blob/master/src/auth.d.ts#L802). This aims to add the interface to be consistent and then have an array of `UserProviderRequest`.

Similar change applies also for [metadata](https://github.com/firebase/firebase-admin-node/blob/master/src/auth.d.ts#L696).

Not sure if this is the best approach.