### PR TITLE
Modify gulpfile to allow for autogenerated types per-service

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,9 +55,11 @@ var paths = {
   curatedTypings: ['src/**/*.d.ts'],
 };
 
-// Create a separate project for buildProject that overrides the rootDir
+// Create a separate project for buildProject that overrides the rootDir.
 // This ensures that the generated production files are in their own root
-// rather than including both src and test in the lib dir.
+// rather than including both src and test in the lib dir. Declaration
+// is used by TypeScript to determine if auto-generated typings should be
+// emitted.
 const declaration = process.env.TYPE_GENERATION_MODE === 'auto';
 var buildProject = ts.createProject('tsconfig.json', { rootDir: 'src', declaration });
 
@@ -91,7 +93,7 @@ gulp.task('compile', function() {
     // Add header
     .pipe(header(banner));
   
-  // Exclude typings that are unintended (currently includes all auto-generated
+  // Exclude typings that are unintended (currently excludes all auto-generated
   // typings, but as services are refactored to auto-generate typings this will
   // change). Moreover, all *-internal.d.ts typings should not be exposed to 
   // developers as it denotes internally used types.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,24 @@ var paths = {
   curatedTypings: ['src/*.d.ts'],
 };
 
+const TEMPORARY_TYPING_EXCLUDES = [
+  '!lib/default-namespace.d.ts',
+  '!lib/firebase-namespace.d.ts',
+  '!lib/firebase-app.d.ts',
+  '!lib/firebase-service.d.ts',
+  '!lib/auth/*.d.ts',
+  '!lib/database/*.d.ts',
+  '!lib/firestore/*.d.ts',
+  '!lib/instance-id/*.d.ts',
+  '!lib/machine-learning/*.d.ts',
+  '!lib/messaging/*.d.ts',
+  '!lib/project-management/*.d.ts',
+  '!lib/remote-config/*.d.ts',
+  '!lib/security-rules/*.d.ts',
+  '!lib/storage/*.d.ts',
+  '!lib/utils/*.d.ts'
+];
+
 // Create a separate project for buildProject that overrides the rootDir.
 // This ensures that the generated production files are in their own root
 // rather than including both src and test in the lib dir. Declaration
@@ -96,24 +114,6 @@ gulp.task('compile', function() {
   // change). Moreover, all *-internal.d.ts typings should not be exposed to 
   // developers as it denotes internally used types.
   if (declaration) {
-    const TEMPORARY_TYPING_EXCLUDES = [
-      '!lib/default-namespace.d.ts',
-      '!lib/firebase-namespace.d.ts',
-      '!lib/firebase-app.d.ts',
-      '!lib/firebase-service.d.ts',
-      '!lib/auth/*.d.ts',
-      '!lib/database/*.d.ts',
-      '!lib/firestore/*.d.ts',
-      '!lib/instance-id/*.d.ts',
-      '!lib/machine-learning/*.d.ts',
-      '!lib/messaging/*.d.ts',
-      '!lib/project-management/*.d.ts',
-      '!lib/remote-config/*.d.ts',
-      '!lib/security-rules/*.d.ts',
-      '!lib/storage/*.d.ts',
-      '!lib/utils/*.d.ts'
-    ];
-
     const configuration = [
       'lib/**/*.js',
       'lib/**/*.d.ts',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ var ts = require('gulp-typescript');
 var del = require('del');
 var header = require('gulp-header');
 var replace = require('gulp-replace');
+var filter = require('gulp-filter');
 
 
 /****************/
@@ -50,12 +51,15 @@ var paths = {
   ],
 
   build: 'lib/',
+
+  curatedTypings: ['src/**/*.d.ts'],
 };
 
 // Create a separate project for buildProject that overrides the rootDir
 // This ensures that the generated production files are in their own root
 // rather than including both src and test in the lib dir.
-var buildProject = ts.createProject('tsconfig.json', {rootDir: 'src'});
+const declaration = process.env.TYPE_GENERATION_MODE === 'auto';
+var buildProject = ts.createProject('tsconfig.json', { rootDir: 'src', declaration });
 
 var buildTest = ts.createProject('tsconfig.json');
 
@@ -71,16 +75,50 @@ gulp.task('cleanup', function() {
   ]);
 });
 
+/**
+ * Task used to compile the TypeScript project. If automatic typings
+ * are set to be generated (determined by TYPE_GENERATION_MODE), declarations
+ * for files terminating in -internal.d.ts are removed because we do not
+ * want to expose internally used types to developers. As auto-generated
+ * typings are a work-in-progress, we remove the *.d.ts files for modules
+ * which we do not intend to auto-generate typings for yet.
+ */
 gulp.task('compile', function() {
-  return gulp.src(paths.src)
+  let workflow = gulp.src(paths.src)
     // Compile Typescript into .js and .d.ts files
     .pipe(buildProject())
 
     // Add header
-    .pipe(header(banner))
+    .pipe(header(banner));
+  
+  // Exclude typings that are unintended (currently includes all auto-generated
+  // typings, but as services are refactored to auto-generate typings this will
+  // change). Moreover, all *-internal.d.ts typings should not be exposed to 
+  // developers as it denotes internally used types.
+  if (declaration) {
+    workflow = workflow.pipe(filter([
+      'lib/**/*.js',
+      'lib/**/*.d.ts',
+      '!lib/**/*-internal.d.ts',
+      '!lib/default-namespace.d.ts',
+      '!lib/firebase-namespace.d.ts',
+      '!lib/firebase-app.d.ts',
+      '!lib/firebase-service.d.ts',
+      '!lib/auth/*.d.ts',
+      '!lib/database/*.d.ts',
+      '!lib/firestore/*.d.ts',
+      '!lib/instance-id/*.d.ts',
+      '!lib/machine-learning/*.d.ts',
+      '!lib/messaging/*.d.ts',
+      '!lib/project-management/*.d.ts',
+      '!lib/remote-config/*.d.ts',
+      '!lib/security-rules/*.d.ts',
+      '!lib/storage/*.d.ts',
+      '!lib/utils/*.d.ts']))
+  }
 
-    // Write to build directory
-    .pipe(gulp.dest(paths.build))
+  // Write to build directory
+  return workflow.pipe(gulp.dest(paths.build))
 });
 
 /**
@@ -104,19 +142,23 @@ gulp.task('copyDatabase', function() {
 });
 
 gulp.task('copyTypings', function() {
-  return gulp.src('src/*.d.ts')
+  let workflow = gulp.src('src/*.d.ts')
     // Add header
-    .pipe(header(banner))
+    .pipe(header(banner));
+  
+  if (declaration) {
+    workflow = workflow.pipe(filter(paths.curatedTypings));
+  }
 
-    // Write to build directory
-    .pipe(gulp.dest(paths.build))
+  // Write to build directory
+  return workflow.pipe(gulp.dest(paths.build))
 });
 
 gulp.task('compile_all', gulp.series('compile', 'copyDatabase', 'copyTypings', 'compile_test'));
 
 // Regenerates js every time a source file changes
 gulp.task('watch', function() {
-  gulp.watch(paths.src.concat(paths.test), {ignoreInitial: false}, gulp.series('compile_all'));
+  gulp.watch(paths.src.concat(paths.test), { ignoreInitial: false }, gulp.series('compile_all'));
 });
 
 // Build task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ var paths = {
 
   build: 'lib/',
 
-  curatedTypings: ['src/**/*.d.ts'],
+  curatedTypings: ['src/*.d.ts'],
 };
 
 // Create a separate project for buildProject that overrides the rootDir.
@@ -77,14 +77,12 @@ gulp.task('cleanup', function() {
   ]);
 });
 
