### PR TITLE
chore: Declared admin and admin.app namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Copy generated d.ts files to the build directory.
 * Re-enable the `npm run build:tests` in CI.
+* Update return types in the methods of `FirebaseNamespace` class.
 
 # Firebase Admin Node.js SDK
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,6 @@ gulp.task('compile', function() {
 
   const configuration = [
     'lib/**/*.js',
-    'lib/credential/index.d.ts',
   ];
 
   workflow = workflow.pipe(filter(configuration));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,8 @@ gulp.task('compile', function() {
 
   const configuration = [
     'lib/**/*.js',
+    'lib/credential/index.d.ts',
+    'lib/firebase-namespace-api.d.ts',
   ];
 
   workflow = workflow.pipe(filter(configuration));

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -18,14 +18,8 @@ import { FirebaseApp } from '../firebase-app';
 import { ServerValue as sv } from '@firebase/database';
 import * as adminDb from './database';
 import * as firebaseDbTypesApi from '@firebase/database-types';
-import * as firebaseAdmin from '../index';
 
-export function database(app?: FirebaseApp): adminDb.Database {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.database();
-}
+export declare function database(app?: FirebaseApp): adminDb.Database;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { AppOptions, app } from './firebase-namespace-api';
 import { credential, GoogleOAuthAccessToken } from './credential/index';
 import { getApplicationDefault } from './credential/credential-internal';
 import * as validator from './utils/validator';
@@ -31,12 +32,9 @@ import { DatabaseService } from './database/database-internal';
 import { Firestore } from '@google-cloud/firestore';
 import { FirestoreService } from './firestore/firestore-internal';
 import { InstanceId } from './instance-id/instance-id';
-
 import { ProjectManagement } from './project-management/project-management';
 import { SecurityRules } from './security-rules/security-rules';
 import { RemoteConfig } from './remote-config/remote-config';
-
-import { Agent } from 'http';
 
 import Credential = credential.Credential;
 
@@ -44,19 +42,6 @@ import Credential = credential.Credential;
  * Type representing a callback which is called every time an app lifecycle event occurs.
  */
 export type AppHook = (event: string, app: FirebaseApp) => void;
-
-/**
- * Type representing the options object passed into initializeApp().
- */
-export interface FirebaseAppOptions {
-  credential?: Credential;
-  databaseAuthVariableOverride?: object | null;
-  databaseURL?: string;
-  serviceAccountId?: string;
-  storageBucket?: string;
-  projectId?: string;
-  httpAgent?: Agent;
-}
 
 /**
  * Type representing a Firebase OAuth access token (derived from a Google OAuth2 access token) which
@@ -243,22 +228,20 @@ export class FirebaseAppInternals {
   }
 }
 
-
-
 /**
  * Global context object for a collection of services using a shared authentication state.
  */
-export class FirebaseApp {
+export class FirebaseApp implements app.App {
   public INTERNAL: FirebaseAppInternals;
 
   private name_: string;
-  private options_: FirebaseAppOptions;
+  private options_: AppOptions;
   private services_: {[name: string]: FirebaseServiceInterface} = {};
   private isDeleted_ = false;
 
-  constructor(options: FirebaseAppOptions, name: string, private firebaseInternals_: FirebaseNamespaceInternals) {
+  constructor(options: AppOptions, name: string, private firebaseInternals_: FirebaseNamespaceInternals) {
     this.name_ = name;
-    this.options_ = deepCopy(options) as FirebaseAppOptions;
+    this.options_ = deepCopy(options);
 
     if (!validator.isNonNullObject(this.options_)) {
       throw new FirebaseAppError(
@@ -294,7 +277,7 @@ export class FirebaseApp {
   /**
    * Returns the Auth service instance associated with this app.
    *
-   * @return {Auth} The Auth service instance of this app.
+   * @return The Auth service instance of this app.
    */
   public auth(): Auth {
     return this.ensureService_('auth', () => {
@@ -306,7 +289,7 @@ export class FirebaseApp {
   /**
    * Returns the Database service for the specified URL, and the current app.
    *
-   * @return {Database} The Database service instance of this app.
+   * @return The Database service instance of this app.
    */
   public database(url?: string): Database {
     const service: DatabaseService = this.ensureService_('database', () => {
@@ -319,7 +302,7 @@ export class FirebaseApp {
   /**
    * Returns the Messaging service instance associated with this app.
    *
-   * @return {Messaging} The Messaging service instance of this app.
+   * @return The Messaging service instance of this app.
    */
   public messaging(): Messaging {
     return this.ensureService_('messaging', () => {
@@ -331,7 +314,7 @@ export class FirebaseApp {
   /**
    * Returns the Storage service instance associated with this app.
    *
-   * @return {Storage} The Storage service instance of this app.
+   * @return The Storage service instance of this app.
    */
   public storage(): Storage {
     return this.ensureService_('storage', () => {
@@ -351,7 +334,7 @@ export class FirebaseApp {
   /**
    * Returns the InstanceId service instance associated with this app.
    *
-   * @return {InstanceId} The InstanceId service instance of this app.
+   * @return The InstanceId service instance of this app.
    */
   public instanceId(): InstanceId {
     return this.ensureService_('iid', () => {
@@ -363,7 +346,7 @@ export class FirebaseApp {
   /**
    * Returns the MachineLearning service instance associated with this app.
    *
-   * @return {MachineLearning} The Machine Learning service instance of this app
+   * @return The Machine Learning service instance of this app
    */
   public machineLearning(): MachineLearning {
     return this.ensureService_('machine-learning', () => {
@@ -376,7 +359,7 @@ export class FirebaseApp {
   /**
    * Returns the ProjectManagement service instance associated with this app.
    *
-   * @return {ProjectManagement} The ProjectManagement service instance of this app.
+   * @return The ProjectManagement service instance of this app.
    */
   public projectManagement(): ProjectManagement {
     return this.ensureService_('project-management', () => {
@@ -389,7 +372,7 @@ export class FirebaseApp {
   /**
    * Returns the SecurityRules service instance associated with this app.
    *
-   * @return {SecurityRules} The SecurityRules service instance of this app.
+   * @return The SecurityRules service instance of this app.
    */
   public securityRules(): SecurityRules {
     return this.ensureService_('security-rules', () => {
@@ -402,7 +385,7 @@ export class FirebaseApp {
   /**
    * Returns the RemoteConfig service instance associated with this app.
    *
-   * @return {RemoteConfig} The RemoteConfig service instance of this app.
+   * @return The RemoteConfig service instance of this app.
    */
   public remoteConfig(): RemoteConfig {
     return this.ensureService_('remoteConfig', () => {
@@ -414,7 +397,7 @@ export class FirebaseApp {
   /**
    * Returns the name of the FirebaseApp instance.
    *
-   * @return {string} The name of the FirebaseApp instance.
+   * @return The name of the FirebaseApp instance.
    */
   get name(): string {
     this.checkDestroyed_();
@@ -424,17 +407,17 @@ export class FirebaseApp {
   /**
    * Returns the options for the FirebaseApp instance.
    *
-   * @return {FirebaseAppOptions} The options for the FirebaseApp instance.
+   * @return The options for the FirebaseApp instance.
    */
-  get options(): FirebaseAppOptions {
+  get options(): AppOptions {
     this.checkDestroyed_();
-    return deepCopy(this.options_) as FirebaseAppOptions;
+    return deepCopy(this.options_);
   }
 
   /**
    * Deletes the FirebaseApp instance.
    *
-   * @return {Promise<void>} An empty Promise fulfilled once the FirebaseApp instance is deleted.
+   * @return An empty Promise fulfilled once the FirebaseApp instance is deleted.
    */
   public delete(): Promise<void> {
     this.checkDestroyed_();
@@ -467,8 +450,8 @@ export class FirebaseApp {
    * Returns the service instance associated with this FirebaseApp instance (creating it on demand
    * if needed). This is used for looking up monkeypatched service instances.
    *
-   * @param {string} serviceName The name of the service instance to return.
-   * @return {FirebaseServiceInterface} The service instance with the provided name.
+   * @param serviceName The name of the service instance to return.
+   * @return The service instance with the provided name.
    */
   private getService_(serviceName: string): FirebaseServiceInterface {
     this.checkDestroyed_();

--- a/src/firebase-namespace-api.ts
+++ b/src/firebase-namespace-api.ts
@@ -13,3 +13,233 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { Agent } from 'http';
+import { credential } from './credential/index';
+
+/**
+ * `FirebaseError` is a subclass of the standard JavaScript `Error` object. In
+ * addition to a message string and stack trace, it contains a string code.
+ */
+export interface FirebaseError {
+
+  /**
+   * Error codes are strings using the following format: `"service/string-code"`.
+   * Some examples include `"auth/invalid-uid"` and
+   * `"messaging/invalid-recipient"`.
+   *
+   * While the message for a given error can change, the code will remain the same
+   * between backward-compatible versions of the Firebase SDK.
+   */
+  code: string;
+
+  /**
+   * An explanatory message for the error that just occurred.
+   *
+   * This message is designed to be helpful to you, the developer. Because
+   * it generally does not convey meaningful information to end users,
+   * this message should not be displayed in your application.
+   */
+  message: string;
+
+  /**
+   * A string value containing the execution backtrace when the error originally
+   * occurred.
+   *
+   * This information can be useful to you and can be sent to
+   * {@link https://firebase.google.com/support/ Firebase Support} to help
+   * explain the cause of an error.
+   */
+  stack: string;
+
+  /**
+   * @return A JSON-serializable representation of this object.
+   */
+  toJSON(): object;
+}
+
+/**
+ * Composite type which includes both a `FirebaseError` object and an index
+ * which can be used to get the errored item.
+ *
+ * @example
+ * ```javascript
+ * var registrationTokens = [token1, token2, token3];
+ * admin.messaging().subscribeToTopic(registrationTokens, 'topic-name')
+ *   .then(function(response) {
+ *     if (response.failureCount > 0) {
+ *       console.log("Following devices unsucessfully subscribed to topic:");
+ *       response.errors.forEach(function(error) {
+ *         var invalidToken = registrationTokens[error.index];
+ *         console.log(invalidToken, error.error);
+ *       });
+ *     } else {
+ *       console.log("All devices successfully subscribed to topic:", response);
+ *     }
+ *   })
+ *   .catch(function(error) {
+ *     console.log("Error subscribing to topic:", error);
+ *   });
+ *```
+  */
+export interface FirebaseArrayIndexError {
+
+  /**
+   * The index of the errored item within the original array passed as part of the
+   * called API method.
+   */
+  index: number;
+
+  /**
+   * The error object.
+   */
+  error: FirebaseError;
+}
+
+/**
+ * Available options to pass to [`initializeApp()`](admin#.initializeApp).
+ */
+export interface AppOptions {
+
+  /**
+   * A {@link admin.credential.Credential `Credential`} object used to
+   * authenticate the Admin SDK.
+   *
+   * See [Initialize the SDK](/docs/admin/setup#initialize_the_sdk) for detailed
+   * documentation and code samples.
+   */
+  credential?: credential.Credential;
+
+  /**
+   * The object to use as the [`auth`](/docs/reference/security/database/#auth)
+   * variable in your Realtime Database Rules when the Admin SDK reads from or
+   * writes to the Realtime Database. This allows you to downscope the Admin SDK
+   * from its default full read and write privileges.
+   *
+   * You can pass `null` to act as an unauthenticated client.
+   *
+   * See
+   * [Authenticate with limited privileges](/docs/database/admin/start#authenticate-with-limited-privileges)
+   * for detailed documentation and code samples.
+   */
+  databaseAuthVariableOverride?: object | null;
+
+  /**
+   * The URL of the Realtime Database from which to read and write data.
+   */
+  databaseURL?: string;
+
+  /**
+   * The ID of the service account to be used for signing custom tokens. This
+   * can be found in the `client_email` field of a service account JSON file.
+   */
+  serviceAccountId?: string;
+
+  /**
+   * The name of the Google Cloud Storage bucket used for storing application data.
+   * Use only the bucket name without any prefixes or additions (do *not* prefix
+   * the name with "gs://").
+   */
+  storageBucket?: string;
+
+  /**
+   * The ID of the Google Cloud project associated with the App.
+   */
+  projectId?: string;
+
+  /**
+   * An [HTTP Agent](https://nodejs.org/api/http.html#http_class_http_agent)
+   * to be used when making outgoing HTTP calls. This Agent instance is used
+   * by all services that make REST calls (e.g. `auth`, `messaging`,
+   * `projectManagement`).
+   *
+   * Realtime Database and Firestore use other means of communicating with
+   * the backend servers, so they do not use this HTTP Agent. `Credential`
+   * instances also do not use this HTTP Agent, but instead support
+   * specifying an HTTP Agent in the corresponding factory methods.
+   */
+  httpAgent?: Agent;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace app {
+  /**
+   * A Firebase app holds the initialization information for a collection of
+   * services.
+   *
+   * Do not call this constructor directly. Instead, use
+   * {@link
+   *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+   *   `admin.initializeApp()`}
+   * to create an app.
+   */
+  export interface App {
+
+    /**
+     * The (read-only) name for this app.
+     *
+     * The default app's name is `"[DEFAULT]"`.
+     *
+     * @example
+     * ```javascript
+     * // The default app's name is "[DEFAULT]"
+     * admin.initializeApp(defaultAppConfig);
+     * console.log(admin.app().name);  // "[DEFAULT]"
+     * ```
+     *
+     * @example
+     * ```javascript
+     * // A named app's name is what you provide to initializeApp()
+     * var otherApp = admin.initializeApp(otherAppConfig, "other");
+     * console.log(otherApp.name);  // "other"
+     * ```
+     */
+    name: string;
+
+    /**
+     * The (read-only) configuration options for this app. These are the original
+     * parameters given in
+     * {@link
+     *   https://firebase.google.com/docs/reference/admin/node/admin#.initializeApp
+     *   `admin.initializeApp()`}.
+     *
+     * @example
+     * ```javascript
+     * var app = admin.initializeApp(config);
+     * console.log(app.options.credential === config.credential);  // true
+     * console.log(app.options.databaseURL === config.databaseURL);  // true
+     * ```
+     */
+    options: AppOptions;
+
+    /**
+     * Renders this local `FirebaseApp` unusable and frees the resources of
+     * all associated services (though it does *not* clean up any backend
+     * resources). When running the SDK locally, this method
+     * must be called to ensure graceful termination of the process.
+     *
+     * @example
+     * ```javascript
+     * app.delete()
+     *   .then(function() {
+     *     console.log("App deleted successfully");
+     *   })
+     *   .catch(function(error) {
+     *     console.log("Error deleting app:", error);
+     *   });
+     * ```
+     */
+    delete(): Promise<void>;
+  }
+}
+
+// Declare other top-level members of the admin namespace below. Unfortunately, there's no
+// compile-time mechanism to ensure that the FirebaseNamespace class actually provides these
+// signatures. But this part of the API is quite small and stable. It should be easy enough to
+// enforce conformance via disciplined coding and good integration tests.
+
+export declare const SDK_VERSION: string;
+export declare const apps: (app.App | null)[];
+
+export declare function app(name?: string): app.App;
+export declare function initializeApp(options?: AppOptions, name?: string): app.App;

--- a/src/firebase-namespace-api.ts
+++ b/src/firebase-namespace-api.ts
@@ -81,7 +81,7 @@ export interface FirebaseError {
  *     console.log("Error subscribing to topic:", error);
  *   });
  *```
-  */
+ */
 export interface FirebaseArrayIndexError {
 
   /**

--- a/src/firebase-namespace.d.ts
+++ b/src/firebase-namespace.d.ts
@@ -14,8 +14,5 @@
  * limitations under the License.
  */
 
-export {
-  credential,
-  GoogleOAuthAccessToken,
-  ServiceAccount,
-} from './credential/index';
+export * from './credential/index';
+export * from './firebase-namespace-api';

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -16,19 +16,13 @@
 
 import { FirebaseApp } from '../firebase-app';
 import * as _firestore from '@google-cloud/firestore';
-import * as firebaseAdmin from '../index';
 
-export function firestore(app?: FirebaseApp): _firestore.Firestore {
-  if (typeof (app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.firestore();
-}
+export declare function firestore(app?: FirebaseApp): _firestore.Firestore;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise
  * `admin.firestore()` cannot be called like a function. Temporarily,
- * admin.firestore is used as the namespace name because we cannot barrel 
+ * admin.firestore is used as the namespace name because we cannot barrel
  * re-export the contents from firestore, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */

--- a/src/instance-id/index.ts
+++ b/src/instance-id/index.ts
@@ -16,19 +16,13 @@
 
 import { FirebaseApp } from '../firebase-app';
 import * as instanceIdApi from './instance-id';
-import * as firebaseAdmin from '../index';
 
-export function instanceId(app?: FirebaseApp): instanceIdApi.InstanceId {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.instanceId();
-}
+export declare function instanceId(app?: FirebaseApp): instanceIdApi.InstanceId;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise
  * `admin.instanceId()` cannot be called like a function. Temporarily,
- * admin.instanceId is used as the namespace name because we cannot barrel 
+ * admin.instanceId is used as the namespace name because we cannot barrel
  * re-export the contents from instance-id, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -17,14 +17,8 @@
 import { FirebaseApp } from '../firebase-app';
 import * as messagingApi from './messaging';
 import * as messagingTypesApi from './messaging-types';
-import * as firebaseAdmin from '../index';
 
-export function messaging(app?: FirebaseApp): messagingApi.Messaging {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.messaging();
-}
+export declare function messaging(app?: FirebaseApp): messagingApi.Messaging;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise

--- a/src/project-management/index.ts
+++ b/src/project-management/index.ts
@@ -19,19 +19,13 @@ import * as androidAppApi from './android-app';
 import * as appMetadataApi from './app-metadata';
 import * as iosAppApi from './ios-app';
 import * as projectManagementApi from './project-management';
-import * as firebaseAdmin from '../index';
 
-export function projectManagement(app?: FirebaseApp): projectManagementApi.ProjectManagement {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.projectManagement();
-}
+export declare function projectManagement(app?: FirebaseApp): projectManagementApi.ProjectManagement;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise
  * `admin.projectManagement()` cannot be called like a function. Temporarily,
- * admin.projectManagement is used as the namespace name because we cannot barrel 
+ * admin.projectManagement is used as the namespace name because we cannot barrel
  * re-export the contents from instance-id, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */
@@ -42,7 +36,7 @@ export namespace admin.projectManagement {
   // See https://github.com/typescript-eslint/typescript-eslint/issues/363
   export import AndroidAppMetadata = appMetadataApi.AndroidAppMetadata
   export import AppMetadata = appMetadataApi.AppMetadata
-  export import AppPlatform = appMetadataApi.AppPlatform 
+  export import AppPlatform = appMetadataApi.AppPlatform
   export import IosAppMetadata = appMetadataApi.IosAppMetadata
 
   // Allows for exposing classes as interfaces in typings

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -17,19 +17,13 @@
 import { FirebaseApp } from '../firebase-app';
 import * as remoteConfigApi from './remote-config';
 import * as remoteConfigClientApi from './remote-config-api-client';
-import * as firebaseAdmin from '../index';
 
-export function remoteConfig(app?: FirebaseApp): remoteConfigApi.RemoteConfig {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.remoteConfig();
-}
+export declare function remoteConfig(app?: FirebaseApp): remoteConfigApi.RemoteConfig;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise
  * `admin.remoteConfig()` cannot be called like a function. Temporarily,
- * admin.remoteConfig is used as the namespace name because we cannot barrel 
+ * admin.remoteConfig is used as the namespace name because we cannot barrel
  * re-export the contents from remote-config, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */

--- a/src/security-rules/index.ts
+++ b/src/security-rules/index.ts
@@ -16,19 +16,13 @@
 
 import { FirebaseApp } from '../firebase-app';
 import * as securityRulesApi from './security-rules';
-import * as firebaseAdmin from '../index';
 
-export function securityRules(app?: FirebaseApp): securityRulesApi.SecurityRules {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.securityRules();
-}
+export declare function securityRules(app?: FirebaseApp): securityRulesApi.SecurityRules;
 
 /**
  * We must define a namespace to make the typings work correctly. Otherwise
  * `admin.securityRules()` cannot be called like a function. Temporarily,
- * admin.securityRules is used as the namespace name because we cannot barrel 
+ * admin.securityRules is used as the namespace name because we cannot barrel
  * re-export the contents from security-rules, and we want it to
  * match the namespacing in the re-export inside src/index.d.ts
  */
@@ -40,8 +34,8 @@ export namespace admin.securityRules {
   export import RulesFile = securityRulesApi.RulesFile;
   export import RulesetMetadata = securityRulesApi.RulesetMetadata;
   export import RulesetMetadataList = securityRulesApi.RulesetMetadataList;
-  
-  /* eslint-disable @typescript-eslint/no-empty-interface */ 
+
+  /* eslint-disable @typescript-eslint/no-empty-interface */
   export interface Ruleset extends securityRulesApi.Ruleset {}
   export interface SecurityRules extends securityRulesApi.SecurityRules {}
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -16,14 +16,8 @@
 
 import * as _storage from './storage';
 import { FirebaseApp } from '../firebase-app';
-import * as firebaseAdmin from '../index';
 
-export function storage(app?: FirebaseApp): _storage.Storage {
-  if (typeof(app) === 'undefined') {
-    app = firebaseAdmin.app();
-  }
-  return app.storage();
-}
+export declare function storage(app?: FirebaseApp): _storage.Storage;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace admin.storage {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, FirebaseAppOptions } from '../firebase-app';
-import { ServiceAccountCredential, ComputeEngineCredential } from '../credential/credential-internal';
-
+import { app as _app } from '../firebase-namespace-api';
+import {
+  ServiceAccountCredential, ComputeEngineCredential
+} from '../credential/credential-internal';
 import * as validator from './validator';
 
 let sdkVersion: string;
@@ -70,12 +71,12 @@ export function addReadonlyGetter(obj: object, prop: string, value: any): void {
  * specified in either the Firebase app options, credentials or the local environment.
  * Otherwise returns null.
  *
- * @param {FirebaseApp} app A Firebase app to get the project ID from.
+ * @param app A Firebase app to get the project ID from.
  *
- * @return {string} A project ID string or null.
+ * @return A project ID string or null.
  */
-export function getExplicitProjectId(app: FirebaseApp): string | null {
-  const options: FirebaseAppOptions = app.options;
+export function getExplicitProjectId(app: _app.App): string | null {
+  const options = app.options;
   if (validator.isNonEmptyString(options.projectId)) {
     return options.projectId;
   }
@@ -99,11 +100,11 @@ export function getExplicitProjectId(app: FirebaseApp): string | null {
  * configured, but the SDK has been initialized with ComputeEngineCredentials, this
  * method attempts to discover the project ID from the local metadata service.
  *
- * @param {FirebaseApp} app A Firebase app to get the project ID from.
+ * @param app A Firebase app to get the project ID from.
  *
- * @return {Promise<string | null>} A project ID string or null.
+ * @return A project ID string or null.
  */
-export function findProjectId(app: FirebaseApp): Promise<string | null> {
+export function findProjectId(app: _app.App): Promise<string | null> {
   const projectId = getExplicitProjectId(app);
   if (projectId) {
     return Promise.resolve(projectId);

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -19,7 +19,7 @@ import fs = require('fs');
 import minimist = require('minimist');
 import path = require('path');
 import { random } from 'lodash';
-import { Credential, GoogleOAuthAccessToken } from '../../src/credential/credential-interfaces';
+import { GoogleOAuthAccessToken } from '../../src/credential/index';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const chalk = require('chalk');
@@ -106,7 +106,7 @@ after(() => {
   ]);
 });
 
-class CertificatelessCredential implements Credential {
+class CertificatelessCredential implements admin.credential.Credential {
   private readonly delegate: admin.credential.Credential;
 
   constructor(delegate: admin.credential.Credential) {

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -24,9 +24,10 @@ import stream = require('stream');
 import * as _ from 'lodash';
 import * as jwt from 'jsonwebtoken';
 
+import { AppOptions } from '../../src/firebase-namespace-api';
 import { FirebaseNamespace } from '../../src/firebase-namespace';
 import { FirebaseServiceInterface } from '../../src/firebase-service';
-import { FirebaseApp, FirebaseAppOptions } from '../../src/firebase-app';
+import { FirebaseApp } from '../../src/firebase-app';
 import { credential as _credential, GoogleOAuthAccessToken } from '../../src/credential/index';
 import { ServiceAccountCredential } from '../../src/credential/credential-internal';
 
@@ -52,13 +53,13 @@ export const storageBucket = 'bucketName.appspot.com';
 
 export const credential = new ServiceAccountCredential(path.resolve(__dirname, './mock.key.json'));
 
-export const appOptions: FirebaseAppOptions = {
+export const appOptions: AppOptions = {
   credential,
   databaseURL,
   storageBucket,
 };
 
-export const appOptionsWithOverride: FirebaseAppOptions = {
+export const appOptionsWithOverride: AppOptions = {
   credential,
   databaseAuthVariableOverride,
   databaseURL,
@@ -66,15 +67,15 @@ export const appOptionsWithOverride: FirebaseAppOptions = {
   projectId,
 };
 
-export const appOptionsNoAuth: FirebaseAppOptions = {
+export const appOptionsNoAuth: AppOptions = {
   databaseURL,
 };
 
-export const appOptionsNoDatabaseUrl: FirebaseAppOptions = {
+export const appOptionsNoDatabaseUrl: AppOptions = {
   credential,
 };
 
-export const appOptionsAuthDB: FirebaseAppOptions = {
+export const appOptionsAuthDB: AppOptions = {
   credential,
   databaseURL,
 };
@@ -101,7 +102,7 @@ export function mockCredentialApp(): FirebaseApp {
   }, appName, new FirebaseNamespace().INTERNAL);
 }
 
-export function appWithOptions(options: FirebaseAppOptions): FirebaseApp {
+export function appWithOptions(options: AppOptions): FirebaseApp {
   const namespaceInternals = new FirebaseNamespace().INTERNAL;
   namespaceInternals.removeApp = _.noop;
   return new FirebaseApp(options, appName, namespaceInternals);

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -20,18 +20,19 @@ import * as sinon from 'sinon';
 import * as mocks from '../resources/mocks';
 
 import { FirebaseNamespace } from '../../src/firebase-namespace';
-import { FirebaseApp, FirebaseAppOptions, FirebaseAppInternals, FirebaseAccessToken } from '../../src/firebase-app';
+import { AppOptions } from '../../src/firebase-namespace-api';
+import { FirebaseApp, FirebaseAppInternals, FirebaseAccessToken } from '../../src/firebase-app';
 import { HttpError, HttpResponse } from '../../src/utils/api-request';
 
 /**
  * Returns a new FirebaseApp instance with the provided options.
  *
- * @param {object} options The options for the FirebaseApp instance to create.
- * @return {FirebaseApp} A new FirebaseApp instance with the provided options.
+ * @param options The options for the FirebaseApp instance to create.
+ * @return A new FirebaseApp instance with the provided options.
  */
 export function createAppWithOptions(options: object): FirebaseApp {
   const mockFirebaseNamespaceInternals = new FirebaseNamespace().INTERNAL;
-  return new FirebaseApp(options as FirebaseAppOptions, mocks.appName, mockFirebaseNamespaceInternals);
+  return new FirebaseApp(options as AppOptions, mocks.appName, mockFirebaseNamespaceInternals);
 }
 
 

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -24,7 +24,7 @@ import {
   toWebSafeBase64, formatString, generateUpdateMask,
 } from '../../../src/utils/index';
 import { isNonEmptyString } from '../../../src/utils/validator';
-import { FirebaseApp, FirebaseAppOptions } from '../../../src/firebase-app';
+import { FirebaseApp } from '../../../src/firebase-app';
 import { ComputeEngineCredential } from '../../../src/credential/credential-internal';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';
@@ -104,7 +104,7 @@ describe('getExplicitProjectId()', () => {
   });
 
   it('should return the explicitly specified project ID from app options', () => {
-    const options: FirebaseAppOptions = {
+    const options = {
       credential: new mocks.MockCredential(),
       projectId: 'explicit-project-id',
     };
@@ -172,7 +172,7 @@ describe('findProjectId()', () => {
   });
 
   it('should return the explicitly specified project ID from app options', () => {
-    const options: FirebaseAppOptions = {
+    const options = {
       credential: new mocks.MockCredential(),
       projectId: 'explicit-project-id',
     };
@@ -246,7 +246,7 @@ describe('findProjectId()', () => {
   });
 
   it('should return the explicitly specified project ID from app options', () => {
-    const options: FirebaseAppOptions = {
+    const options = {
       credential: new mocks.MockCredential(),
       projectId: 'explicit-project-id',
     };


### PR DESCRIPTION
* Declared APIs of top-level admin namespace members:
  - FirebaseError
  - FirebaseArrayIndexError
  - AppOptions
  - app (namespace/function)
    - App
  - SDK_VERSION
  - initializeApp
  - apps
* Implemented the `app.App` interface in the `FirebaseApp` class.
* Using the same `AppOptions` type across the repo.