### PR TITLE
fix(fcm): Add MessagingDeviceGroupResponse as sendToDevice return type

### DIFF
--- a/src/messaging.d.ts
+++ b/src/messaging.d.ts
@@ -1229,7 +1229,7 @@ export namespace admin.messaging {
       registrationToken: string | string[],
       payload: admin.messaging.MessagingPayload,
       options?: admin.messaging.MessagingOptions
-    ): Promise<admin.messaging.MessagingDevicesResponse>;
+    ): Promise<admin.messaging.MessagingDevicesResponse | admin.messaging.MessagingDeviceGroupResponse>;
 
     /**
      * Sends an FCM message to a device group corresponding to the provided


### PR DESCRIPTION
While working on refactoring FCM I realized that there is a slight discrepancy between `sendToDevice`'s source and typing file with respect to the return type. Not sure if this is the best approach to address it.

### Source
https://github.com/firebase/firebase-admin-node/blob/f3d9da5d727e84c9c8dcf0e9484608e0c2b615c4/src/messaging/messaging.ts#L378-L382

### Typing
https://github.com/firebase/firebase-admin-node/blob/f3d9da5d727e84c9c8dcf0e9484608e0c2b615c4/src/messaging.d.ts#L1228-L1232

I figured that since there is a reason for having the `MessagingDeviceGroupResponse` return type, as mentioned below, that the typings might require a change.

https://github.com/firebase/firebase-admin-node/blob/f3d9da5d727e84c9c8dcf0e9484608e0c2b615c4/src/messaging/messaging.ts#L412-L421

Feedback appreciated!