-/**
- * Task used to compile the TypeScript project. If automatic typings
- * are set to be generated (determined by TYPE_GENERATION_MODE), declarations
- * for files terminating in -internal.d.ts are removed because we do not
- * want to expose internally used types to developers. As auto-generated
- * typings are a work-in-progress, we remove the *.d.ts files for modules
- * which we do not intend to auto-generate typings for yet.
- */
+// Task used to compile the TypeScript project. If automatic typings
+// are set to be generated (determined by TYPE_GENERATION_MODE), declarations
+// for files terminating in -internal.d.ts are removed because we do not
+// want to expose internally used types to developers. As auto-generated
+// typings are a work-in-progress, we remove the *.d.ts files for modules
+// which we do not intend to auto-generate typings for yet.
 gulp.task('compile', function() {
   let workflow = gulp.src(paths.src)
     // Compile Typescript into .js and .d.ts files
@@ -98,10 +96,7 @@ gulp.task('compile', function() {
   // change). Moreover, all *-internal.d.ts typings should not be exposed to 
   // developers as it denotes internally used types.
   if (declaration) {
-    workflow = workflow.pipe(filter([
-      'lib/**/*.js',
-      'lib/**/*.d.ts',
-      '!lib/**/*-internal.d.ts',
+    const TEMPORARY_TYPING_EXCLUDES = [
       '!lib/default-namespace.d.ts',
       '!lib/firebase-namespace.d.ts',
       '!lib/firebase-app.d.ts',
@@ -116,7 +111,16 @@ gulp.task('compile', function() {
       '!lib/remote-config/*.d.ts',
       '!lib/security-rules/*.d.ts',
       '!lib/storage/*.d.ts',
-      '!lib/utils/*.d.ts']))
+      '!lib/utils/*.d.ts'
+    ];
+
+    const configuration = [
+      'lib/**/*.js',
+      'lib/**/*.d.ts',
+      '!lib/**/*-internal.d.ts',
+    ].concat(TEMPORARY_TYPING_EXCLUDES);
+
+    workflow = workflow.pipe(filter(configuration));
   }
 
   // Write to build directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "8.13.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -572,8 +572,7 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/minimist": {
       "version": "1.2.0",
@@ -795,7 +794,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-      "dev": true,
       "requires": {
         "ansi-wrap": "^0.1.0"
       }
@@ -841,8 +839,7 @@
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -912,8 +909,7 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-filter": {
       "version": "1.1.2",
@@ -942,8 +938,7 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-differ": {
       "version": "1.0.0",
@@ -1047,8 +1042,7 @@
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "optional": true
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1074,8 +1068,7 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -1163,8 +1156,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1289,7 +1281,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1724,8 +1715,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -2709,7 +2699,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -2719,7 +2708,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -3530,6 +3518,16 @@
             "yargs-parser": "5.0.0-security.0"
           }
         }
+      }
+    },
+    "gulp-filter": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-6.0.0.tgz",
+      "integrity": "sha512-veQFW93kf6jBdWdF/RxMEIlDK2mkjHyPftM381DID2C9ImTVngwYpyyThxm4/EpgcNOT37BLefzMOjEKbyYg0Q==",
+      "requires": {
+        "multimatch": "^4.0.0",
+        "plugin-error": "^1.0.1",
+        "streamfilter": "^3.0.0"
       }
     },
     "gulp-header": {
@@ -4348,7 +4346,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -4438,8 +4435,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -5248,7 +5244,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5386,6 +5381,30 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "array-differ": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+          "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+        }
+      }
     },
     "multipipe": {
       "version": "0.1.2",
@@ -6334,7 +6353,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-      "dev": true,
       "requires": {
         "ansi-colors": "^1.0.1",
         "arr-diff": "^4.0.0",
@@ -7392,6 +7410,26 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "streamfilter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-3.0.0.tgz",
+      "integrity": "sha512-kvKNfXCmUyC8lAXSSHCIXBUlo/lhsLcCU/OmzACZYpRUdtKIH68xYhm/+HI15jFJYtNJGYtCgn2wmIiExY1VwA==",
+      "requires": {
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "streamsearch": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@firebase/database": "^0.6.0",
     "@types/node": "^10.10.0",
     "dicer": "^0.3.0",
+    "gulp-filter": "^6.0.0",
     "jsonwebtoken": "^8.5.1",
     "node-forge": "^0.9.1"
   },


### PR DESCRIPTION
## Context
The goal is to bridge the gap between today's Admin SDK (manually curated d.ts files, nested namespaces) and a modularized SDK that has auto-generated typings. To accomplish this, we can go forward with gradually refactoring the codebase to allow for auto-generated typings.

The first step is to modify the gulpfile to accommodate toggling between auto-generated types and the manually curated ones in the builds. For more information, view the internal document: go/firebase-node-auto-typing.

## Overview
Depending on the value of `TYPE_GENERATION_MODE`:
- `TYPE_GENERATION_MODE = auto`: For all services that support auto-generated typings (i.e., have been refactored) the associated `d.ts` files are emitted. However, we automatically strip all files that have a suffix of `-internal.d.ts`, which is the now-canonical file representation for files containing internally used exported types.
- `TYPE_GENERATION_MODE != auto`: The former behavior (i.e., do not emit `d.ts` files and copy the manually curated typings).

## Test Plan
- Manual inspection
   - Ran it in the current state with `TYPE_GENERATION_MODE != auto`
       - All manually curated `d.ts` files were successfully copied
   - Added `!src/database.d.ts` to `paths.curatedTypings`, and removed `'!lib/database/*.d.ts',` from the compile step, and re-ran with `TYPE_GENERATION_MODE=auto`.
       - All manually curated `d.ts` files were copied except for `database.d.ts`, and inside `./database/` there was a `d.ts` file generated
- Unit, integration and sanity tests pass