### PR TITLE
chore: Using public API types in FirebaseNamespace impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 [![Build Status](https://github.com/firebase/firebase-admin-node/workflows/Continuous%20Integration/badge.svg)](https://github.com/firebase/firebase-admin-node/actions)
 
-# TODO
-
-* Copy generated d.ts files to the build directory.
-* Update return types in the methods of `FirebaseNamespace` class.
-
 # Firebase Admin Node.js SDK
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,18 +83,9 @@ gulp.task('compile', function() {
 
   const configuration = [
     'lib/**/*.js',
-    'lib/auth/index.d.ts',
-    'lib/credential/index.d.ts',
+    'lib/**/index.d.ts',
     'lib/firebase-namespace-api.d.ts',
-    'lib/database/index.d.ts',
-    'lib/firestore/index.d.ts',
-    'lib/instance-id/index.d.ts',
-    'lib/machine-learning/index.d.ts',
-    'lib/messaging/index.d.ts',
-    'lib/project-management/index.d.ts',
-    'lib/remote-config/index.d.ts',
-    'lib/security-rules/index.d.ts',
-    'lib/storage/index.d.ts',
+    '!lib/utils/index.d.ts',
   ];
 
   workflow = workflow.pipe(filter(configuration));

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -42,7 +42,7 @@ import Database = database.Database;
 /**
  * Type representing a callback which is called every time an app lifecycle event occurs.
  */
-export type AppHook = (event: string, app: FirebaseApp) => void;
+export type AppHook = (event: string, app: app.App) => void;
 
 /**
  * Type representing a Firebase OAuth access token (derived from a Google OAuth2 access token) which

--- a/src/firebase-service.ts
+++ b/src/firebase-service.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { app } from './firebase-namespace-api';
 import { FirebaseApp } from './firebase-app';
+
+import App = app.App;
 
 /**
  * Internals of a FirebaseService instance.
@@ -27,7 +30,7 @@ export interface FirebaseServiceInternalsInterface {
  * Services are exposed through instances, each of which is associated with a FirebaseApp.
  */
 export interface FirebaseServiceInterface {
-  app: FirebaseApp;
+  app: App;
   INTERNAL: FirebaseServiceInternalsInterface;
 }
 

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -28,6 +28,7 @@ import { AppOptions } from '../../src/firebase-namespace-api';
 import { FirebaseNamespace } from '../../src/firebase-namespace';
 import { FirebaseServiceInterface } from '../../src/firebase-service';
 import { FirebaseApp } from '../../src/firebase-app';
+import { app as _app } from '../../src/firebase-namespace-api';
 import { credential as _credential, GoogleOAuthAccessToken } from '../../src/credential/index';
 import { ServiceAccountCredential } from '../../src/credential/credential-internal';
 
@@ -223,7 +224,7 @@ export function generateSessionCookie(overrides?: object, expiresIn?: number): s
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export function firebaseServiceFactory(
-  firebaseApp: FirebaseApp,
+  firebaseApp: _app.App,
   _extendApp?: (props: object) => void,
 ): FirebaseServiceInterface {
   const result = {

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -31,19 +31,28 @@ import { FirebaseServiceInterface } from '../../src/firebase-service';
 import { FirebaseApp, FirebaseAccessToken } from '../../src/firebase-app';
 import { FirebaseNamespace, FirebaseNamespaceInternals, FIREBASE_CONFIG_VAR } from '../../src/firebase-namespace';
 
-import { Auth } from '../../src/auth/auth';
-import { Messaging } from '../../src/messaging/messaging';
-import { MachineLearning } from '../../src/machine-learning/machine-learning';
-import { Storage } from '../../src/storage/storage';
-import { Firestore } from '@google-cloud/firestore';
+import { auth } from '../../src/auth/index';
+import { messaging } from '../../src/messaging/index';
+import { machineLearning } from '../../src/machine-learning/index';
+import { storage } from '../../src/storage/index';
+import { firestore } from '../../src/firestore/index';
 import { database } from '../../src/database/index';
-import { InstanceId } from '../../src/instance-id/instance-id';
-import { ProjectManagement } from '../../src/project-management/project-management';
-import { SecurityRules } from '../../src/security-rules/security-rules';
+import { instanceId } from '../../src/instance-id/index';
+import { projectManagement } from '../../src/project-management/index';
+import { securityRules } from '../../src/security-rules/index';
+import { remoteConfig } from '../../src/remote-config/index';
 import { FirebaseAppError, AppErrorCodes } from '../../src/utils/error';
-import { RemoteConfig } from '../../src/remote-config/remote-config';
 
+import Auth = auth.Auth;
 import Database = database.Database;
+import Messaging = messaging.Messaging;
+import MachineLearning = machineLearning.MachineLearning;
+import Storage = storage.Storage;
+import Firestore = firestore.Firestore;
+import InstanceId = instanceId.InstanceId;
+import ProjectManagement = projectManagement.ProjectManagement;
+import SecurityRules = securityRules.SecurityRules;
+import RemoteConfig = remoteConfig.RemoteConfig;
 
 chai.should();
 chai.use(sinonChai);

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -25,23 +25,17 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../resources/mocks';
 
 import { FirebaseNamespace } from '../../src/firebase-namespace';
-import { FirebaseApp } from '../../src/firebase-app';
-import { Auth } from '../../src/auth/auth';
 import {
   enableLogging,
-  Database,
+  Database as DatabaseImpl,
   DataSnapshot,
   OnDisconnect,
   Query,
   Reference,
   ServerValue,
 } from '@firebase/database';
-import { database } from '../../src/database/index';
-import { Messaging } from '../../src/messaging/messaging';
-import { MachineLearning } from '../../src/machine-learning/machine-learning';
-import { Storage } from '../../src/storage/storage';
+
 import {
-  Firestore,
   FieldPath,
   FieldValue,
   GeoPoint,
@@ -49,13 +43,40 @@ import {
   v1beta1,
   setLogFunction,
 } from '@google-cloud/firestore';
-import { InstanceId } from '../../src/instance-id/instance-id';
-import { ProjectManagement } from '../../src/project-management/project-management';
-import { SecurityRules } from '../../src/security-rules/security-rules';
-import { RemoteConfig } from '../../src/remote-config/remote-config';
 import { getSdkVersion } from '../../src/utils/index';
 
-import FirebaseDatabase = database.Database;
+import { app } from '../../src/firebase-namespace-api';
+import { auth } from '../../src/auth/index';
+import { messaging } from '../../src/messaging/index';
+import { machineLearning } from '../../src/machine-learning/index';
+import { storage } from '../../src/storage/index';
+import { firestore } from '../../src/firestore/index';
+import { database } from '../../src/database/index';
+import { instanceId } from '../../src/instance-id/index';
+import { projectManagement } from '../../src/project-management/index';
+import { securityRules } from '../../src/security-rules/index';
+import { remoteConfig } from '../../src/remote-config/index';
+
+import { Auth as AuthImpl } from '../../src/auth/auth';
+import { InstanceId as InstanceIdImpl } from '../../src/instance-id/instance-id';
+import { MachineLearning as MachineLearningImpl } from '../../src/machine-learning/machine-learning';
+import { Messaging as MessagingImpl } from '../../src/messaging/messaging';
+import { ProjectManagement as ProjectManagementImpl } from '../../src/project-management/project-management';
+import { RemoteConfig as RemoteConfigImpl } from '../../src/remote-config/remote-config';
+import { SecurityRules as SecurityRulesImpl } from '../../src/security-rules/security-rules';
+import { Storage as StorageImpl } from '../../src/storage/storage';
+
+import App = app.App;
+import Auth = auth.Auth;
+import Database = database.Database;
+import Firestore = firestore.Firestore;
+import InstanceId = instanceId.InstanceId;
+import MachineLearning = machineLearning.MachineLearning;
+import Messaging = messaging.Messaging;
+import ProjectManagement = projectManagement.ProjectManagement;
+import RemoteConfig = remoteConfig.RemoteConfig;
+import SecurityRules = securityRules.SecurityRules;
+import Storage = storage.Storage;
 
 chai.should();
 chai.use(sinonChai);
@@ -375,19 +396,19 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const auth: Auth = firebaseNamespace.auth();
       expect(auth.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const auth: Auth = firebaseNamespace.auth(app);
       expect(auth.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to Auth type', () => {
-      expect(firebaseNamespace.auth.Auth).to.be.deep.equal(Auth);
+      expect(firebaseNamespace.auth.Auth).to.be.deep.equal(AuthImpl);
     });
   });
 
@@ -406,21 +427,21 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
-      const db: FirebaseDatabase = firebaseNamespace.database();
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
+      const db: Database = firebaseNamespace.database();
       expect(db.app).to.be.deep.equal(app);
       return app.delete();
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
-      const db: FirebaseDatabase = firebaseNamespace.database(app);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const db: Database = firebaseNamespace.database(app);
       expect(db.app).to.be.deep.equal(app);
       return app.delete();
     });
 
     it('should return a reference to Database type', () => {
-      expect(firebaseNamespace.database.Database).to.be.deep.equal(Database);
+      expect(firebaseNamespace.database.Database).to.be.deep.equal(DatabaseImpl);
     });
 
     it('should return a reference to DataSnapshot type', () => {
@@ -463,19 +484,19 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const fcm: Messaging = firebaseNamespace.messaging();
       expect(fcm.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const fcm: Messaging = firebaseNamespace.messaging(app);
       expect(fcm.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to Messaging type', () => {
-      expect(firebaseNamespace.messaging.Messaging).to.be.deep.equal(Messaging);
+      expect(firebaseNamespace.messaging.Messaging).to.be.deep.equal(MessagingImpl);
     });
   });
 
@@ -494,20 +515,20 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const ml: MachineLearning = firebaseNamespace.machineLearning();
       expect(ml.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const ml: MachineLearning = firebaseNamespace.machineLearning(app);
       expect(ml.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to Machine Learning type', () => {
       expect(firebaseNamespace.machineLearning.MachineLearning)
-        .to.be.deep.equal(MachineLearning);
+        .to.be.deep.equal(MachineLearningImpl);
     });
   });
 
@@ -526,19 +547,19 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const gcs: Storage = firebaseNamespace.storage();
       expect(gcs.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const gcs: Storage = firebaseNamespace.storage(app);
       expect(gcs.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to Storage type', () => {
-      expect(firebaseNamespace.storage.Storage).to.be.deep.equal(Storage);
+      expect(firebaseNamespace.storage.Storage).to.be.deep.equal(StorageImpl);
     });
   });
 
