### PR TITLE
fix(auth): Add null to customUserClaims inside BaseAuth.setCustomUserClaims

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -424,7 +424,7 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> {
    * @return {Promise<void>} A promise that resolves when the operation completes
    *     successfully.
    */
-  public setCustomUserClaims(uid: string, customUserClaims: object): Promise<void> {
+  public setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void> {
     return this.authRequestHandler.setCustomUserClaims(uid, customUserClaims)
       .then(() => {
         // Return nothing on success.


### PR DESCRIPTION
While working on auto-generated types for auth, I realized that there might be a missing conditional for `customUserClaims`.

In the typings:
https://github.com/firebase/firebase-admin-node/blob/92b0d37a6de9f19f6a625dbc4bc1a055b162622a/src/auth.d.ts#L1516

In the source:
https://github.com/firebase/firebase-admin-node/blob/92b0d37a6de9f19f6a625dbc4bc1a055b162622a/src/auth/auth.ts#L427