### PR TITLE
fix(auth): Address several auth typing inconsistencies

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1174,7 +1174,6 @@ export namespace admin.auth {
      * configuration.
      */
     callbackURL?: string;
-
   }
 
   /**

--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -820,7 +820,7 @@ export namespace admin.auth {
      * When not provided in an `admin.auth.TenantAwareAuth` context, the user is uploaded
      * to the tenant corresponding to that `TenantAwareAuth` instance's tenant ID.
      */
-    tenantId?: string | null;
+    tenantId?: string;
 
     /**
      * The user's multi-factor related properties.
@@ -1175,10 +1175,6 @@ export namespace admin.auth {
      */
     callbackURL?: string;
 
-    /**
-     * The ability for SAML provider to perform request signing.
-     */
-    enableRequestSigning?: boolean;
   }
 
   /**
@@ -1263,12 +1259,6 @@ export namespace admin.auth {
      * configuration's value is not modified.
      */
     callbackURL?: string;
-
-    /**
-     * Whether the SAML provider can sign requests. If not provided, the existing
-     * configuration's value is not modified.
-     */
-    enableRequestSigning?: boolean;
   }
 
   /**

--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1174,6 +1174,11 @@ export namespace admin.auth {
      * configuration.
      */
     callbackURL?: string;
+
+    /**
+     * The ability for SAML provider to perform request signing.
+     */
+    enableRequestSigning?: boolean;
   }
 
   /**
@@ -1258,6 +1263,12 @@ export namespace admin.auth {
      * configuration's value is not modified.
      */
     callbackURL?: string;
+
+    /**
+     * Whether the SAML provider can sign requests. If not provided, the existing
+     * configuration's value is not modified.
+     */
+    enableRequestSigning?: boolean;
   }
 
   /**

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -99,6 +99,7 @@ export interface DecodedIdToken {
     sign_in_provider: string;
     sign_in_second_factor?: string;
     second_factor_identifier?: string;
+    tenant?: string;
     [key: string]: any;
   };
   iat: number;
@@ -106,7 +107,6 @@ export interface DecodedIdToken {
   phone_number?: string;
   picture?: string;
   sub: string;
-  tenant?: string;
   uid: string;
   [key: string]: any;
 }

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -78,7 +78,7 @@ export interface UserImportRecord {
   customClaims?: {[key: string]: any};
   passwordHash?: Buffer;
   passwordSalt?: Buffer;
-  tenantId?: string | null;
+  tenantId?: string;
 }
 
 /** Interface representing an Auth second factor in Auth server format. */
@@ -114,7 +114,7 @@ interface UploadAccountUser {
   lastLoginAt?: number;
   createdAt?: number;
   customAttributes?: string;
-  tenantId?: string | null;
+  tenantId?: string;
 }
 
 

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -78,7 +78,7 @@ export interface UserImportRecord {
   customClaims?: {[key: string]: any};
   passwordHash?: Buffer;
   passwordSalt?: Buffer;
-  tenantId?: string;
+  tenantId?: string | null;
 }
 
 /** Interface representing an Auth second factor in Auth server format. */
@@ -114,7 +114,7 @@ interface UploadAccountUser {
   lastLoginAt?: number;
   createdAt?: number;
   customAttributes?: string;
-  tenantId?: string;
+  tenantId?: string | null;
 }
 
 

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -148,9 +148,9 @@ export enum MultiFactorId {
  */
 export abstract class MultiFactorInfo {
   public readonly uid: string;
-  public readonly displayName: string;
+  public readonly displayName?: string;
   public readonly factorId: MultiFactorId;
-  public readonly enrollmentTime: string;
+  public readonly enrollmentTime?: string;
 
   /**
    * Initializes the MultiFactorInfo associated subclass using the server side.


### PR DESCRIPTION
During my work for refactoring auth to auto-generate typings I came across several inconsistencies in source and typing files. I'm not sure how to best address them or which require changes, but I did an attempt here.

#### 1. `auth.ts`
Observation: The `tenant` field is defined at the root of the object in the source while it's in the `firebase` scope in the typings.

Source:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/auth.ts#L88-L112

Typing:
https://github.com/firebase/firebase-admin-node/blob/e415188c700a9ba8c2f3eac4fbf09ce598d095b4/src/auth.d.ts#L456-L491

#### 2. `auth-config.ts`
Observation: The `SAMLAuthProviderConfig` contains an `enableRequestSigning` in the source which is absent in typings.

Source:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/auth-config.ts#L42-L50

Typing:
https://github.com/firebase/firebase-admin-node/blob/e415188c700a9ba8c2f3eac4fbf09ce598d095b4/src/auth.d.ts#L1139-L1177

As an extension, a similar pattern can be found here for `SAMLAuthProviderConfig`:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/auth-config.ts#L118-L128

#### 3. `user-import-builder.ts`
Observation: The `tenantId` for `UserImportRecord` is nullable in typings but not source.

Source:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/user-import-builder.ts#L64-L82

Typing:
https://github.com/firebase/firebase-admin-node/blob/e415188c700a9ba8c2f3eac4fbf09ce598d095b4/src/auth.d.ts#L816-L823

#### 4. `auth-config.ts`

Observation: As a consequence from the third point, the `tenantId` field is nullable in one case so it should be propagated.

Source:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/user-import-builder.ts#L95-L118

https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/user-import-builder.ts#L216-L229

This would be a compilation error:

> Type 'string | null | undefined' is not assignable to type 'string | undefined'.
  Type 'null' is not assignable to type 'string | undefined'.

#### 5. `user-record.ts`
The typings have `displayName` and `enrollmentTime` as optional while not in the source. 

Source:
https://github.com/firebase/firebase-admin-node/blob/5e6ebfa57649c425961351fbf772df4fead4f2f8/src/auth/user-record.ts#L149-L153

Typing:
https://github.com/firebase/firebase-admin-node/blob/e415188c700a9ba8c2f3eac4fbf09ce598d095b4/src/auth.d.ts#L80-L106
