### PR TITLE
fix(auth): Fix several typing inconsistencies

### DIFF
--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -166,7 +166,7 @@ export interface EmailSignInConfigServerRequest {
  * to a format that is understood by the Auth server.
  */
 export class EmailSignInConfig implements EmailSignInProviderConfig {
-  public readonly enabled?: boolean;
+  public readonly enabled: boolean;
   public readonly passwordRequired?: boolean;
 
   /**

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -108,6 +108,7 @@ export interface DecodedIdToken {
   sub: string;
   tenant?: string;
   [key: string]: any;
+  uid: string;
 }
 
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -107,8 +107,8 @@ export interface DecodedIdToken {
   picture?: string;
   sub: string;
   tenant?: string;
-  [key: string]: any;
   uid: string;
+  [key: string]: any;
 }
 
 

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -213,7 +213,7 @@ export abstract class MultiFactorInfo {
     }
     utils.addReadonlyGetter(this, 'uid', response.mfaEnrollmentId);
     utils.addReadonlyGetter(this, 'factorId', factorId);
-    utils.addReadonlyGetter(this, 'displayName', response.displayName || null);
+    utils.addReadonlyGetter(this, 'displayName', response.displayName);
     // Encoded using [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format.
     // For example, "2017-01-15T01:30:15.01Z".
     // This can be parsed directly via Date constructor.

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -148,7 +148,7 @@ export enum MultiFactorId {
  */
 export abstract class MultiFactorInfo {
   public readonly uid: string;
-  public readonly displayName: string | null;
+  public readonly displayName: string;
   public readonly factorId: MultiFactorId;
   public readonly enrollmentTime: string;
 
@@ -265,7 +265,7 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
 
 /** Class representing multi-factor related properties of a user. */
 export class MultiFactor {
-  public readonly enrolledFactors: ReadonlyArray<MultiFactorInfo>;
+  public enrolledFactors: MultiFactorInfo[];
 
   /**
    * Initializes the MultiFactor object using the server side or JWT format response.

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -161,6 +161,7 @@ function getDecodedIdToken(uid: string, authTime: Date, tenantId?: string): Deco
       sign_in_provider: 'custom', // eslint-disable-line @typescript-eslint/camelcase
       tenant: tenantId,
     },
+    uid: '123',
   };
 }
 
@@ -186,6 +187,7 @@ function getDecodedSessionCookie(uid: string, authTime: Date, tenantId?: string)
       sign_in_provider: 'custom', // eslint-disable-line @typescript-eslint/camelcase
       tenant: tenantId,
     },
+    uid: '123',
   };
 }
 

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -161,7 +161,7 @@ function getDecodedIdToken(uid: string, authTime: Date, tenantId?: string): Deco
       sign_in_provider: 'custom', // eslint-disable-line @typescript-eslint/camelcase
       tenant: tenantId,
     },
-    uid: '123',
+    uid,
   };
 }
 
@@ -187,7 +187,7 @@ function getDecodedSessionCookie(uid: string, authTime: Date, tenantId?: string)
       sign_in_provider: 'custom', // eslint-disable-line @typescript-eslint/camelcase
       tenant: tenantId,
     },
-    uid: '123',
+    uid,
   };
 }
 

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -173,7 +173,7 @@ function getUserJSON(tenantId?: string): object {
         },
         {
           uid: 'enrollmentId2',
-          displayName: null,
+          displayName: undefined,
           enrollmentTime: now.toUTCString(),
           phoneNumber: '+16505556789',
           factorId: 'phone',
@@ -294,7 +294,7 @@ describe('PhoneMultiFactorInfo', () => {
   describe('getters', () => {
     it('should set missing optional fields to null', () => {
       expect(phoneMultiFactorInfoMissingFields.uid).to.equal(serverResponse.mfaEnrollmentId);
-      expect(phoneMultiFactorInfoMissingFields.displayName).to.be.null;
+      expect(phoneMultiFactorInfoMissingFields.displayName).to.be.undefined;
       expect(phoneMultiFactorInfoMissingFields.phoneNumber).to.equal(serverResponse.phoneInfo);
       expect(phoneMultiFactorInfoMissingFields.enrollmentTime).to.be.null;
       expect(phoneMultiFactorInfoMissingFields.factorId).to.equal('phone');
@@ -365,7 +365,7 @@ describe('PhoneMultiFactorInfo', () => {
     it('should return expected JSON object with missing fields set to null', () => {
       expect(phoneMultiFactorInfoMissingFields.toJSON()).to.deep.equal({
         uid: 'enrollmentId1',
-        displayName: null,
+        displayName: undefined,
         enrollmentTime: null,
         phoneNumber: '+16505551234',
         factorId: 'phone',


### PR DESCRIPTION
While working on the modularization of `instance-id` I came across several typing inconsistencies that I thought I'd bring up. Not sure if this is the best approach for all of them though.

##### 1) `auth-config.ts`
Observation: The `enabled` field should not be optional in `auth-config.ts`.

Source
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth/auth-config.ts#L168-L170

Typing

https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth.d.ts#L960-L972

##### 2) `auth.ts`
Observation: There is a missing `uid` field in `DecodedIdToken`.

Source
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth/auth.ts#L108-L111

Typing
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth.d.ts#L531-L538

##### 3) `user-record.ts`
Observation: `displayName` in `MultiFactorInfo` doesn't have a `null` option for type.

Source
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth/user-record.ts#L149-L152

Typing
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth.d.ts#L80-L90

##### 4) `user-record.ts`
Observation: `enrolledFactors ` in `MultiFactor ` isn't read-only in types.

Source
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth/user-record.ts#L267-L268

Typing
https://github.com/firebase/firebase-admin-node/blob/54a58348ab7d8ee5e1ef4fd90cb68110a3e41391/src/auth.d.ts#L228-L233



