### PR TITLE
Fix updateUser's typing jsdoc (delete => update)

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1459,7 +1459,7 @@ export namespace admin.auth {
      * See [Update a user](/docs/auth/admin/manage-users#update_a_user) for code
      * samples and detailed documentation.
      *
-     * @param uid The `uid` corresponding to the user to update
+     * @param uid The `uid` corresponding to the user to update.
      * @param properties The properties to update on
      *   the provided user.
      *

--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1459,7 +1459,7 @@ export namespace admin.auth {
      * See [Update a user](/docs/auth/admin/manage-users#update_a_user) for code
      * samples and detailed documentation.
      *
-     * @param uid The `uid` corresponding to the user to delete.
+     * @param uid The `uid` corresponding to the user to update
      * @param properties The properties to update on
      *   the provided user.
      *


### PR DESCRIPTION
### Context

The jsdoc for uid param of updateUser in auth.d.ts is wrong, it should be the uid to update instead of to delete.

### The goal of this PR

Fix the wording of the uid param.