### PR TITLE
fix(auth): Make displayName optional for AuthProviderConfig typings

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1072,7 +1072,7 @@ export namespace admin.auth {
      * The user-friendly display name to the current configuration. This name is
      * also used as the provider label in the Cloud Console.
      */
-    displayName: string;
+    displayName?: string;
 
     /**
      * Whether the provider configuration is enabled or disabled. A user

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -29,7 +29,7 @@ export interface AuthProviderConfigFilter {
 /** The base Auth provider configuration interface. */
 export interface AuthProviderConfig {
   providerId: string;
-  displayName?: string;
+  displayName: string;
   enabled: boolean;
 }
 
@@ -264,7 +264,7 @@ export class EmailSignInConfig implements EmailSignInProviderConfig {
  */
 export class SAMLConfig implements SAMLAuthProviderConfig {
   public readonly enabled: boolean;
-  public readonly displayName?: string;
+  public readonly displayName: string;
   public readonly providerId: string;
   public readonly idpEntityId: string;
   public readonly ssoURL: string;
@@ -503,7 +503,7 @@ export class SAMLConfig implements SAMLAuthProviderConfig {
     this.x509Certificates = x509Certificates;
     // When enabled is undefined, it takes its default value of false.
     this.enabled = !!response.enabled;
-    this.displayName = response.displayName;
+    this.displayName = (response.displayName as string);
   }
 
   /** @return {SAMLAuthProviderConfig} The plain object representation of the SAMLConfig. */
@@ -528,7 +528,7 @@ export class SAMLConfig implements SAMLAuthProviderConfig {
  */
 export class OIDCConfig implements OIDCAuthProviderConfig {
   public readonly enabled: boolean;
-  public readonly displayName?: string;
+  public readonly displayName: string;
   public readonly providerId: string;
   public readonly issuer: string;
   public readonly clientId: string;
@@ -687,7 +687,7 @@ export class OIDCConfig implements OIDCAuthProviderConfig {
     this.issuer = response.issuer;
     // When enabled is undefined, it takes its default value of false.
     this.enabled = !!response.enabled;
-    this.displayName = response.displayName;
+    this.displayName = (response.displayName as string);
   }
 
   /** @return {OIDCAuthProviderConfig} The plain object representation of the OIDCConfig. */

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -29,7 +29,7 @@ export interface AuthProviderConfigFilter {
 /** The base Auth provider configuration interface. */
 export interface AuthProviderConfig {
   providerId: string;
-  displayName: string;
+  displayName?: string;
   enabled: boolean;
 }
 
@@ -264,7 +264,7 @@ export class EmailSignInConfig implements EmailSignInProviderConfig {
  */
 export class SAMLConfig implements SAMLAuthProviderConfig {
   public readonly enabled: boolean;
-  public readonly displayName: string;
+  public readonly displayName?: string;
   public readonly providerId: string;
   public readonly idpEntityId: string;
   public readonly ssoURL: string;
@@ -503,7 +503,7 @@ export class SAMLConfig implements SAMLAuthProviderConfig {
     this.x509Certificates = x509Certificates;
     // When enabled is undefined, it takes its default value of false.
     this.enabled = !!response.enabled;
-    this.displayName = (response.displayName as string);
+    this.displayName = response.displayName;
   }
 
   /** @return {SAMLAuthProviderConfig} The plain object representation of the SAMLConfig. */
@@ -528,7 +528,7 @@ export class SAMLConfig implements SAMLAuthProviderConfig {
  */
 export class OIDCConfig implements OIDCAuthProviderConfig {
   public readonly enabled: boolean;
-  public readonly displayName: string;
+  public readonly displayName?: string;
   public readonly providerId: string;
   public readonly issuer: string;
   public readonly clientId: string;
@@ -687,7 +687,7 @@ export class OIDCConfig implements OIDCAuthProviderConfig {
     this.issuer = response.issuer;
     // When enabled is undefined, it takes its default value of false.
     this.enabled = !!response.enabled;
-    this.displayName = (response.displayName as string);
+    this.displayName = response.displayName;
   }
 
   /** @return {OIDCAuthProviderConfig} The plain object representation of the OIDCConfig. */


### PR DESCRIPTION
### Observation
There is a discrepancy regarding `displayName` being a mandatory field in `AuthProviderConfig`.

Source
https://github.com/firebase/firebase-admin-node/blob/031edc2c3eb3b676b95063ce33bfc5673d7dc2bc/src/auth/auth-config.ts#L29-L34

Typings
https://github.com/firebase/firebase-admin-node/blob/031edc2c3eb3b676b95063ce33bfc5673d7dc2bc/src/auth.d.ts#L1062-L1082

### Solution

Assuming the typings are the source of truth I made it a mandatory field.