### PR TITLE
chore: Enable keyword-spacing ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
 
     // Required checks
     'indent': ['error', 2],
+    'keyword-spacing': ['error'],
     "object-curly-spacing": [2, "always"],
     '@typescript-eslint/explicit-function-return-type': [
       'error',


### PR DESCRIPTION
Enabling the [keyword-spacing](https://eslint.org/docs/rules/keyword-spacing) rule which requires some spacing around keywords like `if` and `for`. No current violations detected.