@@ -563,7 +584,7 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const fs: Firestore = firebaseNamespace.firestore(app);
       expect(fs).to.not.be.null;
     });
@@ -612,21 +633,21 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const iid: InstanceId = firebaseNamespace.instanceId();
       expect(iid).to.not.be.null;
       expect(iid.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const iid: InstanceId = firebaseNamespace.instanceId(app);
       expect(iid).to.not.be.null;
       expect(iid.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to InstanceId type', () => {
-      expect(firebaseNamespace.instanceId.InstanceId).to.be.deep.equal(InstanceId);
+      expect(firebaseNamespace.instanceId.InstanceId).to.be.deep.equal(InstanceIdImpl);
     });
   });
 
@@ -645,14 +666,14 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const projectManagement: ProjectManagement = firebaseNamespace.projectManagement();
       expect(projectManagement).to.not.be.null;
       expect(projectManagement.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const projectManagement: ProjectManagement = firebaseNamespace.projectManagement(app);
       expect(projectManagement).to.not.be.null;
       expect(projectManagement.app).to.be.deep.equal(app);
@@ -660,7 +681,7 @@ describe('FirebaseNamespace', () => {
 
     it('should return a reference to ProjectManagement type', () => {
       expect(firebaseNamespace.projectManagement.ProjectManagement)
-        .to.be.deep.equal(ProjectManagement);
+        .to.be.deep.equal(ProjectManagementImpl);
     });
   });
 
@@ -679,14 +700,14 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const securityRules: SecurityRules = firebaseNamespace.securityRules();
       expect(securityRules).to.not.be.null;
       expect(securityRules.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const securityRules: SecurityRules = firebaseNamespace.securityRules(app);
       expect(securityRules).to.not.be.null;
       expect(securityRules.app).to.be.deep.equal(app);
@@ -694,7 +715,7 @@ describe('FirebaseNamespace', () => {
 
     it('should return a reference to SecurityRules type', () => {
       expect(firebaseNamespace.securityRules.SecurityRules)
-        .to.be.deep.equal(SecurityRules);
+        .to.be.deep.equal(SecurityRulesImpl);
     });
   });
 
@@ -713,19 +734,19 @@ describe('FirebaseNamespace', () => {
     });
 
     it('should return a valid namespace when the default app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions);
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions);
       const rc: RemoteConfig = firebaseNamespace.remoteConfig();
       expect(rc.app).to.be.deep.equal(app);
     });
 
     it('should return a valid namespace when the named app is initialized', () => {
-      const app: FirebaseApp = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
+      const app: App = firebaseNamespace.initializeApp(mocks.appOptions, 'testApp');
       const rc: RemoteConfig = firebaseNamespace.remoteConfig(app);
       expect(rc.app).to.be.deep.equal(app);
     });
 
     it('should return a reference to RemoteConfig type', () => {
-      expect(firebaseNamespace.remoteConfig.RemoteConfig).to.be.deep.equal(RemoteConfig);
+      expect(firebaseNamespace.remoteConfig.RemoteConfig).to.be.deep.equal(RemoteConfigImpl);
     });
   });
 });

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -27,6 +27,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../resources/mocks';
 
 import * as firebaseAdmin from '../../src/index';
