### PR TITLE
auth: Add credential service

### DIFF
--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -15,7 +15,7 @@
  */
 
 import { FirebaseApp } from '../firebase-app';
-import { ServiceAccountCredential } from './credential';
+import { ServiceAccountCredential } from '../credential/credential';
 import { AuthClientErrorCode, FirebaseAuthError } from '../utils/error';
 import { AuthorizedHttpClient, HttpError, HttpRequestConfig, HttpClient } from '../utils/api-request';
 

--- a/src/credential.d.ts
+++ b/src/credential.d.ts
@@ -30,36 +30,36 @@ export namespace admin.credential {
   /**
    * Returns a credential created from the
    * {@link
-    *    https://developers.google.com/identity/protocols/application-default-credentials
-    *    Google Application Default Credentials}
-    * that grants admin access to Firebase services. This credential can be used
-    * in the call to
-    * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *  `admin.initializeApp()`}.
-    *
-    * Google Application Default Credentials are available on any Google
-    * infrastructure, such as Google App Engine and Google Compute Engine.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * admin.initializeApp({
-    *   credential: admin.credential.applicationDefault(),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param {!Object=} httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return {!admin.credential.Credential} A credential authenticated via Google
-    *   Application Default Credentials that can be used to initialize an app.
+   *    https://developers.google.com/identity/protocols/application-default-credentials
+   *    Google Application Default Credentials}
+   * that grants admin access to Firebase services. This credential can be used
+   * in the call to
+   * {@link
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *  `admin.initializeApp()`}.
+   *
+   * Google Application Default Credentials are available on any Google
+   * infrastructure, such as Google App Engine and Google Compute Engine.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * admin.initializeApp({
+   *   credential: admin.credential.applicationDefault(),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param {!Object=} httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return {!admin.credential.Credential} A credential authenticated via Google
+   *   Application Default Credentials that can be used to initialize an app.
    */
   function applicationDefault(httpAgent?: Agent): admin.credential.Credential;
 
@@ -68,45 +68,45 @@ export namespace admin.credential {
    * admin access to Firebase services. This credential can be used in the call
    * to
    * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *   `admin.initializeApp()`}.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * // Providing a path to a service account key JSON file
-    * var serviceAccount = require("path/to/serviceAccountKey.json");
-    * admin.initializeApp({
-    *   credential: admin.credential.cert(serviceAccount),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @example
-    * ```javascript
-    * // Providing a service account object inline
-    * admin.initializeApp({
-    *   credential: admin.credential.cert({
-    *     projectId: "<PROJECT_ID>",
-    *     clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
-    *     privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
-    *   }),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param serviceAccountPathOrObject The path to a service
-    *   account key JSON file or an object representing a service account key.
-    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return A credential authenticated via the
-    *   provided service account that can be used to initialize an app.
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *   `admin.initializeApp()`}.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * // Providing a path to a service account key JSON file
+   * var serviceAccount = require("path/to/serviceAccountKey.json");
+   * admin.initializeApp({
+   *   credential: admin.credential.cert(serviceAccount),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @example
+   * ```javascript
+   * // Providing a service account object inline
+   * admin.initializeApp({
+   *   credential: admin.credential.cert({
+   *     projectId: "<PROJECT_ID>",
+   *     clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
+   *     privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
+   *   }),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param serviceAccountPathOrObject The path to a service
+   *   account key JSON file or an object representing a service account key.
+   * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return A credential authenticated via the
+   *   provided service account that can be used to initialize an app.
    */
   function cert(serviceAccountPathOrObject: string | _admin.ServiceAccount, httpAgent?: Agent): admin.credential.Credential;
 

--- a/src/credential.d.ts
+++ b/src/credential.d.ts
@@ -1,0 +1,147 @@
+import * as _admin from './index.d';
+import { Agent } from 'http';
+
+export namespace admin.credential {
+  /**
+   * Interface that provides Google OAuth2 access tokens used to authenticate
+   * with Firebase services.
+   *
+   * In most cases, you will not need to implement this yourself and can instead
+   * use the default implementations provided by
+   * {@link admin.credential `admin.credential`}.
+   */
+  interface Credential {
+
+    /**
+     * Returns a Google OAuth2 access token object used to authenticate with
+     * Firebase services.
+     *
+     * This object contains the following properties:
+     * * `access_token` (`string`): The actual Google OAuth2 access token.
+     * * `expires_in` (`number`): The number of seconds from when the token was
+     *   issued that it expires.
+     *
+     * @return A Google OAuth2 access token object.
+     */
+    getAccessToken(): Promise<_admin.GoogleOAuthAccessToken>;
+  }
+
+
+  /**
+   * Returns a credential created from the
+   * {@link
+    *    https://developers.google.com/identity/protocols/application-default-credentials
+    *    Google Application Default Credentials}
+    * that grants admin access to Firebase services. This credential can be used
+    * in the call to
+    * {@link
+    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+    *  `admin.initializeApp()`}.
+    *
+    * Google Application Default Credentials are available on any Google
+    * infrastructure, such as Google App Engine and Google Compute Engine.
+    *
+    * See
+    * {@link
+    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+    *   Initialize the SDK}
+    * for more details.
+    *
+    * @example
+    * ```javascript
+    * admin.initializeApp({
+    *   credential: admin.credential.applicationDefault(),
+    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+    * });
+    * ```
+    *
+    * @param {!Object=} httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+    *   to be used when retrieving access tokens from Google token servers.
+    *
+    * @return {!admin.credential.Credential} A credential authenticated via Google
+    *   Application Default Credentials that can be used to initialize an app.
+   */
+  function applicationDefault(httpAgent?: Agent): admin.credential.Credential;
+
+  /**
+   * Returns a credential created from the provided service account that grants
+   * admin access to Firebase services. This credential can be used in the call
+   * to
+   * {@link
+    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+    *   `admin.initializeApp()`}.
+    *
+    * See
+    * {@link
+    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+    *   Initialize the SDK}
+    * for more details.
+    *
+    * @example
+    * ```javascript
+    * // Providing a path to a service account key JSON file
+    * var serviceAccount = require("path/to/serviceAccountKey.json");
+    * admin.initializeApp({
+    *   credential: admin.credential.cert(serviceAccount),
+    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+    * });
+    * ```
+    *
+    * @example
+    * ```javascript
+    * // Providing a service account object inline
+    * admin.initializeApp({
+    *   credential: admin.credential.cert({
+    *     projectId: "<PROJECT_ID>",
+    *     clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
+    *     privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
+    *   }),
+    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+    * });
+    * ```
+    *
+    * @param serviceAccountPathOrObject The path to a service
+    *   account key JSON file or an object representing a service account key.
+    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+    *   to be used when retrieving access tokens from Google token servers.
+    *
+    * @return A credential authenticated via the
+    *   provided service account that can be used to initialize an app.
+   */
+  function cert(serviceAccountPathOrObject: string | _admin.ServiceAccount, httpAgent?: Agent): admin.credential.Credential;
+
+  /**
+   * Returns a credential created from the provided refresh token that grants
+   * admin access to Firebase services. This credential can be used in the call
+   * to
+   * {@link
+    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+    *   `admin.initializeApp()`}.
+    *
+    * See
+    * {@link
+    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+    *   Initialize the SDK}
+    * for more details.
+    *
+    * @example
+    * ```javascript
+    * // Providing a path to a refresh token JSON file
+    * var refreshToken = require("path/to/refreshToken.json");
+    * admin.initializeApp({
+    *   credential: admin.credential.refreshToken(refreshToken),
+    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+    * });
+    * ```
+    *
+    * @param refreshTokenPathOrObject The path to a Google
+    *   OAuth2 refresh token JSON file or an object representing a Google OAuth2
+    *   refresh token.
+    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+    *   to be used when retrieving access tokens from Google token servers.
+    *
+    * @return A credential authenticated via the
+    *   provided service account that can be used to initialize an app.
+   */
+  function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): admin.credential.Credential;
+}

--- a/src/credential.d.ts
+++ b/src/credential.d.ts
@@ -115,33 +115,33 @@ export namespace admin.credential {
    * admin access to Firebase services. This credential can be used in the call
    * to
    * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *   `admin.initializeApp()`}.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * // Providing a path to a refresh token JSON file
-    * var refreshToken = require("path/to/refreshToken.json");
-    * admin.initializeApp({
-    *   credential: admin.credential.refreshToken(refreshToken),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param refreshTokenPathOrObject The path to a Google
-    *   OAuth2 refresh token JSON file or an object representing a Google OAuth2
-    *   refresh token.
-    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return A credential authenticated via the
-    *   provided service account that can be used to initialize an app.
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *   `admin.initializeApp()`}.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * // Providing a path to a refresh token JSON file
+   * var refreshToken = require("path/to/refreshToken.json");
+   * admin.initializeApp({
+   *   credential: admin.credential.refreshToken(refreshToken),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param refreshTokenPathOrObject The path to a Google
+   *   OAuth2 refresh token JSON file or an object representing a Google OAuth2
+   *   refresh token.
+   * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return A credential authenticated via the
+   *   provided service account that can be used to initialize an app.
    */
   function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): admin.credential.Credential;
 }

--- a/src/credential/credential.ts
+++ b/src/credential/credential.ts
@@ -20,8 +20,10 @@ import os = require('os');
 import path = require('path');
 
 import { AppErrorCodes, FirebaseAppError } from '../utils/error';
+import { FirebaseApp } from '../firebase-app';
 import { HttpClient, HttpRequestConfig, HttpError, HttpResponse } from '../utils/api-request';
 import { Agent } from 'http';
+import { FirebaseServiceInterface, FirebaseServiceInternalsInterface } from '../firebase-service';
 import * as util from '../utils/validator';
 
 const GOOGLE_TOKEN_AUDIENCE = 'https://accounts.google.com/o/oauth2/token';
@@ -53,6 +55,11 @@ const REFRESH_TOKEN_PATH = '/oauth2/v4/token';
 const ONE_HOUR_IN_SECONDS = 60 * 60;
 const JWT_ALGORITHM = 'RS256';
 
+let globalAppDefaultCred: Credential;
+const globalCertCreds: { [key: string]: ServiceAccountCredential } = {};
+const globalRefreshTokenCreds: { [key: string]: RefreshTokenCredential } = {};
+
+
 /**
  * Interface for Google OAuth 2.0 access tokens.
  */
@@ -68,6 +75,68 @@ export interface GoogleOAuthAccessToken {
  */
 export interface Credential {
   getAccessToken(): Promise<GoogleOAuthAccessToken>;
+}
+
+/**
+ * Internals of an InstanceId service instance.
+ */
+export class CredentialServiceInternals implements FirebaseServiceInternalsInterface {
+  /**
+   * Deletes the service and its associated resources.
+   *
+   * @return {Promise<()>} An empty Promise that will be fulfilled when the service is deleted.
+   */
+  public delete(): Promise<void> {
+    // There are no resources to clean up
+    return Promise.resolve(undefined);
+  }
+}
+
+
+export class CredentialService implements FirebaseServiceInterface {
+  public INTERNAL: CredentialServiceInternals = new CredentialServiceInternals();
+  private readonly app_: FirebaseApp;
+
+  /**
+   * @param {object} app The app for this Auth service.
+   * @constructor
+   */
+  constructor(app: FirebaseApp) {
+    this.app_ = app;
+  }
+
+  /**
+   * Returns the app associated with this Auth instance.
+   *
+   * @return {FirebaseApp} The app associated with this Auth instance.
+   */
+  get app(): FirebaseApp {
+    return this.app_;
+  }
+
+  static cert(serviceAccountPathOrObject: string | object, httpAgent?: Agent): Credential {
+    const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
+    if (!(stringifiedServiceAccount in globalCertCreds)) {
+      globalCertCreds[stringifiedServiceAccount] = new ServiceAccountCredential(serviceAccountPathOrObject, httpAgent);
+    }
+    return globalCertCreds[stringifiedServiceAccount];
+  }
+
+  static refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential {
+    const stringifiedRefreshToken = JSON.stringify(refreshTokenPathOrObject);
+    if (!(stringifiedRefreshToken in globalRefreshTokenCreds)) {
+      globalRefreshTokenCreds[stringifiedRefreshToken] = new RefreshTokenCredential(
+        refreshTokenPathOrObject, httpAgent);
+    }
+    return globalRefreshTokenCreds[stringifiedRefreshToken];
+  }
+
+  static applicationDefault(httpAgent?: Agent): Credential {
+    if (typeof globalAppDefaultCred === 'undefined') {
+      globalAppDefaultCred = getApplicationDefault(httpAgent);
+    }
+    return globalAppDefaultCred;
+  }
 }
 
 /**

--- a/src/credential/credential.ts
+++ b/src/credential/credential.ts
@@ -71,9 +71,25 @@ export interface GoogleOAuthAccessToken {
 }
 
 /**
- * Interface for things that generate access tokens.
+ * Interface that provides Google OAuth2 access tokens used to authenticate
+ * with Firebase services.
+ *
+ * In most cases, you will not need to implement this yourself and can instead
+ * use the default implementations provided by
+ * {@link admin.credential `admin.credential`}.
  */
 export interface Credential {
+  /**
+   * Returns a Google OAuth2 access token object used to authenticate with
+   * Firebase services.
+   *
+   * This object contains the following properties:
+   * * `access_token` (`string`): The actual Google OAuth2 access token.
+   * * `expires_in` (`number`): The number of seconds from when the token was
+   *   issued that it expires.
+   *
+   * @return A Google OAuth2 access token object.
+   */
   getAccessToken(): Promise<GoogleOAuthAccessToken>;
 }
 
@@ -114,6 +130,92 @@ export class CredentialService implements FirebaseServiceInterface {
     return this.app_;
   }
 
+  /**
+   * Returns a credential created from the
+   * {@link
+   *    https://developers.google.com/identity/protocols/application-default-credentials
+   *    Google Application Default Credentials}
+   * that grants admin access to Firebase services. This credential can be used
+   * in the call to
+   * {@link
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *  `admin.initializeApp()`}.
+   *
+   * Google Application Default Credentials are available on any Google
+   * infrastructure, such as Google App Engine and Google Compute Engine.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * admin.initializeApp({
+   *   credential: admin.credential.applicationDefault(),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param {!Object=} httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return {!admin.credential.Credential} A credential authenticated via Google
+   *   Application Default Credentials that can be used to initialize an app.
+   */
+  static applicationDefault(httpAgent?: Agent): Credential {
+    if (typeof globalAppDefaultCred === 'undefined') {
+      globalAppDefaultCred = getApplicationDefault(httpAgent);
+    }
+    return globalAppDefaultCred;
+  }
+
+  /**
+   * Returns a credential created from the provided service account that grants
+   * admin access to Firebase services. This credential can be used in the call
+   * to
+   * {@link
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *   `admin.initializeApp()`}.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * // Providing a path to a service account key JSON file
+   * var serviceAccount = require("path/to/serviceAccountKey.json");
+   * admin.initializeApp({
+   *   credential: admin.credential.cert(serviceAccount),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @example
+   * ```javascript
+   * // Providing a service account object inline
+   * admin.initializeApp({
+   *   credential: admin.credential.cert({
+   *     projectId: "<PROJECT_ID>",
+   *     clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
+   *     privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
+   *   }),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param serviceAccountPathOrObject The path to a service
+   *   account key JSON file or an object representing a service account key.
+   * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return A credential authenticated via the
+   *   provided service account that can be used to initialize an app.
+   */
   static cert(serviceAccountPathOrObject: string | object, httpAgent?: Agent): Credential {
     const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
     if (!(stringifiedServiceAccount in globalCertCreds)) {
@@ -122,6 +224,39 @@ export class CredentialService implements FirebaseServiceInterface {
     return globalCertCreds[stringifiedServiceAccount];
   }
 
+  /**
+   * Returns a credential created from the provided refresh token that grants
+   * admin access to Firebase services. This credential can be used in the call
+   * to
+   * {@link
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *   `admin.initializeApp()`}.
+   *
+   * See
+   * {@link
+   *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+   *   Initialize the SDK}
+   * for more details.
+   *
+   * @example
+   * ```javascript
+   * // Providing a path to a refresh token JSON file
+   * var refreshToken = require("path/to/refreshToken.json");
+   * admin.initializeApp({
+   *   credential: admin.credential.refreshToken(refreshToken),
+   *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+   * });
+   * ```
+   *
+   * @param refreshTokenPathOrObject The path to a Google
+   *   OAuth2 refresh token JSON file or an object representing a Google OAuth2
+   *   refresh token.
+   * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   *   to be used when retrieving access tokens from Google token servers.
+   *
+   * @return A credential authenticated via the
+   *   provided service account that can be used to initialize an app.
+   */
   static refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential {
     const stringifiedRefreshToken = JSON.stringify(refreshTokenPathOrObject);
     if (!(stringifiedRefreshToken in globalRefreshTokenCreds)) {
@@ -129,13 +264,6 @@ export class CredentialService implements FirebaseServiceInterface {
         refreshTokenPathOrObject, httpAgent);
     }
     return globalRefreshTokenCreds[stringifiedRefreshToken];
-  }
-
-  static applicationDefault(httpAgent?: Agent): Credential {
-    if (typeof globalAppDefaultCred === 'undefined') {
-      globalAppDefaultCred = getApplicationDefault(httpAgent);
-    }
-    return globalAppDefaultCred;
   }
 }
 

--- a/src/credential/index.ts
+++ b/src/credential/index.ts
@@ -14,22 +14,11 @@
  * limitations under the License.
  */
 
-import { FirebaseApp } from '../firebase-app';
 import * as credentialApi from './credential';
-import * as firebaseAdmin from '../index';
-
-export function credential(app?: FirebaseApp): credentialApi.CredentialService {
-  if (typeof (app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.credential();
-}
 
 /**
- * We must define a namespace to make the typings work correctly. Otherwise
- * `admin.credential()` cannot be called like a function. Temporarily,
- * admin.credential is used as the namespace name because we cannot barrel
- * re-export the contents from credential.ts, and we want it to
+ * Temporarily, admin.credential is used as the namespace name because we
+ * cannot barrel re-export the contents from credential.ts, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -40,7 +29,7 @@ export namespace admin.credential {
   // Allows for exposing classes as interfaces in typings
   /* eslint-disable @typescript-eslint/no-empty-interface */
   export import Credential = credentialApi.Credential;
-  export const applicationDefault = credentialApi.CredentialService.applicationDefault;
-  export const cert = credentialApi.CredentialService.cert;
-  export const refreshToken = credentialApi.CredentialService.refreshToken;
+  export const applicationDefault = credentialApi.applicationDefault;
+  export const cert = credentialApi.cert;
+  export const refreshToken = credentialApi.refreshToken;
 }

--- a/src/credential/index.ts
+++ b/src/credential/index.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from '../firebase-app';
+import * as credentialApi from './credential';
+import * as firebaseAdmin from '../index';
+
+export function credential(app?: FirebaseApp): credentialApi.CredentialService {
+  if (typeof (app) === 'undefined') {
+    app = firebaseAdmin.app();
+  }
+  return app.credential();
+}
+
+/**
+ * We must define a namespace to make the typings work correctly. Otherwise
+ * `admin.credential()` cannot be called like a function. Temporarily,
+ * admin.credential is used as the namespace name because we cannot barrel
+ * re-export the contents from credential.ts, and we want it to
+ * match the namespacing in the re-export inside src/index.d.ts
+ */
+/* eslint-disable @typescript-eslint/no-namespace */
+export namespace admin.credential {
+  // See https://github.com/microsoft/TypeScript/issues/4336
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // See https://github.com/typescript-eslint/typescript-eslint/issues/363
+  // Allows for exposing classes as interfaces in typings
+  /* eslint-disable @typescript-eslint/no-empty-interface */
+  export import Credential = credentialApi.Credential;
+  export const applicationDefault = credentialApi.CredentialService.applicationDefault;
+  export const cert = credentialApi.CredentialService.cert;
+  export const refreshToken = credentialApi.CredentialService.refreshToken;
+}

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -305,7 +305,7 @@ export class FirebaseApp {
   /**
    * Returns the Credential service instance associated with this app.
    *
-   * @return {Credential} The Auth service instance of this app.
+   * @return {Credential} The Credential service instance of this app.
    */
   public credential(): CredentialService {
     return this.ensureService_('credential', () => {

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Credential, GoogleOAuthAccessToken, getApplicationDefault } from './auth/credential';
+import {
+  Credential, CredentialService, GoogleOAuthAccessToken, getApplicationDefault
+} from './credential/credential';
 import * as validator from './utils/validator';
 import { deepCopy, deepExtend } from './utils/deep-copy';
 import { FirebaseServiceInterface } from './firebase-service';
@@ -297,6 +299,18 @@ export class FirebaseApp {
     return this.ensureService_('auth', () => {
       const authService: typeof Auth = require('./auth/auth').Auth;
       return new authService(this);
+    });
+  }
+
+  /**
+   * Returns the Credential service instance associated with this app.
+   *
+   * @return {Credential} The Auth service instance of this app.
+   */
+  public credential(): CredentialService {
+    return this.ensureService_('credential', () => {
+      const credentialService: typeof CredentialService = require('./credential/credential').CredentialService;
+      return new credentialService(this);
     });
   }
 

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  Credential, CredentialService, GoogleOAuthAccessToken, getApplicationDefault
+  Credential, GoogleOAuthAccessToken, getApplicationDefault
 } from './credential/credential';
 import * as validator from './utils/validator';
 import { deepCopy, deepExtend } from './utils/deep-copy';
@@ -299,18 +299,6 @@ export class FirebaseApp {
     return this.ensureService_('auth', () => {
       const authService: typeof Auth = require('./auth/auth').Auth;
       return new authService(this);
-    });
-  }
-
-  /**
-   * Returns the Credential service instance associated with this app.
-   *
-   * @return {Credential} The Credential service instance of this app.
-   */
-  public credential(): CredentialService {
-    return this.ensureService_('credential', () => {
-      const credentialService: typeof CredentialService = require('./credential/credential').CredentialService;
-      return new credentialService(this);
     });
   }
 

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -15,17 +15,14 @@
  */
 
 import fs = require('fs');
-import { Agent } from 'http';
 import { deepExtend } from './utils/deep-copy';
 import { AppErrorCodes, FirebaseAppError } from './utils/error';
 import { AppHook, FirebaseApp, FirebaseAppOptions } from './firebase-app';
 import { FirebaseServiceFactory, FirebaseServiceInterface } from './firebase-service';
 import {
-  Credential,
-  RefreshTokenCredential,
-  ServiceAccountCredential,
+  CredentialService,
   getApplicationDefault,
-} from './auth/credential';
+} from './credential/credential';
 
 import { Auth } from './auth/auth';
 import { MachineLearning } from './machine-learning/machine-learning';
@@ -49,12 +46,6 @@ const DEFAULT_APP_NAME = '[DEFAULT]';
  * otherwise it will be assumed to be pointing to a file.
  */
 export const FIREBASE_CONFIG_VAR = 'FIREBASE_CONFIG';
-
-
-let globalAppDefaultCred: Credential;
-const globalCertCreds: { [key: string]: ServiceAccountCredential } = {};
-const globalRefreshTokenCreds: { [key: string]: RefreshTokenCredential } = {};
-
 
 export interface FirebaseServiceNamespace <T> {
   (app?: FirebaseApp): T;
@@ -273,6 +264,7 @@ export class FirebaseNamespaceInternals {
 }
 
 
+/* 
 const firebaseCredential = {
   cert: (serviceAccountPathOrObject: string | object, httpAgent?: Agent): Credential => {
     const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
@@ -297,7 +289,7 @@ const firebaseCredential = {
     }
     return globalAppDefaultCred;
   },
-};
+}; */
 
 
 /**
@@ -309,7 +301,7 @@ export class FirebaseNamespace {
   public __esModule = true;
   /* tslint:enable:variable-name */
 
-  public credential = firebaseCredential;
+  // public credential = firebaseCredential; // TODO(hlazu): Remove!
   public SDK_VERSION = getSdkVersion();
   public INTERNAL: FirebaseNamespaceInternals;
 
@@ -333,6 +325,14 @@ export class FirebaseNamespace {
     };
     const auth = require('./auth/auth').Auth;
     return Object.assign(fn, { Auth: auth });
+  }
+
+  get credential(): FirebaseServiceNamespace<CredentialService> {
+    const fn: FirebaseServiceNamespace<CredentialService> = (app?: FirebaseApp) => {
+      return this.ensureApp(app).credential();
+    };
+    const credential = require('./credential/credential').CredentialService;
+    return Object.assign(fn, credential);
   }
 
   /**

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -20,8 +20,7 @@ import { AppErrorCodes, FirebaseAppError } from './utils/error';
 import { AppHook, FirebaseApp, FirebaseAppOptions } from './firebase-app';
 import { FirebaseServiceFactory, FirebaseServiceInterface } from './firebase-service';
 import {
-  getApplicationDefault,
-  cert, refreshToken, applicationDefault
+  getApplicationDefault, cert, refreshToken, applicationDefault
 } from './credential/credential';
 
 import { Auth } from './auth/auth';
@@ -266,6 +265,7 @@ export class FirebaseNamespaceInternals {
 const firebaseCredential = {
   cert, refreshToken, applicationDefault
 };
+
 
 /**
  * Global Firebase context object.

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -19,7 +19,10 @@ import { deepExtend } from './utils/deep-copy';
 import { AppErrorCodes, FirebaseAppError } from './utils/error';
 import { AppHook, FirebaseApp, FirebaseAppOptions } from './firebase-app';
 import { FirebaseServiceFactory, FirebaseServiceInterface } from './firebase-service';
-import { CredentialService, getApplicationDefault } from './credential/credential';
+import {
+  getApplicationDefault,
+  cert, refreshToken, applicationDefault
+} from './credential/credential';
 
 import { Auth } from './auth/auth';
 import { MachineLearning } from './machine-learning/machine-learning';
@@ -260,6 +263,10 @@ export class FirebaseNamespaceInternals {
   }
 }
 
+const firebaseCredential = {
+  cert, refreshToken, applicationDefault
+};
+
 /**
  * Global Firebase context object.
  */
@@ -269,6 +276,7 @@ export class FirebaseNamespace {
   public __esModule = true;
   /* tslint:enable:variable-name */
 
+  public credential = firebaseCredential;
   public SDK_VERSION = getSdkVersion();
   public INTERNAL: FirebaseNamespaceInternals;
 
@@ -292,14 +300,6 @@ export class FirebaseNamespace {
     };
     const auth = require('./auth/auth').Auth;
     return Object.assign(fn, { Auth: auth });
-  }
-
-  get credential(): FirebaseServiceNamespace<CredentialService> {
-    const fn: FirebaseServiceNamespace<CredentialService> = (app?: FirebaseApp) => {
-      return this.ensureApp(app).credential();
-    };
-    const credential = require('./credential/credential').CredentialService;
-    return Object.assign(fn, credential);
   }
 
   /**

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -19,10 +19,7 @@ import { deepExtend } from './utils/deep-copy';
 import { AppErrorCodes, FirebaseAppError } from './utils/error';
 import { AppHook, FirebaseApp, FirebaseAppOptions } from './firebase-app';
 import { FirebaseServiceFactory, FirebaseServiceInterface } from './firebase-service';
-import {
-  CredentialService,
-  getApplicationDefault,
-} from './credential/credential';
+import { CredentialService, getApplicationDefault } from './credential/credential';
 
 import { Auth } from './auth/auth';
 import { MachineLearning } from './machine-learning/machine-learning';
@@ -263,35 +260,6 @@ export class FirebaseNamespaceInternals {
   }
 }
 
-
-/* 
-const firebaseCredential = {
-  cert: (serviceAccountPathOrObject: string | object, httpAgent?: Agent): Credential => {
-    const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
-    if (!(stringifiedServiceAccount in globalCertCreds)) {
-      globalCertCreds[stringifiedServiceAccount] = new ServiceAccountCredential(serviceAccountPathOrObject, httpAgent);
-    }
-    return globalCertCreds[stringifiedServiceAccount];
-  },
-
-  refreshToken: (refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential => {
-    const stringifiedRefreshToken = JSON.stringify(refreshTokenPathOrObject);
-    if (!(stringifiedRefreshToken in globalRefreshTokenCreds)) {
-      globalRefreshTokenCreds[stringifiedRefreshToken] = new RefreshTokenCredential(
-        refreshTokenPathOrObject, httpAgent);
-    }
-    return globalRefreshTokenCreds[stringifiedRefreshToken];
-  },
-
-  applicationDefault: (httpAgent?: Agent): Credential => {
-    if (typeof globalAppDefaultCred === 'undefined') {
-      globalAppDefaultCred = getApplicationDefault(httpAgent);
-    }
-    return globalAppDefaultCred;
-  },
-}; */
-
-
 /**
  * Global Firebase context object.
  */
@@ -301,7 +269,6 @@ export class FirebaseNamespace {
   public __esModule = true;
   /* tslint:enable:variable-name */
 
-  // public credential = firebaseCredential; // TODO(hlazu): Remove!
   public SDK_VERSION = getSdkVersion();
   public INTERNAL: FirebaseNamespaceInternals;
 

--- a/src/firestore/firestore-internal.ts
+++ b/src/firestore/firestore-internal.ts
@@ -17,7 +17,7 @@
 import { FirebaseApp } from '../firebase-app';
 import { FirebaseFirestoreError } from '../utils/error';
 import { FirebaseServiceInterface, FirebaseServiceInternalsInterface } from '../firebase-service';
-import { ServiceAccountCredential, isApplicationDefault } from '../auth/credential';
+import { ServiceAccountCredential, isApplicationDefault } from '../credential/credential';
 import { Firestore, Settings } from '@google-cloud/firestore';
 
 import * as validator from '../utils/validator';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,6 +19,7 @@ import * as _firestore from '@google-cloud/firestore';
 import { Agent } from 'http';
 
 import * as _auth from './auth';
+import * as _credential from './credential';
 import * as _database from './database';
 import * as _messaging from './messaging';
 import * as _instanceId from './instance-id';
@@ -596,149 +597,10 @@ declare namespace admin.auth {
 }
 
 declare namespace admin.credential {
-
-  /**
-   * Interface that provides Google OAuth2 access tokens used to authenticate
-   * with Firebase services.
-   *
-   * In most cases, you will not need to implement this yourself and can instead
-   * use the default implementations provided by
-   * {@link admin.credential `admin.credential`}.
-   */
-  interface Credential {
-
-    /**
-     * Returns a Google OAuth2 access token object used to authenticate with
-     * Firebase services.
-     *
-     * This object contains the following properties:
-     * * `access_token` (`string`): The actual Google OAuth2 access token.
-     * * `expires_in` (`number`): The number of seconds from when the token was
-     *   issued that it expires.
-     *
-     * @return A Google OAuth2 access token object.
-     */
-    getAccessToken(): Promise<admin.GoogleOAuthAccessToken>;
-  }
-
-
-  /**
-   * Returns a credential created from the
-   * {@link
-    *    https://developers.google.com/identity/protocols/application-default-credentials
-    *    Google Application Default Credentials}
-    * that grants admin access to Firebase services. This credential can be used
-    * in the call to
-    * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *  `admin.initializeApp()`}.
-    *
-    * Google Application Default Credentials are available on any Google
-    * infrastructure, such as Google App Engine and Google Compute Engine.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * admin.initializeApp({
-    *   credential: admin.credential.applicationDefault(),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param {!Object=} httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return {!admin.credential.Credential} A credential authenticated via Google
-    *   Application Default Credentials that can be used to initialize an app.
-   */
-  function applicationDefault(httpAgent?: Agent): admin.credential.Credential;
-
-  /**
-   * Returns a credential created from the provided service account that grants
-   * admin access to Firebase services. This credential can be used in the call
-   * to
-   * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *   `admin.initializeApp()`}.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * // Providing a path to a service account key JSON file
-    * var serviceAccount = require("path/to/serviceAccountKey.json");
-    * admin.initializeApp({
-    *   credential: admin.credential.cert(serviceAccount),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @example
-    * ```javascript
-    * // Providing a service account object inline
-    * admin.initializeApp({
-    *   credential: admin.credential.cert({
-    *     projectId: "<PROJECT_ID>",
-    *     clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
-    *     privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
-    *   }),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param serviceAccountPathOrObject The path to a service
-    *   account key JSON file or an object representing a service account key.
-    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return A credential authenticated via the
-    *   provided service account that can be used to initialize an app.
-   */
-  function cert(serviceAccountPathOrObject: string | admin.ServiceAccount, httpAgent?: Agent): admin.credential.Credential;
-
-  /**
-   * Returns a credential created from the provided refresh token that grants
-   * admin access to Firebase services. This credential can be used in the call
-   * to
-   * {@link
-    *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
-    *   `admin.initializeApp()`}.
-    *
-    * See
-    * {@link
-    *   https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-    *   Initialize the SDK}
-    * for more details.
-    *
-    * @example
-    * ```javascript
-    * // Providing a path to a refresh token JSON file
-    * var refreshToken = require("path/to/refreshToken.json");
-    * admin.initializeApp({
-    *   credential: admin.credential.refreshToken(refreshToken),
-    *   databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
-    * });
-    * ```
-    *
-    * @param refreshTokenPathOrObject The path to a Google
-    *   OAuth2 refresh token JSON file or an object representing a Google OAuth2
-    *   refresh token.
-    * @param httpAgent Optional [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
-    *   to be used when retrieving access tokens from Google token servers.
-    *
-    * @return A credential authenticated via the
-    *   provided service account that can be used to initialize an app.
-   */
-  function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): admin.credential.Credential;
+  export import Credential = _credential.admin.credential.Credential;
+  export import applicationDefault = _credential.admin.credential.applicationDefault;
+  export import cert = _credential.admin.credential.cert;
+  export import refreshToken = _credential.admin.credential.refreshToken;
 }
 
 declare namespace admin.database {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -17,7 +17,7 @@
 import { FirebaseApp } from '../firebase-app';
 import { FirebaseError } from '../utils/error';
 import { FirebaseServiceInterface, FirebaseServiceInternalsInterface } from '../firebase-service';
-import { ServiceAccountCredential, isApplicationDefault } from '../auth/credential';
+import { ServiceAccountCredential, isApplicationDefault } from '../credential/credential';
 import { Bucket, Storage as StorageClient } from '@google-cloud/storage';
 
 import * as utils from '../utils/index';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { FirebaseApp, FirebaseAppOptions } from '../firebase-app';
-import { ServiceAccountCredential, ComputeEngineCredential } from '../auth/credential';
+import { ServiceAccountCredential, ComputeEngineCredential } from '../credential/credential';
 
 import * as validator from './validator';
 

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -19,7 +19,7 @@ import fs = require('fs');
 import minimist = require('minimist');
 import path = require('path');
 import { random } from 'lodash';
-import { Credential, GoogleOAuthAccessToken } from '../../src/auth/credential';
+import { Credential, GoogleOAuthAccessToken } from '../../src/credential/credential';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const chalk = require('chalk');

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -27,7 +27,7 @@ import * as jwt from 'jsonwebtoken';
 import { FirebaseNamespace } from '../../src/firebase-namespace';
 import { FirebaseServiceInterface } from '../../src/firebase-service';
 import { FirebaseApp, FirebaseAppOptions } from '../../src/firebase-app';
-import { Credential, GoogleOAuthAccessToken, ServiceAccountCredential } from '../../src/auth/credential';
+import { Credential, GoogleOAuthAccessToken, ServiceAccountCredential } from '../../src/credential/credential';
 
 const ALGORITHM = 'RS256';
 const ONE_HOUR_IN_SECONDS = 60 * 60;

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -42,7 +42,7 @@ import {
 } from '../../../src/auth/auth-config';
 import { deepCopy } from '../../../src/utils/deep-copy';
 import { TenantManager } from '../../../src/auth/tenant-manager';
-import { ServiceAccountCredential } from '../../../src/auth/credential';
+import { ServiceAccountCredential } from '../../../src/credential/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 
 chai.should();

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -28,7 +28,7 @@ import {
   BLACKLISTED_CLAIMS, FirebaseTokenGenerator, ServiceAccountSigner, IAMSigner,
 } from '../../../src/auth/token-generator';
 
-import { ServiceAccountCredential } from '../../../src/auth/credential';
+import { ServiceAccountCredential } from '../../../src/credential/credential';
 import { AuthorizedHttpClient, HttpClient } from '../../../src/utils/api-request';
 import { FirebaseApp } from '../../../src/firebase-app';
 import * as utils from '../utils';

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -31,7 +31,7 @@ import * as mocks from '../../resources/mocks';
 import { FirebaseTokenGenerator, ServiceAccountSigner } from '../../../src/auth/token-generator';
 import * as verifier from '../../../src/auth/token-verifier';
 
-import { ServiceAccountCredential } from '../../../src/auth/credential';
+import { ServiceAccountCredential } from '../../../src/credential/credential';
 import { AuthClientErrorCode } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/firebase-app';
 

--- a/test/unit/credential/credential.spec.ts
+++ b/test/unit/credential/credential.spec.ts
@@ -33,7 +33,7 @@ import * as mocks from '../../resources/mocks';
 import {
   GoogleOAuthAccessToken, RefreshTokenCredential, ServiceAccountCredential,
   ComputeEngineCredential, getApplicationDefault, isApplicationDefault, Credential,
-} from '../../../src/auth/credential';
+} from '../../../src/credential/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import { Agent } from 'https';
 import { FirebaseAppError } from '../../../src/utils/error';

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -25,7 +25,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from './utils';
 import * as mocks from '../resources/mocks';
 
-import { GoogleOAuthAccessToken, ServiceAccountCredential } from '../../src/auth/credential';
+import { GoogleOAuthAccessToken, ServiceAccountCredential } from '../../src/credential/credential';
 import { FirebaseServiceInterface } from '../../src/firebase-service';
 import { FirebaseApp, FirebaseAccessToken } from '../../src/firebase-app';
 import { FirebaseNamespace, FirebaseNamespaceInternals, FIREBASE_CONFIG_VAR } from '../../src/firebase-namespace';

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -27,7 +27,9 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../resources/mocks';
 
 import * as firebaseAdmin from '../../src/index';
-import { RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault } from '../../src/auth/credential';
+import {
+  RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault
+} from '../../src/credential/credential';
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -21,7 +21,7 @@ import { expect } from 'chai';
 
 import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/firebase-app';
-import { ComputeEngineCredential, RefreshTokenCredential } from '../../../src/auth/credential';
+import { ComputeEngineCredential, RefreshTokenCredential } from '../../../src/credential/credential';
 import { FirestoreService, getFirestoreOptions } from '../../../src/firestore/firestore-internal';
 
 describe('Firestore', () => {

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -27,7 +27,6 @@ import './utils/api-request.spec';
 
 // Auth
 import './auth/auth.spec';
-import './auth/credential.spec';
 import './auth/user-record.spec';
 import './auth/token-generator.spec';
 import './auth/token-verifier.spec';
@@ -37,6 +36,9 @@ import './auth/action-code-settings-builder.spec';
 import './auth/auth-config.spec';
 import './auth/tenant.spec';
 import './auth/tenant-manager.spec';
+
+// Credential
+import './credential/credential.spec';
 
 // Database
 import './database/database.spec';

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../src/utils/index';
 import { isNonEmptyString } from '../../../src/utils/validator';
 import { FirebaseApp, FirebaseAppOptions } from '../../../src/firebase-app';
-import { ComputeEngineCredential } from '../../../src/auth/credential';
+import { ComputeEngineCredential } from '../../../src/credential/credential';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';
 import { FirebaseAppError } from '../../../src/utils/error';


### PR DESCRIPTION
This pull request covers the following:

1. Splits the `index.d.ts` file which allows to substitute the typings (i.e., `index.d.ts` import for `credentials` will map to `src/credential.d.ts` or `src/credential/index.d.ts` depending on if auto-generated types are toggled).
   - Note: This might introduce the duplicate "callable" bug in the documentation web-page
2. Refactors `credential.ts` to be a separate service outside of auth
3. Extracted the credentials related component of `auth/*.spec.ts` into new unit test folder `credential/*.spec.ts`
4. Adds documentation for auto-generated typings, as part of #992 


