### PR TITLE
fix(auth): Migrated IAM sign endpoint to iamcredentials.googleapis.com

### DIFF
--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -151,13 +151,13 @@ export class IAMSigner implements CryptoSigner {
     return this.getAccountId().then((serviceAccount) => {
       const request: HttpRequestConfig = {
         method: 'POST',
-        url: `https://iam.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccount}:signBlob`,
-        data: {bytesToSign: buffer.toString('base64')},
+        url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccount}:signBlob`,
+        data: {payload: buffer.toString('base64')},
       };
       return this.httpClient.send(request);
     }).then((response: any) => {
       // Response from IAM is base64 encoded. Decode it into a buffer and return.
-      return Buffer.from(response.data.signature, 'base64');
+      return Buffer.from(response.data.signedBlob, 'base64');
     }).catch((err) => {
       if (err instanceof HttpError) {
         const error = err.response.data;

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -127,13 +127,13 @@ describe('CryptoSigner', () => {
     });
 
     describe('explicit service account ID', () => {
-      const response = {signature: Buffer.from('testsignature').toString('base64')};
+      const response = {signedBlob: Buffer.from('testsignature').toString('base64')};
       const input = Buffer.from('input');
       const signRequest = {
         method: 'POST',
-        url: `https://iam.googleapis.com/v1/projects/-/serviceAccounts/test-service-account:signBlob`,
+        url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-service-account:signBlob`,
         headers: {Authorization: `Bearer ${mockAccessToken}`},
-        data: {bytesToSign: input.toString('base64')},
+        data: {payload: input.toString('base64')},
       };
       let stub: sinon.SinonStub;
 
@@ -147,7 +147,7 @@ describe('CryptoSigner', () => {
         const requestHandler = new AuthorizedHttpClient(mockApp);
         const signer = new IAMSigner(requestHandler, 'test-service-account');
         return signer.sign(input).then((signature) => {
-          expect(signature.toString('base64')).to.equal(response.signature);
+          expect(signature.toString('base64')).to.equal(response.signedBlob);
           expect(stub).to.have.been.calledOnce.and.calledWith(signRequest);
         });
       });
@@ -179,7 +179,7 @@ describe('CryptoSigner', () => {
 
     describe('auto discovered service account', () => {
       const input = Buffer.from('input');
-      const response = {signature: Buffer.from('testsignature').toString('base64')};
+      const response = {signedBlob: Buffer.from('testsignature').toString('base64')};
       const metadataRequest = {
         method: 'GET',
         url: `http://metadata/computeMetadata/v1/instance/service-accounts/default/email`,
@@ -187,9 +187,9 @@ describe('CryptoSigner', () => {
       };
       const signRequest = {
         method: 'POST',
-        url: `https://iam.googleapis.com/v1/projects/-/serviceAccounts/discovered-service-account:signBlob`,
+        url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/discovered-service-account:signBlob`,
         headers: {Authorization: `Bearer ${mockAccessToken}`},
-        data: {bytesToSign: input.toString('base64')},
+        data: {payload: input.toString('base64')},
       };
       let stub: sinon.SinonStub;
 
@@ -204,7 +204,7 @@ describe('CryptoSigner', () => {
         const requestHandler = new AuthorizedHttpClient(mockApp);
         const signer = new IAMSigner(requestHandler);
         return signer.sign(input).then((signature) => {
-          expect(signature.toString('base64')).to.equal(response.signature);
+          expect(signature.toString('base64')).to.equal(response.signedBlob);
           expect(stub).to.have.been.calledTwice;
           expect(stub.getCall(0).args[0]).to.deep.equal(metadataRequest);
           expect(stub.getCall(1).args[0]).to.deep.equal(signRequest);


### PR DESCRIPTION
The iam.googleapis.com API that we use for signing JWTs is going away and being replaced by a new IAM service accounts API: https://cloud.google.com/iam/docs/migrating-to-credentials-api#blob

This PR migrates our existing code that relies on this endpoint.