+import { FirebaseApp, FirebaseAppInternals } from '../../src/firebase-app';
 import {
   RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault
 } from '../../src/credential/credential-internal';
@@ -115,7 +116,7 @@ describe('Firebase', () => {
       });
 
       expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
-      return firebaseAdmin.app().INTERNAL.getToken()
+      return getAppInternals().getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
 
@@ -126,7 +127,7 @@ describe('Firebase', () => {
       });
 
       expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
-      return firebaseAdmin.app().INTERNAL.getToken()
+      return getAppInternals().getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
 
@@ -138,7 +139,7 @@ describe('Firebase', () => {
       });
 
       expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.true;
-      return firebaseAdmin.app().INTERNAL.getToken().then((token) => {
+      return getAppInternals().getToken().then((token) => {
         if (typeof credPath === 'undefined') {
           delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
         } else {
@@ -160,7 +161,7 @@ describe('Firebase', () => {
       });
 
       expect(isApplicationDefault(firebaseAdmin.app().options.credential)).to.be.false;
-      return firebaseAdmin.app().INTERNAL.getToken()
+      return getAppInternals().getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
   });
@@ -247,4 +248,8 @@ describe('Firebase', () => {
       }).not.to.throw();
     });
   });
+
+  function getAppInternals(): FirebaseAppInternals {
+    return (firebaseAdmin.app() as FirebaseApp).INTERNAL;
+  }
 });


### PR DESCRIPTION
* Using the public `App` type in `AppHook`, `FirebaseNamespace` and `FirebaseServiceInterface` types.
* Configured the gulpfile to copy all `**/index.d.ts` files to the output except `utils/index.d.ts` which is internal.