### PR TITLE
fix: Use object instead of Object in typings

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -29,7 +29,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -71,7 +71,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -102,7 +102,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -219,7 +219,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -235,7 +235,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this multi-factor object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -974,7 +974,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -1324,7 +1324,7 @@ export namespace admin.auth {
      * @return A promise fulfilled with a custom token for the
      *   provided `uid` and payload.
      */
-    createCustomToken(uid: string, developerClaims?: Object): Promise<string>;
+    createCustomToken(uid: string, developerClaims?: object): Promise<string>;
 
     /**
      * Creates a new user.
@@ -1513,7 +1513,7 @@ export namespace admin.auth {
      * @return A promise that resolves when the operation completes
      *   successfully.
      */
-    setCustomUserClaims(uid: string, customUserClaims: Object | null): Promise<void>;
+    setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
 
     /**
      * Revokes all refresh tokens for an existing user.

--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -235,7 +235,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this multi-factor object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**

--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -29,7 +29,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**
@@ -71,7 +71,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**
@@ -102,7 +102,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**
@@ -219,7 +219,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**
@@ -974,7 +974,7 @@ export namespace admin.auth {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**

--- a/src/database.d.ts
+++ b/src/database.d.ts
@@ -422,7 +422,7 @@ export namespace admin.database {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object | null;
+    toJSON(): object | null;
 
     /**
      * Extracts a JavaScript value from a `DataSnapshot`.
@@ -604,7 +604,7 @@ export namespace admin.database {
      * });
      * ```
      *
-     * @param values Object containing multiple values.
+     * @param values object containing multiple values.
      * @param onComplete An optional callback function that will
      *   be called when synchronization to the server has completed. The
      *   callback will be passed a single parameter: null for success, or an Error
@@ -612,7 +612,7 @@ export namespace admin.database {
      * @return Resolves when synchronization to the
      *   Database is complete.
      */
-    update(values: Object, onComplete?: (a: Error | null) => any): Promise<void>;
+    update(values: object, onComplete?: (a: Error | null) => any): Promise<void>;
   }
 
   type EventType = 'value' | 'child_added' | 'child_changed' | 'child_moved' | 'child_removed';
@@ -865,7 +865,7 @@ export namespace admin.database {
     off(
       eventType?: admin.database.EventType,
       callback?: (a: admin.database.DataSnapshot, b?: string | null) => any,
-      context?: Object | null
+      context?: object | null
     ): void;
 
     /**
@@ -987,8 +987,8 @@ export namespace admin.database {
     on(
       eventType: admin.database.EventType,
       callback: (a: admin.database.DataSnapshot, b?: string | null) => any,
-      cancelCallbackOrContext?: ((a: Error) => any) | Object | null,
-      context?: Object | null
+      cancelCallbackOrContext?: ((a: Error) => any) | object | null,
+      context?: object | null
     ): (a: admin.database.DataSnapshot | null, b?: string) => any;
 
     /**
@@ -1025,8 +1025,8 @@ export namespace admin.database {
     once(
       eventType: admin.database.EventType,
       successCallback?: (a: admin.database.DataSnapshot, b?: string | null ) => any,
-      failureCallbackOrContext?: ((a: Error) => void) | Object | null,
-      context?: Object | null
+      failureCallbackOrContext?: ((a: Error) => void) | object | null,
+      context?: object | null
     ): Promise<admin.database.DataSnapshot>;
 
     /**
@@ -1158,7 +1158,7 @@ export namespace admin.database {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
 
     /**
      * Gets the absolute URL for this location.
@@ -1618,12 +1618,12 @@ export namespace admin.database {
      * adaNameRef.update({ first: 'Ada', last: 'Lovelace' });
      * ```
      *
-     * @param values Object containing multiple values.
+     * @param values object containing multiple values.
      * @param onComplete Callback called when write to server is
      *   complete.
      * @return Resolves when update on server is complete.
      */
-    update(values: Object, onComplete?: (a: Error | null) => any): Promise<void>;
+    update(values: object, onComplete?: (a: Error | null) => any): Promise<void>;
   }
 
   /**
@@ -1651,7 +1651,7 @@ export namespace admin.database.ServerValue {
    * });
    * ```
    */
-  const TIMESTAMP: Object;
+  const TIMESTAMP: object;
 
   /**
    * Returns a placeholder value that can be used to atomically increment the
@@ -1660,5 +1660,5 @@ export namespace admin.database.ServerValue {
    * @param delta the amount to modify the current value atomically.
    * @return a placeholder value for modifying data atomically server-side.
    */
-  function increment(delta: number): Object;
+  function increment(delta: number): object;
 }

--- a/src/database.d.ts
+++ b/src/database.d.ts
@@ -422,7 +422,7 @@ export namespace admin.database {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object | null;
+    toJSON(): Object | null;
 
     /**
      * Extracts a JavaScript value from a `DataSnapshot`.
@@ -1158,7 +1158,7 @@ export namespace admin.database {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
 
     /**
      * Gets the absolute URL for this location.
@@ -1660,5 +1660,5 @@ export namespace admin.database.ServerValue {
    * @param delta the amount to modify the current value atomically.
    * @return a placeholder value for modifying data atomically server-side.
    */
-  function increment(delta: number): object;
+  function increment(delta: number): Object;
 }

--- a/src/database.d.ts
+++ b/src/database.d.ts
@@ -1651,7 +1651,7 @@ export namespace admin.database.ServerValue {
    * });
    * ```
    */
-  const TIMESTAMP: object;
+  const TIMESTAMP: Object;
 
   /**
    * Returns a placeholder value that can be used to atomically increment the

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ declare namespace admin {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): Object;
+    toJSON(): object;
   }
 
   /**
@@ -149,7 +149,7 @@ declare namespace admin {
      * [Authenticate with limited privileges](/docs/database/admin/start#authenticate-with-limited-privileges)
      * for detailed documentation and code samples.
      */
-    databaseAuthVariableOverride?: Object | null;
+    databaseAuthVariableOverride?: object | null;
 
     /**
      * The URL of the Realtime Database from which to read and write data.
@@ -737,7 +737,7 @@ declare namespace admin.credential {
     * @return A credential authenticated via the
     *   provided service account that can be used to initialize an app.
    */
-  function refreshToken(refreshTokenPathOrObject: string | Object, httpAgent?: Agent): admin.credential.Credential;
+  function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): admin.credential.Credential;
 }
 
 declare namespace admin.database {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ declare namespace admin {
     /**
      * @return A JSON-serializable representation of this object.
      */
-    toJSON(): object;
+    toJSON(): Object;
   }
 
   /**


### PR DESCRIPTION
It is best-practice in TypeScript to use `object` instead of `Object`. While moving towards auto-generated typings, we will get this for free as the source was written correctly, however in the meantime this would make the move more transparent.

From my understanding this should be a safe move so-long as none of the developers use primitive types in place of Object (for example `Number`), but I don't think that is the case here. 

I provided more details in an internal document: go/firebase-admin-node-object

