### PR TITLE
feat(rc): Add Remote Config Version Management API

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1112,11 +1112,19 @@ declare namespace admin.remoteConfig {
      * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
      * 
-     * @param versionNumber Version number of the Remote Config template to look up.
-     *    If not specified, the latest Remote Config template is returned. Optional.
      * @return A promise that fulfills with a `RemoteConfigTemplate`.
      */
-    getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate>;
+    getTemplate(): Promise<RemoteConfigTemplate>;
+
+    /**
+     * Gets the requested version of the {@link admin.remoteConfig.RemoteConfigTemplate
+     * `RemoteConfigTemplate`} of the project.
+     * 
+     * @param versionNumber Version number of the Remote Config template to look up.
+     * 
+     * @return A promise that fulfills with a `RemoteConfigTemplate`.
+     */
+    getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
 
     /**
      * Validates a {@link admin.remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -994,10 +994,12 @@ declare namespace admin.remoteConfig {
     /**
      * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
-     *
+     * 
+     * @param versionNumber Version number of the Remote Config template to look up.
+     *    If not specified, the latest Remote Config template is returned. Optional.
      * @return A promise that fulfills with a `RemoteConfigTemplate`.
      */
-    getTemplate(): Promise<RemoteConfigTemplate>;
+    getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate>;
 
     /**
      * Validates a {@link admin.remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1026,6 +1026,18 @@ declare namespace admin.remoteConfig {
     publishTemplate(template: RemoteConfigTemplate, options?: { force: boolean }): Promise<RemoteConfigTemplate>;
 
     /**
+    * Rolls back a project's published Remote Config template to the specified version.
+    * A rollback is equivalent to getting a previously published Remote Config
+    * template and re-publishing it using a force update.
+    * 
+    * @param versionNumber The version number of the Remote Config template to rollback to.
+    *    The specified version number must be lower than the current version number, and not have
+    *    been deleted due to staleness.
+    * @return A promise that fulfills with the published `RemoteConfigTemplate`.
+    */
+    rollback(versionNumber: string | number): Promise<RemoteConfigTemplate>;
+
+    /**
      * Creates and returns a new Remote Config template from a JSON string.
      *
      * @param json The JSON string to populate a Remote Config template.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -878,6 +878,11 @@ declare namespace admin.remoteConfig {
      * ETag of the current Remote Config template (readonly).
      */
     readonly etag: string;
+
+    /**
+     * Version information of the current Remote Config template.
+     */
+    version?: Version;
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -983,6 +983,123 @@ declare namespace admin.remoteConfig {
   type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue;
 
   /**
+   * Interface representing a Remote Config template version.
+   * Output only, except for the version description. Contains metadata about a particular
+   * version of the Remote Config template. All fields are set at the time the specified Remote
+   * Config template was published. A version's description field may be specified in
+   * `publishTemplate` calls.
+   */
+  export interface Version {
+    /**
+     * The version number of a Remote Config template.
+     */
+    versionNumber?: string;
+
+    /**
+     * The timestamp of when this version of the Remote Config template was written to the
+     * Remote Config server.
+     */
+    updateTime?: string;
+
+    /**
+     * The source of origin of the template update action.
+     */
+    updateOrigin?: ('REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED' | 'CONSOLE' |
+      'REST_API' | 'ADMIN_SDK_NODE');
+
+    /**
+     * The type of the template update action.
+     */
+    updateType?: ('REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED' |
+      'INCREMENTAL_UPDATE' | 'FORCED_UPDATE' | 'ROLLBACK');
+
+    /**
+     * Aggregation of all metadata fields about the account that performed the update.
+     */
+    updateUser?: RemoteConfigUser;
+
+    /**
+     * The user-provided description of the corresponding Remote Config template.
+     */
+    description?: string;
+
+    /**
+     * Only present if this version is the result of a rollback, and will be the version number of
+     * the Remote Config template that was rolled-back to.
+     */
+    rollbackSource?: string;
+
+    /**
+     * Indicates weather this Remote Config template was published before version history was
+     * supported.
+     */
+    isLegacy?: boolean;
+  }
+
+  /** Interface representing a list of Remote Config template versions. */
+  export interface ListVersionsResult {
+    /**
+     * A list of version metadata objects, sorted in reverse chronological order.
+     */
+    versions: Version[];
+
+    /**
+     * Token to retrieve the next page of results, or empty if there are no more results
+     * in the list.
+     */
+    nextPageToken?: string;
+  }
+
+  /** Interface representing a Remote Config list version options. */
+  export interface ListVersionsOptions {
+    /**
+     * The maximum number of items to return per page.
+     */
+    pageSize?: number;
+
+    /**
+     * The `nextPageToken` value returned from a previous list versions request, if any.
+     */
+    pageToken?: string;
+    
+    /** 
+     * Specify the newest version number to include in the results.
+     * If specified, must be greater than zero. Defaults to the newest version.
+     */
+    endVersionNumber?: string | number;
+
+    /**
+     * Specify the earliest update time to include in the results. Any entries updated before this
+     * time are omitted.
+     */
+    startTime?: Date | string;
+
+    /**
+     * Specify the latest update time to include in the results. Any entries updated on or after
+     * this time are omitted.
+     */
+    endTime?: Date | string;
+  }
+
+  /** Interface representing a Remote Config user.*/
+  export interface RemoteConfigUser {
+    /**
+     * Email address. Output only.
+     */
+    email: string;
+
+    /**
+     * Display name. Output only.
+     */
+    name?: string;
+
+    /**
+     * Image URL. Output only.
+     */
+    imageUrl?: string;
+  }
+
+  /**
    * The Firebase `RemoteConfig` service interface.
    *
    * Do not call this constructor directly. Instead, use
@@ -1036,6 +1153,18 @@ declare namespace admin.remoteConfig {
     * @return A promise that fulfills with the published `RemoteConfigTemplate`.
     */
     rollback(versionNumber: string | number): Promise<RemoteConfigTemplate>;
+
+    /**
+    * Gets a list of Remote Config template versions that have been published, sorted in reverse 
+    * chronological order. Only the last 300 versions are stored.
+    * All versions that correspond to non-active Remote Config templates (i.e., all except the 
+    * template that is being fetched by clients) are also deleted if they are older than 90 days.
+    * 
+    * @param options Optional {@link admin.remoteConfig.ListVersionsOptions `ListVersionsOptions`}
+    *    object for getting a list of tempalte versions.
+    * @return A promise that fulfills with a `ListVersionsResult`.
+    */
+    listVersions(options?: ListVersionsOptions): Promise<ListVersionsResult>;
 
     /**
      * Creates and returns a new Remote Config template from a JSON string.
@@ -1122,7 +1251,7 @@ declare namespace admin.machineLearning {
      *
      * Example: `tfliteModel: { gcsTfliteUri: 'gs://your-bucket/your-model.tflite' }`
      */
-    tfliteModel?: {gcsTfliteUri: string};
+    tfliteModel?: { gcsTfliteUri: string };
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -880,7 +880,7 @@ declare namespace admin.remoteConfig {
     readonly etag: string;
 
     /**
-     * Version information of the current Remote Config template.
+     * Version information for the current Remote Config template.
      */
     version?: Version;
   }
@@ -991,7 +991,7 @@ declare namespace admin.remoteConfig {
    * Interface representing a Remote Config template version.
    * Output only, except for the version description. Contains metadata about a particular
    * version of the Remote Config template. All fields are set at the time the specified Remote
-   * Config template was published. A version's description field may be specified in
+   * Config template is published. A version's description field may be specified in
    * `publishTemplate` calls.
    */
   export interface Version {
@@ -1002,12 +1002,12 @@ declare namespace admin.remoteConfig {
 
     /**
      * The timestamp of when this version of the Remote Config template was written to the
-     * Remote Config server.
+     * Remote Config backend.
      */
     updateTime?: string;
 
     /**
-     * The source of origin of the template update action.
+     * The origin of the template update action.
      */
     updateOrigin?: ('REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED' | 'CONSOLE' |
       'REST_API' | 'ADMIN_SDK_NODE');
@@ -1029,13 +1029,13 @@ declare namespace admin.remoteConfig {
     description?: string;
 
     /**
-     * Only present if this version is the result of a rollback, and will be the version number of
-     * the Remote Config template that was rolled-back to.
+     * The version number of the Remote Config template that has become the current version
+     * due to a rollback. Only present if this version is the result of a rollback.
      */
     rollbackSource?: string;
 
     /**
-     * Indicates weather this Remote Config template was published before version history was
+     * Indicates whether this Remote Config template was published before version history was
      * supported.
      */
     isLegacy?: boolean;
@@ -1055,7 +1055,7 @@ declare namespace admin.remoteConfig {
     nextPageToken?: string;
   }
 
-  /** Interface representing a Remote Config list version options. */
+  /** Interface representing options for Remote Config list versions operation. */
   export interface ListVersionsOptions {
     /**
      * The maximum number of items to return per page.
@@ -1068,19 +1068,19 @@ declare namespace admin.remoteConfig {
     pageToken?: string;
     
     /** 
-     * Specify the newest version number to include in the results.
+     * Specifies the newest version number to include in the results.
      * If specified, must be greater than zero. Defaults to the newest version.
      */
     endVersionNumber?: string | number;
 
     /**
-     * Specify the earliest update time to include in the results. Any entries updated before this
+     * Specifies the earliest update time to include in the results. Any entries updated before this
      * time are omitted.
      */
     startTime?: Date | string;
 
     /**
-     * Specify the latest update time to include in the results. Any entries updated on or after
+     * Specifies the latest update time to include in the results. Any entries updated on or after
      * this time are omitted.
      */
     endTime?: Date | string;
@@ -1116,7 +1116,7 @@ declare namespace admin.remoteConfig {
     /**
      * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
-     * 
+     *
      * @return A promise that fulfills with a `RemoteConfigTemplate`.
      */
     getTemplate(): Promise<RemoteConfigTemplate>;
@@ -1160,9 +1160,11 @@ declare namespace admin.remoteConfig {
     * A rollback is equivalent to getting a previously published Remote Config
     * template and re-publishing it using a force update.
     * 
-    * @param versionNumber The version number of the Remote Config template to rollback to.
+    * @param versionNumber The version number of the Remote Config template to roll back to.
     *    The specified version number must be lower than the current version number, and not have
-    *    been deleted due to staleness.
+    *    been deleted due to staleness. Only the last 300 versions are stored.
+    *    All versions that correspond to non-active Remote Config templates (that is, all except the
+    *    template that is being fetched by clients) are also deleted if they are more than 90 days old.
     * @return A promise that fulfills with the published `RemoteConfigTemplate`.
     */
     rollback(versionNumber: string | number): Promise<RemoteConfigTemplate>;
@@ -1170,11 +1172,11 @@ declare namespace admin.remoteConfig {
     /**
     * Gets a list of Remote Config template versions that have been published, sorted in reverse 
     * chronological order. Only the last 300 versions are stored.
-    * All versions that correspond to non-active Remote Config templates (i.e., all except the 
-    * template that is being fetched by clients) are also deleted if they are older than 90 days.
+    * All versions that correspond to non-active Remote Config templates (that is, all except the 
+    * template that is being fetched by clients) are also deleted if they are more than 90 days old.
     * 
     * @param options Optional {@link admin.remoteConfig.ListVersionsOptions `ListVersionsOptions`}
-    *    object for getting a list of tempalte versions.
+    *    object for getting a list of template versions.
     * @return A promise that fulfills with a `ListVersionsResult`.
     */
     listVersions(options?: ListVersionsOptions): Promise<ListVersionsResult>;

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -143,18 +143,33 @@ export class RemoteConfigApiClient {
     this.httpClient = new AuthorizedHttpClient(app);
   }
 
-  public getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate> {
-    const requestData: { [k: string]: any } = {};
-    if (typeof versionNumber !== 'undefined') {
-      requestData['versionNumber'] = this.validateVersionNumber(versionNumber);
-    }
+  public getTemplate(): Promise<RemoteConfigTemplate> {
+    return this.getUrl()
+      .then((url) => {
+        const request: HttpRequestConfig = {
+          method: 'GET',
+          url: `${url}/remoteConfig`,
+          headers: FIREBASE_REMOTE_CONFIG_HEADERS
+        };
+        return this.httpClient.send(request);
+      })
+      .then((resp) => {
+        return this.toRemoteConfigTemplate(resp);
+      })
+      .catch((err) => {
+        throw this.toFirebaseError(err);
+      });
+  }
+
+  public getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate> {
+    const data = { versionNumber: this.validateVersionNumber(versionNumber) };
     return this.getUrl()
       .then((url) => {
         const request: HttpRequestConfig = {
           method: 'GET',
           url: `${url}/remoteConfig`,
           headers: FIREBASE_REMOTE_CONFIG_HEADERS,
-          data: requestData
+          data
         };
         return this.httpClient.send(request);
       })

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -24,6 +24,10 @@ import {
   RemoteConfigParameter,
   RemoteConfigCondition,
   RemoteConfigParameterGroup,
+  ListVersionsOptions,
+  ListVersionsResult,
+  RemoteConfigUser,
+  Version,
 } from './remote-config-api-client';
 
 /**
@@ -113,6 +117,25 @@ export class RemoteConfig implements FirebaseServiceInterface {
     return this.client.rollback(versionNumber)
       .then((templateResponse) => {
         return new RemoteConfigTemplateImpl(templateResponse);
+      });
+  }
+
+  /**
+  * Gets a list of Remote Config template versions that have been published, sorted in reverse 
+  * chronological order. Only the last 300 versions are stored.
+  * All versions that correspond to non-active Remote Config templates (i.e., all except the 
+  * template that is being fetched by clients) are also deleted if they are older than 90 days.
+  * 
+  * @param {ListVersionsOptions} options Optional options object for getting a list of versions.
+  * @return A promise that fulfills with a `ListVersionsResult`.
+  */
+  public listVersions(options?: ListVersionsOptions): Promise<ListVersionsResult> {
+    return this.client.listVersions(options)
+      .then((listVersionsResponse) => {
+        return {
+          versions: listVersionsResponse.versions.map(version => new VersionImpl(version)),
+          nextPageToken: listVersionsResponse.nextPageToken,
+        }
       });
   }
 
@@ -216,6 +239,124 @@ class RemoteConfigTemplateImpl implements RemoteConfigTemplate {
       parameters: this.parameters,
       parameterGroups: this.parameterGroups,
       etag: this.etag,
+    }
+  }
+}
+
+/**
+* Remote Config Version internal implementation.
+*/
+class VersionImpl implements Version {
+  public readonly versionNumber?: string; // int64 format
+  public readonly updateTime?: string; // in UTC
+  public readonly updateOrigin?: ('REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED' | 'CONSOLE' |
+    'REST_API' | 'ADMIN_SDK_NODE');
+  public readonly updateType?: ('REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED' |
+    'INCREMENTAL_UPDATE' | 'FORCED_UPDATE' | 'ROLLBACK');
+  public readonly updateUser?: RemoteConfigUser;
+  public readonly description?: string;
+  public readonly rollbackSource?: string;
+  public readonly isLegacy?: boolean;
+
+  constructor(version: Version) {
+    if (!validator.isNonNullObject(version)) {
+      throw new FirebaseRemoteConfigError(
+        'invalid-argument',
+        `Invalid Remote Config version instance: ${JSON.stringify(version)}`);
+    }
+
+    if (typeof version.versionNumber !== 'undefined') {
+      if (!validator.isNonEmptyString(version.versionNumber) &&
+        !validator.isNumber(version.versionNumber)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version number must be a non-empty string in int64 format or a number');
+      }
+      if (!Number.isInteger(Number(version.versionNumber))) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version number must be an integer or a string in int64 format');
+      }
+      this.versionNumber = version.versionNumber;
+    }
+
+    if (typeof version.updateOrigin !== 'undefined') {
+      if (!validator.isNonEmptyString(version.updateOrigin)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version update origin must be a non-empty string');
+      }
+      this.updateOrigin = version.updateOrigin;
+    }
+
+    if (typeof version.updateType !== 'undefined') {
+      if (!validator.isNonEmptyString(version.updateType)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version update type must be a non-empty string');
+      }
+      this.updateType = version.updateType;
+    }
+
+    if (typeof version.updateUser !== 'undefined') {
+      if (!validator.isNonNullObject(version.updateUser)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version update user must be a non-null object');
+      }
+      this.updateUser = version.updateUser;
+    }
+
+    if (typeof version.description !== 'undefined') {
+      if (!validator.isNonEmptyString(version.description)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version description must be a non-empty string');
+      }
+      this.description = version.description;
+    }
+
+    if (typeof version.rollbackSource !== 'undefined') {
+      if (!validator.isNonEmptyString(version.rollbackSource)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version rollback source must be a non-empty string');
+      }
+      this.rollbackSource = version.rollbackSource;
+    }
+
+    if (typeof version.isLegacy !== 'undefined') {
+      if (!validator.isBoolean(version.isLegacy)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version.isLegacy must be a boolean');
+      }
+      this.isLegacy = version.isLegacy;
+    }
+
+    if (typeof version.updateTime !== 'undefined') {
+      if (!validator.isISODateString(version.updateTime)) {
+        throw new FirebaseRemoteConfigError(
+          'invalid-argument',
+          'Version update time must be a valid ISO date string');
+      }
+      this.updateTime = new Date(version.updateTime).toUTCString(); // in UTC
+    }
+  }
+
+  /**
+   * @return {Version} A JSON-serializable representation of this object.
+   */
+  public toJSON(): Version {
+    return {
+      versionNumber: this.versionNumber,
+      updateOrigin: this.updateOrigin,
+      updateType: this.updateType,
+      updateUser: this.updateUser,
+      description: this.description,
+      rollbackSource: this.rollbackSource,
+      isLegacy: this.isLegacy,
+      updateTime: this.updateTime,
     }
   }
 }

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -60,10 +60,12 @@ export class RemoteConfig implements FirebaseServiceInterface {
   /**
   * Gets the current active version of the Remote Config template of the project.
   *
+  * @param {number | string} versionNumber Version number of the Remote Config template to look up.
+  *    If not specified, the latest Remote Config template will be returned. Optional.
   * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
   */
-  public getTemplate(): Promise<RemoteConfigTemplate> {
-    return this.client.getTemplate()
+  public getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate> {
+    return this.client.getTemplate(versionNumber)
       .then((templateResponse) => {
         return new RemoteConfigTemplateImpl(templateResponse);
       });

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -101,6 +101,22 @@ export class RemoteConfig implements FirebaseServiceInterface {
   }
 
   /**
+   * Rollbacks a project's published Remote Config template to the specified version.
+   * A rollback is equivalent to getting a previously published Remote Config
+   * template, and re-publishing it using a force update.
+   *
+   * @param {number | string} versionNumber The version number of the Remote Config template
+   *    to rollback to.
+   * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills with the published template.
+   */
+  public rollback(versionNumber: number | string): Promise<RemoteConfigTemplate> {
+    return this.client.rollback(versionNumber)
+      .then((templateResponse) => {
+        return new RemoteConfigTemplateImpl(templateResponse);
+      });
+  }
+
+  /**
    * Creates and returns a new Remote Config template from a JSON string.
    *
    * @param {string} json The JSON string to populate a Remote Config template.

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -64,12 +64,24 @@ export class RemoteConfig implements FirebaseServiceInterface {
   /**
   * Gets the current active version of the Remote Config template of the project.
   *
-  * @param {number | string} versionNumber Version number of the Remote Config template to look up.
-  *    If not specified, the latest Remote Config template will be returned. Optional.
   * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
   */
-  public getTemplate(versionNumber?: number | string): Promise<RemoteConfigTemplate> {
-    return this.client.getTemplate(versionNumber)
+  public getTemplate(): Promise<RemoteConfigTemplate> {
+    return this.client.getTemplate()
+      .then((templateResponse) => {
+        return new RemoteConfigTemplateImpl(templateResponse);
+      });
+  }
+
+  /**
+  * Gets the requested version of the Remote Config template of the project.
+  *
+  * @param {number | string} versionNumber Version number of the Remote Config template to look up.
+  * 
+  * @return {Promise<RemoteConfigTemplate>} A Promise that fulfills when the template is available.
+  */
+  public getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate> {
+    return this.client.getTemplateAtVersion(versionNumber)
       .then((templateResponse) => {
         return new RemoteConfigTemplateImpl(templateResponse);
       });

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -135,7 +135,14 @@ describe('RemoteConfigApiClient', () => {
         .should.eventually.be.rejectedWith(noProjectId);
     });
 
-    it('should resolve with the requested template on success', () => {
+    ['', 'abc', 'a123b', 'a123', '123a', 1.2, '70.2', null, NaN, true, [], {}].forEach((invalidVersion) => {
+      it(`should reject if the versionNumber is: ${invalidVersion}`, () => {
+        expect(() => apiClient.getTemplate(invalidVersion as any))
+          .to.throw(/^versionNumber must be (a non-empty string in int64 format or a number|an integer or a string in int64 format)$/);
+      });
+    });
+
+    it('should resolve with the latest template on success', () => {
       const stub = sinon
         .stub(HttpClient.prototype, 'send')
         .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-1' }));
@@ -150,6 +157,27 @@ describe('RemoteConfigApiClient', () => {
             method: 'GET',
             url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',
             headers: EXPECTED_HEADERS,
+            data: {},
+          });
+        });
+    });
+
+    it('should resolve with the requested template version on success', () => {
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-60' }));
+      stubs.push(stub);
+      return apiClient.getTemplate('60')
+        .then((resp) => {
+          expect(resp.conditions).to.deep.equal(TEST_RESPONSE.conditions);
+          expect(resp.parameters).to.deep.equal(TEST_RESPONSE.parameters);
+          expect(resp.parameterGroups).to.deep.equal(TEST_RESPONSE.parameterGroups);
+          expect(resp.etag).to.equal('etag-123456789012-60');
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'GET',
+            url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',
+            headers: EXPECTED_HEADERS,
+            data: { versionNumber: '60' },
           });
         });
     });

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -165,9 +165,6 @@ describe('RemoteConfigApiClient', () => {
         .should.eventually.be.rejectedWith(noProjectId);
     });
 
-    // test for version number validations
-    runTemplateVersionNumberTests((v: string | number) => { apiClient.getTemplate(v); });
-
     // tests for api response validations
     runEtagHeaderTests(() => apiClient.getTemplate());
     runErrorResponseTests(() => apiClient.getTemplate());
@@ -187,17 +184,30 @@ describe('RemoteConfigApiClient', () => {
             method: 'GET',
             url: 'https://firebaseremoteconfig.googleapis.com/v1/projects/test-project/remoteConfig',
             headers: EXPECTED_HEADERS,
-            data: {},
           });
         });
     });
+  });
+
+  describe('getTemplateAtVersion', () => {
+    it(`should reject when project id is not available`, () => {
+      return clientWithoutProjectId.getTemplateAtVersion(65)
+        .should.eventually.be.rejectedWith(noProjectId);
+    });
+
+    // test for version number validations
+    runTemplateVersionNumberTests((v: string | number) => { apiClient.getTemplateAtVersion(v); });
+
+    // tests for api response validations
+    runEtagHeaderTests(() => apiClient.getTemplateAtVersion(65));
+    runErrorResponseTests(() => apiClient.getTemplateAtVersion(65));
 
     it('should convert version number to string', () => {
       const stub = sinon
         .stub(HttpClient.prototype, 'send')
         .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-60' }));
       stubs.push(stub);
-      return apiClient.getTemplate(60)
+      return apiClient.getTemplateAtVersion(60)
         .then(() => {
           expect(stub).to.have.been.calledOnce.and.calledWith({
             method: 'GET',
@@ -213,7 +223,7 @@ describe('RemoteConfigApiClient', () => {
         .stub(HttpClient.prototype, 'send')
         .resolves(utils.responseFrom(TEST_RESPONSE, 200, { etag: 'etag-123456789012-60' }));
       stubs.push(stub);
-      return apiClient.getTemplate('60')
+      return apiClient.getTemplateAtVersion('60')
         .then((resp) => {
           expect(resp.conditions).to.deep.equal(TEST_RESPONSE.conditions);
           expect(resp.parameters).to.deep.equal(TEST_RESPONSE.parameters);

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -27,6 +27,7 @@ import {
   RemoteConfigTemplate,
   RemoteConfigCondition,
   TagColor,
+  ListVersionsResult,
 } from '../../../src/remote-config/remote-config-api-client';
 import { FirebaseRemoteConfigError } from '../../../src/remote-config/remote-config-utils';
 import { deepCopy } from '../../../src/utils/deep-copy';
@@ -97,6 +98,34 @@ describe('RemoteConfig', () => {
     parameterGroups: PARAMETER_GROUPS,
     etag: 'etag-123456789012-6',
   };
+
+  const REMOTE_CONFIG_LIST_VERSIONS_RESULT: ListVersionsResult = {
+    versions: [
+      {
+        versionNumber: '78',
+        updateTime: '2020-05-07T18:46:09.495Z',
+        updateUser: {
+          email: 'user@gmail.com',
+          imageUrl: 'https://photo.jpg'
+        },
+        description: 'Rollback to version 76',
+        updateOrigin: 'REST_API',
+        updateType: 'ROLLBACK',
+        rollbackSource: '76'
+      },
+      {
+        versionNumber: '77',
+        updateTime: '2020-05-07T18:44:41.555Z',
+        updateUser: {
+          email: 'user@gmail.com',
+          imageUrl: 'https://photo.jpg'
+        },
+        updateOrigin: 'REST_API',
+        updateType: 'INCREMENTAL_UPDATE',
+      },
+    ],
+    nextPageToken: '76'
+  }
 
   let remoteConfig: RemoteConfig;
 
@@ -191,6 +220,143 @@ describe('RemoteConfig', () => {
   describe('rollback', () => {
     runInvalidResponseTests(() => remoteConfig.rollback('5'), 'rollback');
     runValidResponseTests(() => remoteConfig.rollback('5'), 'rollback');
+  });
+
+  describe('listVersions', () => {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'listVersions')
+        .rejects(INTERNAL_ERROR);
+      stubs.push(stub);
+      return remoteConfig.listVersions()
+        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
+    });
+
+    ['', 'abc', 'a123b', 'a123', '123a', 1.2, '70.2', null, NaN, true, [], {}].forEach((invalidVersion) => {
+      it(`should reject if the versionNumber is: ${invalidVersion}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].versionNumber = invalidVersion as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.to.match(/^Error: Version number must be (a non-empty string in int64 format or a number|an integer or a string in int64 format)$/);
+      });
+    });
+
+    ['', 123, 1.2, null, NaN, true, [], {}].forEach((invalidUpdateOrigin) => {
+      it(`should reject if the updateOrigin is: ${invalidUpdateOrigin}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].updateOrigin = invalidUpdateOrigin as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version update origin must be a non-empty string');
+      });
+    });
+
+    ['', 123, 1.2, null, NaN, true, [], {}].forEach((invalidUpdateType) => {
+      it(`should reject if the updateType is: ${invalidUpdateType}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].updateType = invalidUpdateType as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version update type must be a non-empty string');
+      });
+    });
+
+    ['', 'abc', 1.2, 123, null, NaN, true, []].forEach((invalidUpdateUser) => {
+      it(`should reject if the updateUser is: ${invalidUpdateUser}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].updateUser = invalidUpdateUser as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version update user must be a non-null object');
+      });
+    });
+
+    ['', 123, 1.2, null, NaN, true, [], {}].forEach((invalidDescription) => {
+      it(`should reject if the description is: ${invalidDescription}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].description = invalidDescription as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version description must be a non-empty string');
+      });
+    });
+
+    ['', 123, 1.2, null, NaN, true, [], {}].forEach((invalidRollbackSource) => {
+      it(`should reject if the rollbackSource is: ${invalidRollbackSource}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].rollbackSource = invalidRollbackSource as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version rollback source must be a non-empty string');
+      });
+    });
+
+    ['', 'abc', 123, 1.2, null, NaN, [], {}].forEach((invalidIsLegacy) => {
+      it(`should reject if the isLegacy is: ${invalidIsLegacy}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].isLegacy = invalidIsLegacy as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version.isLegacy must be a boolean');
+      });
+    });
+
+    ['', 'abc', 123, 1.2, null, NaN, [], {}].forEach((invalidUpdateTime) => {
+      it(`should reject if the updateTime is: ${invalidUpdateTime}`, () => {
+        const response = deepCopy(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+        response.versions[0].updateTime = invalidUpdateTime as any;
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, 'listVersions')
+          .resolves(response);
+        stubs.push(stub);
+        return remoteConfig.listVersions()
+          .should.eventually.be.rejected.and.have.property('message',
+            'Version update time must be a valid ISO date string');
+      });
+    });
+
+    it('should resolve with template versions list on success', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, 'listVersions')
+        .resolves(REMOTE_CONFIG_LIST_VERSIONS_RESULT);
+      stubs.push(stub);
+      return remoteConfig.listVersions({
+        pageSize: 2
+      })
+        .then((response) => {
+          expect(response.versions.length).to.equal(2);
+          expect(response.versions[0].updateTime).equals('Thu, 07 May 2020 18:46:09 GMT');
+          expect(response.versions[1].updateTime).equals('Thu, 07 May 2020 18:44:41 GMT');
+        });
+    });
   });
 
   const INVALID_PARAMETERS: any[] = [null, '', 'abc', 1, true, []];

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -203,6 +203,11 @@ describe('RemoteConfig', () => {
     runValidResponseTests(() => remoteConfig.getTemplate(), 'getTemplate');
   });
 
+  describe('getTemplateAtVersion', () => {
+    runInvalidResponseTests(() => remoteConfig.getTemplateAtVersion(65), 'getTemplateAtVersion');
+    runValidResponseTests(() => remoteConfig.getTemplateAtVersion(65), 'getTemplateAtVersion');
+  });
+
   describe('validateTemplate', () => {
     runInvalidResponseTests(() => remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE),
       'validateTemplate');

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -170,470 +170,27 @@ describe('RemoteConfig', () => {
   });
 
   describe('getTemplate', () => {
-    it('should propagate API errors', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .rejects(INTERNAL_ERROR);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
-    });
+    runInvalidResponseTests(() => remoteConfig.getTemplate(), 'getTemplate');
+    runValidResponseTests(() => remoteConfig.getTemplate(), 'getTemplate');
+  });
 
-    it('should reject when API response is invalid', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(null);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template: null');
-    });
+  describe('validateTemplate', () => {
+    runInvalidResponseTests(() => remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE),
+      'validateTemplate');
+    runValidResponseTests(() => remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE),
+      'validateTemplate');
+  });
 
-    it('should reject when API response does not contain an ETag', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.etag = '';
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
-    });
-
-    it('should reject when API response does not contain valid parameters', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameters = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameters must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid parameter groups', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameterGroups = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameter groups must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid conditions', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.conditions = Object();
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config conditions must be an array`);
-    });
-
-    it('should resolve with parameters:{} when no parameters present in the response', () => {
-      const response = deepCopy({ conditions: [], parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          // if parameters are not present in the response, we set it to an empty object.
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with parameterGroups:{} when no parameter groups present in the response', () => {
-      const response = deepCopy({ conditions: [], parameters: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          // if parameter groups are not present in the response, we set it to an empty object.
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with conditions:[] when no conditions present in the response', () => {
-      const response = deepCopy({ parameters: {}, parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.getTemplate()
-        .then((template) => {
-          // if conditions are not present in the response, we set it to an empty array.
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with Remote Config template on success', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'getTemplate')
-        .resolves(REMOTE_CONFIG_RESPONSE);
-      stubs.push(stub);
-
-      return remoteConfig.getTemplate()
-        .then((template) => {
-          expect(template.conditions.length).to.equal(1);
-          expect(template.conditions[0].name).to.equal('ios');
-          expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal(TagColor.BLUE);
-          expect(template.etag).to.equal('etag-123456789012-5');
-          // verify that etag is read-only
-          expect(() => {
-            (template as any).etag = "new-etag";
-          }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
-
-          const key = 'holiday_promo_enabled';
-          const p1 = template.parameters[key];
-          expect(p1.defaultValue).deep.equals({ value: 'true' });
-          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
-          expect(p1.description).equals('this is a promo');
-
-          expect(template.parameterGroups).deep.equals(PARAMETER_GROUPS);
-
-          const c = template.conditions.find((c) => c.name === 'ios');
-          expect(c).to.be.not.undefined;
-          const cond = c as RemoteConfigCondition;
-          expect(cond.name).to.equal('ios');
-          expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal(TagColor.BLUE);
-
-          const parsed = JSON.parse(JSON.stringify(template));
-          expect(parsed).deep.equals(REMOTE_CONFIG_RESPONSE);
-        });
-    });
+  describe('publishTemplate', () => {
+    runInvalidResponseTests(() => remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE),
+      'publishTemplate');
+    runValidResponseTests(() => remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE),
+      'publishTemplate');
   });
 
   const INVALID_PARAMETERS: any[] = [null, '', 'abc', 1, true, []];
   const INVALID_PARAMETER_GROUPS: any[] = [null, '', 'abc', 1, true, []];
   const INVALID_CONDITIONS: any[] = [null, '', 'abc', 1, true, {}];
-  const INVALID_ETAG_TEMPLATES: any[] = [
-    { parameters: {}, parameterGroups: {}, conditions: [], etag: '' },
-    Object()
-  ];
-  const INVALID_TEMPLATES: any[] = [null, 'abc', 123];
-
-  describe('validateTemplate', () => {
-    it('should propagate API errors', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .rejects(INTERNAL_ERROR);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
-    });
-
-    it('should reject when API response is invalid', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(null);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template: null');
-    });
-
-    it('should reject when API response does not contain an ETag', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.etag = '';
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
-    });
-
-    it('should reject when API response does not contain valid parameters', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameters = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameters must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid parameter groups', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameterGroups = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameter groups must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid conditions', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.conditions = Object();
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config conditions must be an array`);
-    });
-
-    it('should resolve with parameter:{} when no parameters present in the response', () => {
-      const response = deepCopy({ conditions: [], parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          // if parameters are not present in the response, we set it to an empty object.
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with parameterGroups:{} when no parameter groups present in the response', () => {
-      const response = deepCopy({ conditions: [], parameters: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          // if parameterGroups are not present in the response, we set it to an empty object.
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with conditions:[] when no conditions present in the response', () => {
-      const response = deepCopy({ parameters: {}, parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          // if conditions are not present in the response, we set it to an empty array.
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    // validate input template
-    testInvalidInputTemplates((t: RemoteConfigTemplate) => { remoteConfig.validateTemplate(t); });
-
-    it('should resolve with Remote Config template on success', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'validateTemplate')
-        .resolves(REMOTE_CONFIG_TEMPLATE);
-      stubs.push(stub);
-
-      return remoteConfig.validateTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions.length).to.equal(1);
-          expect(template.conditions[0].name).to.equal('ios');
-          expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal(TagColor.PINK);
-          // verify that the etag is unchanged
-          expect(template.etag).to.equal('etag-123456789012-6');
-          // verify that the etag is read-only
-          expect(() => {
-            (template as any).etag = "new-etag";
-          }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
-
-          const key = 'holiday_promo_enabled';
-          const p1 = template.parameters[key];
-          expect(p1.defaultValue).deep.equals({ value: 'true' });
-          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
-          expect(p1.description).equals('this is a promo');
-
-          expect(template.parameterGroups).deep.equals(PARAMETER_GROUPS);
-
-          const c = template.conditions.find((c) => c.name === 'ios');
-          expect(c).to.be.not.undefined;
-          const cond = c as RemoteConfigCondition;
-          expect(cond.name).to.equal('ios');
-          expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal(TagColor.PINK);
-        });
-    });
-  });
-
-  describe('publishTemplate', () => {
-    it('should propagate API errors', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .rejects(INTERNAL_ERROR);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
-    });
-
-    it('should reject when API response is invalid', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(null);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Invalid Remote Config template: null');
-    });
-
-    it('should reject when API response does not contain an ETag', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.etag = '';
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
-    });
-
-    it('should reject when API response does not contain valid parameters', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameters = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameters must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid parameter groups', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.parameterGroups = null;
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameter groups must be a non-null object`);
-    });
-
-    it('should reject when API response does not contain valid conditions', () => {
-      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
-      response.conditions = Object();
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config conditions must be an array`);
-    });
-
-    it('should resolve with parameters:{} when no parameters present in the response', () => {
-      const response = deepCopy({ conditions: [], parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          // if parameters are not present in the response, we set it to an empty object.
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with parameterGroups:{} when no parameter groups present in the response', () => {
-      const response = deepCopy({ conditions: [], parameters: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          // if parameterGroups are not present in the response, we set it to an empty object.
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    it('should resolve with conditions:[] when no conditions present in the response', () => {
-      const response = deepCopy({ parameters: {}, parameterGroups: {}, etag: '0-1010-2' });
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(response);
-      stubs.push(stub);
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          // if conditions are not present in the response, we set it to an empty array.
-          expect(template.conditions).deep.equals([]);
-          expect(template.parameters).deep.equals({});
-          expect(template.parameterGroups).deep.equals({});
-        });
-    });
-
-    // validate input template
-    testInvalidInputTemplates((t: RemoteConfigTemplate) => { remoteConfig.publishTemplate(t); });
-
-    it('should resolve with Remote Config template on success', () => {
-      const stub = sinon
-        .stub(RemoteConfigApiClient.prototype, 'publishTemplate')
-        .resolves(REMOTE_CONFIG_RESPONSE);
-      stubs.push(stub);
-
-      return remoteConfig.publishTemplate(REMOTE_CONFIG_TEMPLATE)
-        .then((template) => {
-          expect(template.conditions.length).to.equal(1);
-          expect(template.conditions[0].name).to.equal('ios');
-          expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
-          expect(template.conditions[0].tagColor).to.equal(TagColor.BLUE);
-          expect(template.etag).to.equal('etag-123456789012-5');
-          // verify that the etag is read-only
-          expect(() => {
-            (template as any).etag = "new-etag";
-          }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
-
-          const key = 'holiday_promo_enabled';
-          const p1 = template.parameters[key];
-          expect(p1.defaultValue).deep.equals({ value: 'true' });
-          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
-          expect(p1.description).equals('this is a promo');
-
-          expect(template.parameterGroups).deep.equals(PARAMETER_GROUPS);
-
-          const c = template.conditions.find((c) => c.name === 'ios');
-          expect(c).to.be.not.undefined;
-          const cond = c as RemoteConfigCondition;
-          expect(cond.name).to.equal('ios');
-          expect(cond.expression).to.equal('device.os == \'ios\'');
-          expect(cond.tagColor).to.equal(TagColor.BLUE);
-        });
-    });
-  });
 
   describe('createTemplateFromJSON', () => {
     const INVALID_STRINGS: any[] = [null, undefined, '', 1, true, {}, []];
@@ -653,9 +210,8 @@ describe('RemoteConfig', () => {
       });
     });
 
-    const invalidEtags = [...INVALID_STRINGS];
     let sourceTemplate = deepCopy(REMOTE_CONFIG_RESPONSE);
-    invalidEtags.forEach((invalidEtag) => {
+    INVALID_STRINGS.forEach((invalidEtag) => {
       sourceTemplate.etag = invalidEtag;
       const jsonString = JSON.stringify(sourceTemplate);
       it(`should throw if the ETag is ${JSON.stringify(invalidEtag)}`, () => {
@@ -678,10 +234,11 @@ describe('RemoteConfig', () => {
     INVALID_PARAMETER_GROUPS.forEach((invalidParameterGroup) => {
       sourceTemplate.parameterGroups = invalidParameterGroup;
       const jsonString = JSON.stringify(sourceTemplate);
-      it(`should throw if the parameter groups are ${JSON.stringify(invalidParameterGroup)}`, () => {
-        expect(() => remoteConfig.createTemplateFromJSON(jsonString))
-          .to.throw('Remote Config parameter groups must be a non-null object');
-      });
+      it(`should throw if the parameter groups are ${JSON.stringify(invalidParameterGroup)}`,
+        () => {
+          expect(() => remoteConfig.createTemplateFromJSON(jsonString))
+            .to.throw('Remote Config parameter groups must be a non-null object');
+        });
     });
 
     sourceTemplate = deepCopy(REMOTE_CONFIG_RESPONSE);
@@ -706,7 +263,8 @@ describe('RemoteConfig', () => {
       // verify that the etag is read-only
       expect(() => {
         (newTemplate as any).etag = "new-etag";
-      }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
+      }).to.throw(
+        'Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
 
       const key = 'holiday_promo_enabled';
       const p1 = newTemplate.parameters[key];
@@ -725,49 +283,161 @@ describe('RemoteConfig', () => {
     });
   });
 
-  function testInvalidInputTemplates(rcOperation: Function): void {
-    const inputTemplate = deepCopy(REMOTE_CONFIG_TEMPLATE);
-    INVALID_PARAMETERS.forEach((invalidParameter) => {
-      it(`should throw if the parameters is ${JSON.stringify(invalidParameter)}`, () => {
-        (inputTemplate as any).parameters = invalidParameter;
-        inputTemplate.conditions = [];
-        expect(() => rcOperation(inputTemplate))
-          .to.throw('Remote Config parameters must be a non-null object');
-      });
+  function runInvalidResponseTests(rcOperation: () => Promise<RemoteConfigTemplate>,
+    operationName: any): void {
+    it('should propagate API errors', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .rejects(INTERNAL_ERROR);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.deep.equal(INTERNAL_ERROR);
     });
 
-    INVALID_PARAMETER_GROUPS.forEach((invalidParameterGroup) => {
-      it(`should throw if the parameter groups is ${JSON.stringify(invalidParameterGroup)}`, () => {
-        (inputTemplate as any).parameterGroups = invalidParameterGroup;
-        inputTemplate.conditions = [];
-        inputTemplate.parameters = {};
-        expect(() => rcOperation(inputTemplate))
-          .to.throw('Remote Config parameter groups must be a non-null object');
-      });
+    it('should reject when API response is invalid', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(null);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.have.property(
+          'message', 'Invalid Remote Config template: null');
     });
 
-    INVALID_CONDITIONS.forEach((invalidConditions) => {
-      it(`should throw if the conditions is ${JSON.stringify(invalidConditions)}`, () => {
-        (inputTemplate as any).conditions = invalidConditions;
-        inputTemplate.parameters = {};
-        inputTemplate.parameterGroups = {};
-        expect(() => rcOperation(inputTemplate))
-          .to.throw('Remote Config conditions must be an array');
-      });
+    it('should reject when API response does not contain an ETag', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.etag = '';
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Invalid Remote Config template: ${JSON.stringify(response)}`);
     });
 
-    INVALID_ETAG_TEMPLATES.forEach((invalidEtagTemplate) => {
-      it(`should throw if the template is ${JSON.stringify(invalidEtagTemplate)}`, () => {
-        expect(() => rcOperation(invalidEtagTemplate))
-          .to.throw('ETag must be a non-empty string.');
-      });
+    it('should reject when API response does not contain valid parameters', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.parameters = null;
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Remote Config parameters must be a non-null object`);
     });
 
-    INVALID_TEMPLATES.forEach((invalidTemplate) => {
-      it(`should throw if the template is ${JSON.stringify(invalidTemplate)}`, () => {
-        expect(() => rcOperation(invalidTemplate))
-          .to.throw(`Invalid Remote Config template: ${JSON.stringify(invalidTemplate)}`);
+    it('should reject when API response does not contain valid parameter groups', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.parameterGroups = null;
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Remote Config parameter groups must be a non-null object`);
+    });
+
+    it('should reject when API response does not contain valid conditions', () => {
+      const response = deepCopy(REMOTE_CONFIG_RESPONSE);
+      response.conditions = Object();
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .should.eventually.be.rejected.and.have.property(
+          'message', `Remote Config conditions must be an array`);
+    });
+  }
+
+  function runValidResponseTests(rcOperation: () => Promise<RemoteConfigTemplate>,
+    operationName: any): void {
+    it('should resolve with parameters:{} when no parameters present in the response', () => {
+      const response = deepCopy({ conditions: [], parameterGroups: {}, etag: '0-1010-2' });
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .then((template) => {
+          expect(template.conditions).deep.equals([]);
+          // if parameters are not present in the response, we set it to an empty object.
+          expect(template.parameters).deep.equals({});
+          expect(template.parameterGroups).deep.equals({});
+        });
+    });
+
+    it('should resolve with parameterGroups:{} when no parameter groups present in the response',
+      () => {
+        const response = deepCopy({ conditions: [], parameters: {}, etag: '0-1010-2' });
+        const stub = sinon
+          .stub(RemoteConfigApiClient.prototype, operationName)
+          .resolves(response);
+        stubs.push(stub);
+        return rcOperation()
+          .then((template) => {
+            expect(template.conditions).deep.equals([]);
+            expect(template.parameters).deep.equals({});
+            // if parameter groups are not present in the response, we set it to an empty object.
+            expect(template.parameterGroups).deep.equals({});
+          });
       });
+
+    it('should resolve with conditions:[] when no conditions present in the response', () => {
+      const response = deepCopy({ parameters: {}, parameterGroups: {}, etag: '0-1010-2' });
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(response);
+      stubs.push(stub);
+      return rcOperation()
+        .then((template) => {
+          // if conditions are not present in the response, we set it to an empty array.
+          expect(template.conditions).deep.equals([]);
+          expect(template.parameters).deep.equals({});
+          expect(template.parameterGroups).deep.equals({});
+        });
+    });
+
+    it('should resolve with Remote Config template on success', () => {
+      const stub = sinon
+        .stub(RemoteConfigApiClient.prototype, operationName)
+        .resolves(REMOTE_CONFIG_RESPONSE);
+      stubs.push(stub);
+
+      return rcOperation()
+        .then((template) => {
+          expect(template.conditions.length).to.equal(1);
+          expect(template.conditions[0].name).to.equal('ios');
+          expect(template.conditions[0].expression).to.equal('device.os == \'ios\'');
+          expect(template.conditions[0].tagColor).to.equal(TagColor.BLUE);
+          expect(template.etag).to.equal('etag-123456789012-5');
+          // verify that etag is read-only
+          expect(() => {
+            (template as any).etag = "new-etag";
+          }).to.throw(
+            'Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
+
+          const key = 'holiday_promo_enabled';
+          const p1 = template.parameters[key];
+          expect(p1.defaultValue).deep.equals({ value: 'true' });
+          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
+          expect(p1.description).equals('this is a promo');
+
+          expect(template.parameterGroups).deep.equals(PARAMETER_GROUPS);
+
+          const c = template.conditions.find((c) => c.name === 'ios');
+          expect(c).to.be.not.undefined;
+          const cond = c as RemoteConfigCondition;
+          expect(cond.name).to.equal('ios');
+          expect(cond.expression).to.equal('device.os == \'ios\'');
+          expect(cond.tagColor).to.equal(TagColor.BLUE);
+
+          const parsed = JSON.parse(JSON.stringify(template));
+          expect(parsed).deep.equals(REMOTE_CONFIG_RESPONSE);
+        });
     });
   }
 });

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -188,6 +188,11 @@ describe('RemoteConfig', () => {
       'publishTemplate');
   });
 
+  describe('rollback', () => {
+    runInvalidResponseTests(() => remoteConfig.rollback('5'), 'rollback');
+    runValidResponseTests(() => remoteConfig.rollback('5'), 'rollback');
+  });
+
   const INVALID_PARAMETERS: any[] = [null, '', 'abc', 1, true, []];
   const INVALID_PARAMETER_GROUPS: any[] = [null, '', 'abc', 1, true, []];
   const INVALID_CONDITIONS: any[] = [null, '', 'abc', 1, true, {}];


### PR DESCRIPTION
RELEASE NOTES: Added version management support for `admin.remoteConfig()` API. This API now supports `listVersions()`, `getTemplateAtVersion()`, and `rollback()` operations to help developers programmatically manage their Remote Config templates.