### PR TITLE
chore: Remove instances of XXX_SDK_VERSION_XXX by reading version from package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,9 +76,6 @@ gulp.task('compile', function() {
     // Compile Typescript into .js and .d.ts files
     .pipe(buildProject())
 
-    // Replace SDK version
-    .pipe(replace(/\<XXX_SDK_VERSION_XXX\>/g, pkg.version))
-
     // Add header
     .pipe(header(banner))
 

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -44,7 +44,7 @@ import { Tenant, TenantOptions, TenantServerResponse } from './tenant';
 
 /** Firebase Auth request header. */
 const FIREBASE_AUTH_HEADER = {
-  'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+  'X-Client-Version': `Node/Admin/${utils.SDK_VERSION}`,
 };
 /** Firebase Auth request timeout duration in milliseconds. */
 const FIREBASE_AUTH_TIMEOUT = 25000;

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -44,7 +44,7 @@ import { Tenant, TenantOptions, TenantServerResponse } from './tenant';
 
 /** Firebase Auth request header. */
 const FIREBASE_AUTH_HEADER = {
-  'X-Client-Version': `Node/Admin/${utils.SDK_VERSION}`,
+  'X-Client-Version': `Node/Admin/${utils.getSdkVersion()}`,
 };
 /** Firebase Auth request timeout duration in milliseconds. */
 const FIREBASE_AUTH_TIMEOUT = 25000;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -8,6 +8,7 @@ import { Database } from '@firebase/database';
 
 import * as validator from '../utils/validator';
 import { AuthorizedHttpClient, HttpRequestConfig, HttpError } from '../utils/api-request';
+import { SDK_VERSION } from '../utils/index';
 
 
 /**
@@ -78,8 +79,7 @@ export class DatabaseService implements FirebaseServiceInterface {
     let db: Database = this.INTERNAL.databases[dbUrl];
     if (typeof db === 'undefined') {
       const rtdb = require('@firebase/database'); // eslint-disable-line @typescript-eslint/no-var-requires
-      const { version } = require('../../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
-      db = rtdb.initStandalone(this.appInternal, dbUrl, version).instance;
+      db = rtdb.initStandalone(this.appInternal, dbUrl, SDK_VERSION).instance;
 
       const rulesClient = new DatabaseRulesClient(this.app, dbUrl);
       db.getRules = () => {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -8,7 +8,7 @@ import { Database } from '@firebase/database';
 
 import * as validator from '../utils/validator';
 import { AuthorizedHttpClient, HttpRequestConfig, HttpError } from '../utils/api-request';
-import { SDK_VERSION } from '../utils/index';
+import { getSdkVersion } from '../utils/index';
 
 
 /**
@@ -79,7 +79,7 @@ export class DatabaseService implements FirebaseServiceInterface {
     let db: Database = this.INTERNAL.databases[dbUrl];
     if (typeof db === 'undefined') {
       const rtdb = require('@firebase/database'); // eslint-disable-line @typescript-eslint/no-var-requires
-      db = rtdb.initStandalone(this.appInternal, dbUrl, SDK_VERSION).instance;
+      db = rtdb.initStandalone(this.appInternal, dbUrl, getSdkVersion()).instance;
 
       const rulesClient = new DatabaseRulesClient(this.app, dbUrl);
       db.getRules = () => {

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -39,6 +39,7 @@ import { SecurityRules } from './security-rules/security-rules';
 import { RemoteConfig } from './remote-config/remote-config';
 
 import * as validator from './utils/validator';
+import { SDK_VERSION as SDK_VERSION_UTILS } from './utils/index';
 
 const DEFAULT_APP_NAME = '[DEFAULT]';
 
@@ -309,7 +310,7 @@ export class FirebaseNamespace {
   /* tslint:enable:variable-name */
 
   public credential = firebaseCredential;
-  public SDK_VERSION = '<XXX_SDK_VERSION_XXX>';
+  public SDK_VERSION = SDK_VERSION_UTILS;
   public INTERNAL: FirebaseNamespaceInternals;
 
   /* tslint:disable */

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -39,7 +39,7 @@ import { SecurityRules } from './security-rules/security-rules';
 import { RemoteConfig } from './remote-config/remote-config';
 
 import * as validator from './utils/validator';
-import { SDK_VERSION as SDK_VERSION_UTILS } from './utils/index';
+import { getSdkVersion } from './utils/index';
 
 const DEFAULT_APP_NAME = '[DEFAULT]';
 
@@ -310,7 +310,7 @@ export class FirebaseNamespace {
   /* tslint:enable:variable-name */
 
   public credential = firebaseCredential;
-  public SDK_VERSION = SDK_VERSION_UTILS;
+  public SDK_VERSION = getSdkVersion();
   public INTERNAL: FirebaseNamespaceInternals;
 
   /* tslint:disable */

--- a/src/machine-learning/machine-learning-api-client.ts
+++ b/src/machine-learning/machine-learning-api-client.ts
@@ -23,7 +23,7 @@ import { FirebaseApp } from '../firebase-app';
 
 const ML_V1BETA2_API = 'https://firebaseml.googleapis.com/v1beta2';
 const FIREBASE_VERSION_HEADER = {
-  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
 };
 
 export interface StatusErrorResponse {

--- a/src/machine-learning/machine-learning-api-client.ts
+++ b/src/machine-learning/machine-learning-api-client.ts
@@ -23,7 +23,7 @@ import { FirebaseApp } from '../firebase-app';
 
 const ML_V1BETA2_API = 'https://firebaseml.googleapis.com/v1beta2';
 const FIREBASE_VERSION_HEADER = {
-  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
+  'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
 };
 
 export interface StatusErrorResponse {

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -21,17 +21,17 @@ import {
 import { createFirebaseError, getErrorCode } from './messaging-errors';
 import { SubRequest, BatchRequestClient } from './batch-request';
 import { SendResponse, BatchResponse } from './messaging-types';
-import { SDK_VERSION } from '../utils/index';
+import { getSdkVersion } from '../utils/index';
 
 // FCM backend constants
 const FIREBASE_MESSAGING_TIMEOUT = 10000;
 const FIREBASE_MESSAGING_BATCH_URL = 'https://fcm.googleapis.com/batch';
 const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {
-  'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+  'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
 };
 const LEGACY_FIREBASE_MESSAGING_HEADERS = {
-  'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+  'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
   'access_token_auth': 'true',
 };
 

--- a/src/messaging/messaging-api-request.ts
+++ b/src/messaging/messaging-api-request.ts
@@ -21,16 +21,17 @@ import {
 import { createFirebaseError, getErrorCode } from './messaging-errors';
 import { SubRequest, BatchRequestClient } from './batch-request';
 import { SendResponse, BatchResponse } from './messaging-types';
+import { SDK_VERSION } from '../utils/index';
 
 // FCM backend constants
 const FIREBASE_MESSAGING_TIMEOUT = 10000;
 const FIREBASE_MESSAGING_BATCH_URL = 'https://fcm.googleapis.com/batch';
 const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {
-  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
 };
 const LEGACY_FIREBASE_MESSAGING_HEADERS = {
-  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
   'access_token_auth': 'true',
 };
 

--- a/src/project-management/project-management-api-request.ts
+++ b/src/project-management/project-management-api-request.ts
@@ -21,7 +21,7 @@ import {
 import { FirebaseProjectManagementError, ProjectManagementErrorCode } from '../utils/error';
 import * as validator from '../utils/validator';
 import { ShaCertificate } from './android-app';
-import { SDK_VERSION } from '../utils/index';
+import { getSdkVersion } from '../utils/index';
 
 /** Project management backend host and port. */
 const PROJECT_MANAGEMENT_HOST_AND_PORT = 'firebase.googleapis.com:443';
@@ -31,7 +31,7 @@ const PROJECT_MANAGEMENT_PATH = '/v1/';
 const PROJECT_MANAGEMENT_BETA_PATH = '/v1beta1/';
 /** Project management request header. */
 const PROJECT_MANAGEMENT_HEADERS = {
-  'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
+  'X-Client-Version': `Node/Admin/${getSdkVersion()}`,
 };
 /** Project management request timeout duration in milliseconds. */
 const PROJECT_MANAGEMENT_TIMEOUT_MILLIS = 10000;

--- a/src/project-management/project-management-api-request.ts
+++ b/src/project-management/project-management-api-request.ts
@@ -21,6 +21,7 @@ import {
 import { FirebaseProjectManagementError, ProjectManagementErrorCode } from '../utils/error';
 import * as validator from '../utils/validator';
 import { ShaCertificate } from './android-app';
+import { SDK_VERSION } from '../utils/index';
 
 /** Project management backend host and port. */
 const PROJECT_MANAGEMENT_HOST_AND_PORT = 'firebase.googleapis.com:443';
@@ -30,7 +31,7 @@ const PROJECT_MANAGEMENT_PATH = '/v1/';
 const PROJECT_MANAGEMENT_BETA_PATH = '/v1beta1/';
 /** Project management request header. */
 const PROJECT_MANAGEMENT_HEADERS = {
-  'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+  'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
 };
 /** Project management request timeout duration in milliseconds. */
 const PROJECT_MANAGEMENT_TIMEOUT_MILLIS = 10000;

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -25,7 +25,7 @@ import { deepCopy } from '../utils/deep-copy';
 // Remote Config backend constants
 const FIREBASE_REMOTE_CONFIG_V1_API = 'https://firebaseremoteconfig.googleapis.com/v1';
 const FIREBASE_REMOTE_CONFIG_HEADERS = {
-  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
+  'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
   // There is a known issue in which the ETag is not properly returned in cases where the request
   // does not specify a compression type. Currently, it is required to include the header
   // `Accept-Encoding: gzip` or equivalent in all requests.

--- a/src/remote-config/remote-config-api-client.ts
+++ b/src/remote-config/remote-config-api-client.ts
@@ -25,7 +25,7 @@ import { deepCopy } from '../utils/deep-copy';
 // Remote Config backend constants
 const FIREBASE_REMOTE_CONFIG_V1_API = 'https://firebaseremoteconfig.googleapis.com/v1';
 const FIREBASE_REMOTE_CONFIG_HEADERS = {
-  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
   // There is a known issue in which the ETag is not properly returned in cases where the request
   // does not specify a compression type. Currently, it is required to include the header
   // `Accept-Encoding: gzip` or equivalent in all requests.

--- a/src/security-rules/security-rules-api-client.ts
+++ b/src/security-rules/security-rules-api-client.ts
@@ -23,7 +23,7 @@ import { FirebaseApp } from '../firebase-app';
 
 const RULES_V1_API = 'https://firebaserules.googleapis.com/v1';
 const FIREBASE_VERSION_HEADER = {
-  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
+  'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
 };
 
 export interface Release {

--- a/src/security-rules/security-rules-api-client.ts
+++ b/src/security-rules/security-rules-api-client.ts
@@ -23,7 +23,7 @@ import { FirebaseApp } from '../firebase-app';
 
 const RULES_V1_API = 'https://firebaserules.googleapis.com/v1';
 const FIREBASE_VERSION_HEADER = {
-  'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+  'X-Firebase-Client': `fire-admin-node/${utils.SDK_VERSION}`,
 };
 
 export interface Release {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,8 +19,15 @@ import { ServiceAccountCredential, ComputeEngineCredential } from '../auth/crede
 
 import * as validator from './validator';
 
-const { version } = require('../../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
-export const SDK_VERSION = version;
+let sdkVersion: string;
+
+export function getSdkVersion(): string {
+  if (!sdkVersion) {
+    const { version } = require('../../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
+    sdkVersion = version;
+  }
+  return sdkVersion;
+}
 
 /**
  * Renames properties on an object given a mapping from old to new property names.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,9 @@ import { ServiceAccountCredential, ComputeEngineCredential } from '../auth/crede
 
 import * as validator from './validator';
 
+const { version } = require('../../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
+export const SDK_VERSION = version;
+
 /**
  * Renames properties on an object given a mapping from old to new property names.
  *

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -47,6 +47,7 @@ import { UserIdentifier } from '../../../src/auth/identifier';
 import { TenantOptions } from '../../../src/auth/tenant';
 import { UpdateRequest, UpdateMultiFactorInfoRequest } from '../../../src/auth/user-record';
 import { expectUserImportResult } from './user-import-builder.spec';
+import { SDK_VERSION } from '../../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -849,7 +850,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
     let getTokenStub: sinon.SinonStub;
     const mockAccessToken: string = utils.generateRandomAccessToken();
     const expectedHeaders: {[key: string]: string} = {
-      'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+      'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
       'Authorization': 'Bearer ' + mockAccessToken,
     };
     const callParams = (path: string, method: any, data: any): HttpRequestConfig => {

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -47,7 +47,7 @@ import { UserIdentifier } from '../../../src/auth/identifier';
 import { TenantOptions } from '../../../src/auth/tenant';
 import { UpdateRequest, UpdateMultiFactorInfoRequest } from '../../../src/auth/user-record';
 import { expectUserImportResult } from './user-import-builder.spec';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -850,7 +850,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
     let getTokenStub: sinon.SinonStub;
     const mockAccessToken: string = utils.generateRandomAccessToken();
     const expectedHeaders: {[key: string]: string} = {
-      'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
+      'X-Client-Version': `Node/Admin/${getSdkVersion()}`,
       'Authorization': 'Bearer ' + mockAccessToken,
     };
     const callParams = (path: string, method: any, data: any): HttpRequestConfig => {

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -52,6 +52,7 @@ import { InstanceId } from '../../src/instance-id/instance-id';
 import { ProjectManagement } from '../../src/project-management/project-management';
 import { SecurityRules } from '../../src/security-rules/security-rules';
 import { RemoteConfig } from '../../src/remote-config/remote-config';
+import { SDK_VERSION } from '../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -73,7 +74,7 @@ describe('FirebaseNamespace', () => {
 
   describe('#SDK_VERSION', () => {
     it('should return the SDK version', () => {
-      expect(firebaseNamespace.SDK_VERSION).to.equal('<XXX_SDK_VERSION_XXX>');
+      expect(firebaseNamespace.SDK_VERSION).to.equal(SDK_VERSION);
     });
   });
 

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -52,7 +52,7 @@ import { InstanceId } from '../../src/instance-id/instance-id';
 import { ProjectManagement } from '../../src/project-management/project-management';
 import { SecurityRules } from '../../src/security-rules/security-rules';
 import { RemoteConfig } from '../../src/remote-config/remote-config';
-import { SDK_VERSION } from '../../src/utils/index';
+import { getSdkVersion } from '../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -74,7 +74,7 @@ describe('FirebaseNamespace', () => {
 
   describe('#SDK_VERSION', () => {
     it('should return the SDK version', () => {
-      expect(firebaseNamespace.SDK_VERSION).to.equal(SDK_VERSION);
+      expect(firebaseNamespace.SDK_VERSION).to.equal(getSdkVersion());
     });
   });
 

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -27,7 +27,7 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -87,7 +87,7 @@ describe('MachineLearningApiClient', () => {
   };
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+    'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -27,6 +27,7 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
+import { SDK_VERSION } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -86,7 +87,7 @@ describe('MachineLearningApiClient', () => {
   };
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -35,6 +35,7 @@ import {
   Messaging, BLACKLISTED_OPTIONS_KEYS, BLACKLISTED_DATA_PAYLOAD_KEYS,
 } from '../../../src/messaging/messaging';
 import { HttpClient } from '../../../src/utils/api-request';
+import { SDK_VERSION } from '../../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -321,7 +322,7 @@ describe('Messaging', () => {
   const mockAccessToken: string = utils.generateRandomAccessToken();
   const expectedHeaders = {
     'Authorization': 'Bearer ' + mockAccessToken,
-    'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
     'access_token_auth': 'true',
   };
   const emptyResponse = utils.responseFrom({});

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -35,7 +35,7 @@ import {
   Messaging, BLACKLISTED_OPTIONS_KEYS, BLACKLISTED_DATA_PAYLOAD_KEYS,
 } from '../../../src/messaging/messaging';
 import { HttpClient } from '../../../src/utils/api-request';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -322,7 +322,7 @@ describe('Messaging', () => {
   const mockAccessToken: string = utils.generateRandomAccessToken();
   const expectedHeaders = {
     'Authorization': 'Bearer ' + mockAccessToken,
-    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+    'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'access_token_auth': 'true',
   };
   const emptyResponse = utils.responseFrom({});

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -26,7 +26,7 @@ import { ProjectManagementRequestHandler } from '../../../src/project-management
 import { HttpClient } from '../../../src/utils/api-request';
 import * as mocks from '../../resources/mocks';
 import * as utils from '../utils';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 import { ShaCertificate } from '../../../src/project-management/android-app';
 import { AppPlatform } from '../../../src/project-management/app-metadata';
 
@@ -73,7 +73,7 @@ describe('ProjectManagementRequestHandler', () => {
   beforeEach(() => {
     mockApp = mocks.app();
     expectedHeaders = {
-      'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
+      'X-Client-Version': `Node/Admin/${getSdkVersion()}`,
       'Authorization': 'Bearer ' + mockAccessToken,
     };
     requestHandler = new ProjectManagementRequestHandler(mockApp);

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -26,6 +26,7 @@ import { ProjectManagementRequestHandler } from '../../../src/project-management
 import { HttpClient } from '../../../src/utils/api-request';
 import * as mocks from '../../resources/mocks';
 import * as utils from '../utils';
+import { SDK_VERSION } from '../../../src/utils/index';
 import { ShaCertificate } from '../../../src/project-management/android-app';
 import { AppPlatform } from '../../../src/project-management/app-metadata';
 
@@ -72,7 +73,7 @@ describe('ProjectManagementRequestHandler', () => {
   beforeEach(() => {
     mockApp = mocks.app();
     expectedHeaders = {
-      'X-Client-Version': 'Node/Admin/<XXX_SDK_VERSION_XXX>',
+      'X-Client-Version': `Node/Admin/${SDK_VERSION}`,
       'Authorization': 'Bearer ' + mockAccessToken,
     };
     requestHandler = new ProjectManagementRequestHandler(mockApp);

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -33,7 +33,7 @@ import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
 import { deepCopy } from '../../../src/utils/deep-copy';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -54,7 +54,7 @@ describe('RemoteConfigApiClient', () => {
 
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+    'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'Accept-Encoding': 'gzip',
   };
 

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -33,6 +33,7 @@ import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
 import { deepCopy } from '../../../src/utils/deep-copy';
+import { SDK_VERSION } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -53,7 +54,7 @@ describe('RemoteConfigApiClient', () => {
 
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
     'Accept-Encoding': 'gzip',
   };
 

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -26,6 +26,7 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
+import { SDK_VERSION } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -42,7 +43,7 @@ describe('SecurityRulesApiClient', () => {
   };
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': 'fire-admin-node/<XXX_SDK_VERSION_XXX>',
+    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -26,7 +26,7 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 import { FirebaseAppError } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
-import { SDK_VERSION } from '../../../src/utils/index';
+import { getSdkVersion } from '../../../src/utils/index';
 
 const expect = chai.expect;
 
@@ -43,7 +43,7 @@ describe('SecurityRulesApiClient', () => {
   };
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
-    'X-Firebase-Client': `fire-admin-node/${SDK_VERSION}`,
+    'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -38,8 +38,8 @@ describe('SDK_VERSION', () => {
   it('utils index should retrieve the SDK_VERSION from package.json', () => {
     const mockVersionNumber = "MockVersion";
 
-    const Module = require('module'); // eslint-disable-line @typescript-eslint/no-var-requires
-    const stub = sinon.stub(Module.prototype, 'require');
+    const module = require('module'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const stub = sinon.stub(module.prototype, 'require');
     stub.withArgs('../../package.json').returns({ version: mockVersionNumber });
     stub.callThrough();
 

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -29,6 +29,7 @@ import { ComputeEngineCredential } from '../../../src/auth/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';
 import { FirebaseAppError } from '../../../src/utils/error';
+import { getSdkVersion } from '../../../src/utils/index';
 
 interface Obj {
   [key: string]: any;
@@ -36,18 +37,8 @@ interface Obj {
 
 describe('SDK_VERSION', () => {
   it('utils index should retrieve the SDK_VERSION from package.json', () => {
-    const mockVersionNumber = "MockVersion";
-
-    const module = require('module'); // eslint-disable-line @typescript-eslint/no-var-requires
-    const stub = sinon.stub(module.prototype, 'require');
-    stub.withArgs('../../package.json').returns({ version: mockVersionNumber });
-    stub.callThrough();
-
-    delete require.cache[require.resolve('../../../src/utils/index')];
-    const utils = require('../../../src/utils/index'); // eslint-disable-line @typescript-eslint/no-var-requires
-
-    expect(utils.SDK_VERSION).to.equal(mockVersionNumber);
-    stub.restore();
+    const { version } = require('../../../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
+    expect(getSdkVersion()).to.equal(version);
   });
 });
 

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -34,6 +34,23 @@ interface Obj {
   [key: string]: any;
 }
 
+describe('SDK_VERSION', () => {
+  it('utils index should retrieve the SDK_VERSION from package.json', () => {
+    const mockVersionNumber = "MockVersion";
+
+    const Module = require('module'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const stub = sinon.stub(Module.prototype, 'require');
+    stub.withArgs('../../package.json').returns({ version: mockVersionNumber });
+    stub.callThrough();
+
+    delete require.cache[require.resolve('../../../src/utils/index')];
+    const utils = require('../../../src/utils/index'); // eslint-disable-line @typescript-eslint/no-var-requires
+
+    expect(utils.SDK_VERSION).to.equal(mockVersionNumber);
+    stub.restore();
+  });
+});
+
 describe('addReadonlyGetter()', () => {
   it('should add a new property to the provided object', () => {
     const obj: Obj = {};


### PR DESCRIPTION
### Summary
Removes instances of `XXX_SDK_VERSION_XXX` which were substituted by gulp at the build stage, and instead reads from `package.json` the value of `version`. 

### Test Plan
Added unit test to verify that the value is read from `package.json`.

Edit: I had a thought of perhaps adding an integration test to it or for the `example.test.ts`, however this is a util function which isn't supposed to be exposed to developers hence my initial reaction was against that.