### PR TITLE
fix(auth): Make uid mandatory for UserImportRecord

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -825,7 +825,20 @@ export namespace admin.auth {
     /**
      * The user's multi-factor related properties.
      */
-    multiFactor?: admin.auth.MultiFactorUpdateSettings;
+    multiFactor?: {
+      enrolledFactors: admin.auth.SecondFactor[];
+    };
+  }
+
+  /**
+   * Interface representing user's multi-factor related properties.
+   */
+  interface SecondFactor {
+    uid: string;
+    phoneNumber: string;
+    displayName?: string;
+    enrollmentTime?: string;
+    factorId: string;
   }
 
   /**

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -39,7 +39,8 @@ export interface UserImportOptions {
   };
 }
 
-interface SecondFactor {
+/** Interface representing user's multi-factor related properties */
+export interface SecondFactor {
   uid: string;
   phoneNumber: string;
   displayName?: string;

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -94,6 +94,7 @@ export interface UpdateRequest {
 
 /** Parameters for create user operation */
 export interface CreateRequest extends UpdateRequest {
+  uid?: string;
   multiFactor?: {
     enrolledFactors: CreateMultiFactorInfoRequest[];
   };

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -64,7 +64,7 @@ export interface CreatePhoneMultiFactorInfoRequest extends CreateMultiFactorInfo
  * for an `UpdateRequest`.
  */
 export interface UpdateMultiFactorInfoRequest {
-  uid?: string;
+  uid: string;
   displayName?: string;
   enrollmentTime?: string;
   factorId: string;

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -64,7 +64,7 @@ export interface CreatePhoneMultiFactorInfoRequest extends CreateMultiFactorInfo
  * for an `UpdateRequest`.
  */
 export interface UpdateMultiFactorInfoRequest {
-  uid: string;
+  uid?: string;
   displayName?: string;
   enrollmentTime?: string;
   factorId: string;
@@ -78,7 +78,8 @@ export interface UpdatePhoneMultiFactorInfoRequest extends UpdateMultiFactorInfo
   phoneNumber: string;
 }
 
-interface Request {
+/** Parameters for update user operation */
+export interface UpdateRequest {
   disabled?: boolean;
   displayName?: string | null;
   email?: string;
@@ -86,18 +87,13 @@ interface Request {
   password?: string;
   phoneNumber?: string | null;
   photoURL?: string | null;
-}
-
-/** Parameters for update user operation */
-export interface UpdateRequest extends Request {
   multiFactor?: {
     enrolledFactors: UpdateMultiFactorInfoRequest[] | null;
   };
 }
 
 /** Parameters for create user operation */
-export interface CreateRequest extends Request {
-  uid: string;
+export interface CreateRequest extends UpdateRequest {
   multiFactor?: {
     enrolledFactors: CreateMultiFactorInfoRequest[];
   };

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -78,8 +78,7 @@ export interface UpdatePhoneMultiFactorInfoRequest extends UpdateMultiFactorInfo
   phoneNumber: string;
 }
 
-/** Parameters for update user operation */
-export interface UpdateRequest {
+interface Request {
   disabled?: boolean;
   displayName?: string | null;
   email?: string;
@@ -87,14 +86,18 @@ export interface UpdateRequest {
   password?: string;
   phoneNumber?: string | null;
   photoURL?: string | null;
+}
+
+/** Parameters for update user operation */
+export interface UpdateRequest extends Request {
   multiFactor?: {
     enrolledFactors: UpdateMultiFactorInfoRequest[] | null;
   };
 }
 
 /** Parameters for create user operation */
-export interface CreateRequest extends UpdateRequest {
-  uid?: string;
+export interface CreateRequest extends Request {
+  uid: string;
   multiFactor?: {
     enrolledFactors: CreateMultiFactorInfoRequest[];
   };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -590,6 +590,7 @@ declare namespace admin.auth {
   export import UpdatePhoneMultiFactorInfoRequest = _auth.admin.auth.UpdatePhoneMultiFactorInfoRequest;
   export import MultiFactorCreateSettings = _auth.admin.auth.MultiFactorCreateSettings;
   export import MultiFactorUpdateSettings = _auth.admin.auth.MultiFactorUpdateSettings;
+  export import SecondFactor = _auth.admin.auth.SecondFactor;
 }
 
 declare namespace admin.credential {

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -1859,7 +1859,7 @@ describe('admin.auth', () => {
       const uid = generateRandomString(20).toLowerCase();
       const email = uid + '@example.com';
       const now = new Date(1476235905000).toUTCString();
-      const enrolledFactors: admin.auth.UpdatePhoneMultiFactorInfoRequest[] = [
+      const enrolledFactors: admin.auth.SecondFactor[] = [
         {
           uid: 'mfaUid1',
           phoneNumber: '+16505550001',


### PR DESCRIPTION
In the type signature for the equivalent of `UserImportRecord`'s `multiFactor.enrolledFactors`, the `uid` is an optional field, however in the implementation it is mandatory. I am not certain if it should be mandatory or not, but I think it should be mandatory.

To account for this, originally I added an extra interface in the hierarchy of `UpdateRequest` and `CreateRequest` that will mandate the `uid` is provided, because otherwise the type-checker would raise a warning as `UpdateMultiFactorInfoRequest` cannot be extended by `CreateMultiFactorInfoRequest`.

However I realized that instead a better approach might be to simply bring the `SecondFactor` interface to the typing so that the other hierarchy doesn't change.


Summary of observation:

## Source
- `UserImportRecord` expects `SecondFactor[]` for property `multiFactor`: https://github.com/firebase/firebase-admin-node/blob/b5909906bd4b73630f2a6311ac06b9e65be2d621/src/auth/user-import-builder.ts#L52-L73
- `SecondFactor` (UID not optional): https://github.com/firebase/firebase-admin-node/blob/bed1e5ec6c3e515b037b993cdbbeb1f5b585f56a/src/auth/user-import-builder.ts#L42-L48
 
## Typing
- `UserImportRecord` expects `MultiFactorUpdateSettings`: https://github.com/firebase/firebase-admin-node/blob/bed1e5ec6c3e515b037b993cdbbeb1f5b585f56a/src/auth.d.ts#L828
- `MultiFactorUpdateSettings` yields `UpdateMultiFactorInfoRequest`:  https://github.com/firebase/firebase-admin-node/blob/bed1e5ec6c3e515b037b993cdbbeb1f5b585f56a/src/auth.d.ts#L255-L262
- `UpdateMultiFactorInfoRequest` (UID as optional): 
https://github.com/firebase/firebase-admin-node/blob/bed1e5ec6c3e515b037b993cdbbeb1f5b585f56a/src/auth.d.ts#L269-L275

## Other SDKs
- It appears that in the Java SDK the UID is mandatory: [link](https://github.com/firebase/firebase-admin-java/blob/master/src/main/java/com/google/firebase/auth/ImportUserRecord.java#L254)

