### PR TITLE
Add null to databaseAuthVariableOverride

### DIFF
--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -47,7 +47,7 @@ export type AppHook = (event: string, app: FirebaseApp) => void;
  */
 export interface FirebaseAppOptions {
   credential?: Credential;
-  databaseAuthVariableOverride?: object;
+  databaseAuthVariableOverride?: object | null;
   databaseURL?: string;
   serviceAccountId?: string;
   storageBucket?: string;


### PR DESCRIPTION
I noticed that the `databaseAuthVariableOverride` does not accept null in the source:

https://github.com/firebase/firebase-admin-node/blob/488f9318350c6b46af2e93b99907b9a02f170029/src/firebase-app.ts#L48-L56

Meanwhile, in typings it accepts null:

https://github.com/firebase/firebase-admin-node/blob/488f9318350c6b46af2e93b99907b9a02f170029/src/index.d.ts#L138-L163

Another observation is `object` vs `Object` discrepancy, from my understanding `object` is generally preferred but I don't know if it's safe or worth changing the typings for this.