### PR TITLE
chore: update node-forge to ^0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3441,14 +3441,6 @@
       "optional": true,
       "requires": {
         "node-forge": "^0.9.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
-          "optional": true
-        }
       }
     },
     "graceful-fs": {
@@ -5621,9 +5613,9 @@
       "optional": true
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-pre-gyp": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^10.10.0",
     "dicer": "^0.3.0",
     "jsonwebtoken": "^8.5.1",
-    "node-forge": "^0.7.6"
+    "node-forge": "^0.9.1"
   },
   "optionalDependencies": {
     "@google-cloud/firestore": "^4.0.0",


### PR DESCRIPTION
As commnented on https://github.com/firebase/firebase-admin-node/pull/934#discussion_r452226525

Given that node-forge is a 0.x version, npm considers it to be a breaking change, and hence not compatible with the current requirement.

node-forge is also transitively being used by firestore (direct dependency is google-p12-pem), and requiring version ^0.9.0, which means two copies of the library are currently needed. Switching to just one dependency would save 1.7Mib.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
