### PR TITLE
chore: Updated TypeDoc workflow to generate API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 # Firebase Admin Node.js SDK
 
-## Current issues with doc generation
-
-* Firestore typing aliases listed as variables.
-* RTDB typing aliases listed as variables.
-
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Firebase Admin Node.js SDK
 
+## Current issues with doc generation
+
+* Firestore typing aliases listed as variables.
+* RTDB typing aliases listed as variables.
+
 
 ## Table of Contents
 

--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -36,6 +36,8 @@ toc:
     path: /docs/reference/admin/node/admin.auth.CreatePhoneMultiFactorInfoRequest
   - title: "CreateRequest"
     path: /docs/reference/admin/node/admin.auth.CreateRequest
+  - title: "EmailSignInProviderConfig"
+    path: /docs/reference/admin/node/admin.auth.EmailSignInProviderConfig
   - title: "ListProviderConfigResults"
     path: /docs/reference/admin/node/admin.auth.ListProviderConfigResults
   - title: "ListTenantsResult"
@@ -121,19 +123,7 @@ toc:
   path: /docs/reference/admin/node/admin.database
   section:
   - title: "Database"
-    path: /docs/reference/admin/node/_database_types_.FirebaseDatabase
-  - title: "DataSnapshot"
-    path: /docs/reference/admin/node/admin.database.DataSnapshot
-  - title: "OnDisconnect"
-    path: /docs/reference/admin/node/admin.database.OnDisconnect
-  - title: "Query"
-    path: /docs/reference/admin/node/admin.database.Query
-  - title: "Reference"
-    path: /docs/reference/admin/node/admin.database.Reference
-  - title: "ServerValue"
-    path: /docs/reference/admin/node/admin.database.ServerValue
-  - title: "ThenableReference"
-    path: /docs/reference/admin/node/admin.database.ThenableReference
+    path: /docs/reference/admin/node/admin.database.Database-1
 
 - title: "admin.firestore"
   path: /docs/reference/admin/node/admin.firestore
@@ -167,6 +157,8 @@ toc:
 - title: "admin.messaging"
   path: /docs/reference/admin/node/admin.messaging
   section:
+  - title: "BaseMessage"
+    path: /docs/reference/admin/node/admin.messaging.BaseMessage
   - title: "TopicMessage"
     path: /docs/reference/admin/node/admin.messaging.TopicMessage
   - title: "TokenMessage"

--- a/docgen/content-sources/node/toc.yaml
+++ b/docgen/content-sources/node/toc.yaml
@@ -17,13 +17,13 @@ toc:
   path: /docs/reference/admin/node/admin.app
   section:
   - title: "App"
-    path: /docs/reference/admin/node/admin.app.App
+    path: /docs/reference/admin/node/admin.app.App-1
 
 - title: "admin.auth"
   path: /docs/reference/admin/node/admin.auth
   section:
   - title: "Auth"
-    path: /docs/reference/admin/node/admin.auth.Auth
+    path: /docs/reference/admin/node/admin.auth.Auth-1
   - title: "ActionCodeSettings"
     path: /docs/reference/admin/node/admin.auth.ActionCodeSettings
   - title: "AuthProviderConfig"
@@ -115,13 +115,13 @@ toc:
   path: /docs/reference/admin/node/admin.credential
   section:
   - title: "Credential"
-    path: /docs/reference/admin/node/admin.credential.Credential
+    path: /docs/reference/admin/node/admin.credential.Credential-1
 
 - title: "admin.database"
   path: /docs/reference/admin/node/admin.database
   section:
   - title: "Database"
-    path: /docs/reference/admin/node/admin.database.Database
+    path: /docs/reference/admin/node/_database_types_.FirebaseDatabase
   - title: "DataSnapshot"
     path: /docs/reference/admin/node/admin.database.DataSnapshot
   - title: "OnDisconnect"
@@ -142,7 +142,7 @@ toc:
   path: /docs/reference/admin/node/admin.instanceId
   section:
   - title: "InstanceId"
-    path: /docs/reference/admin/node/admin.instanceId.InstanceId
+    path: /docs/reference/admin/node/admin.instanceId.InstanceId-1
 
 - title: "admin.machineLearning"
   path: /docs/reference/admin/node/admin.machineLearning
@@ -152,7 +152,7 @@ toc:
   - title: "ListModelsResult"
     path: /docs/reference/admin/node/admin.machineLearning.ListModelsResult
   - title: "MachineLearning"
-    path: /docs/reference/admin/node/admin.machineLearning.MachineLearning
+    path: /docs/reference/admin/node/admin.machineLearning.MachineLearning-1
   - title: "Model"
     path: /docs/reference/admin/node/admin.machineLearning.Model
   - title: "ModelOptionsBase"
@@ -168,11 +168,11 @@ toc:
   path: /docs/reference/admin/node/admin.messaging
   section:
   - title: "TopicMessage"
-    path: /docs/reference/admin/node/TopicMessage
+    path: /docs/reference/admin/node/admin.messaging.TopicMessage
   - title: "TokenMessage"
-    path: /docs/reference/admin/node/TokenMessage
+    path: /docs/reference/admin/node/admin.messaging.TokenMessage
   - title: "ConditionMessage"
-    path: /docs/reference/admin/node/ConditionMessage
+    path: /docs/reference/admin/node/admin.messaging.ConditionMessage
   - title: "AndroidConfig"
     path: /docs/reference/admin/node/admin.messaging.AndroidConfig
   - title: "AndroidFcmOptions"
@@ -184,7 +184,7 @@ toc:
   - title: "LightSettings"
     path: /docs/reference/admin/node/admin.messaging.LightSettings
   - title: "Messaging"
-    path: /docs/reference/admin/node/admin.messaging.Messaging
+    path: /docs/reference/admin/node/admin.messaging.Messaging-1
   - title: "MessagingConditionResponse"
     path: /docs/reference/admin/node/admin.messaging.MessagingConditionResponse
   - title: "MessagingDeviceGroupResponse"
@@ -248,7 +248,7 @@ toc:
   - title: "IosAppMetadata"
     path: /docs/reference/admin/node/admin.projectManagement.IosAppMetadata
   - title: "ProjectManagement"
-    path: /docs/reference/admin/node/admin.projectManagement.ProjectManagement
+    path: /docs/reference/admin/node/admin.projectManagement.ProjectManagement-1
   - title: "ShaCertificate"
     path: /docs/reference/admin/node/admin.projectManagement.ShaCertificate
 
@@ -264,19 +264,19 @@ toc:
   - title: "RulesetMetadataList"
     path: /docs/reference/admin/node/admin.securityRules.RulesetMetadataList
   - title: "SecurityRules"
-    path: /docs/reference/admin/node/admin.securityRules.SecurityRules
+    path: /docs/reference/admin/node/admin.securityRules.SecurityRules-1
 
 - title: "admin.storage"
   path: /docs/reference/admin/node/admin.storage
   section:
   - title: "Storage"
-    path: /docs/reference/admin/node/admin.storage.Storage
+    path: /docs/reference/admin/node/admin.storage.Storage-1
 
 - title: "admin.remoteConfig"
   path: /docs/reference/admin/node/admin.remoteConfig
   section:
   - title: "RemoteConfig"
-    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfig
+    path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfig-1
   - title: "RemoteConfigTemplate"
     path: /docs/reference/admin/node/admin.remoteConfig.RemoteConfigTemplate
   - title: "RemoteConfigParameter"

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -270,6 +270,7 @@ function fixAllLinks(htmlFiles) {
  * Updates the auto-generated Firestore API references page, by appending
  * the specified HTML content block.
  *
+ * @param {string} htmlPath Path of the HTML file to update.
  * @param {string} contentBlock The HTML content block to be added to the Firestore docs.
  */
 function updateHtml(htmlPath, contentBlock) {

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -28,7 +28,7 @@ const repoPath = path.resolve(`${__dirname}/..`);
 // Command-line options.
 const { source: sourceFile } = yargs
   .option('source', {
-    default: `${repoPath}/src/*.d.ts`,
+    default: `${repoPath}/lib/*.d.ts ${repoPath}/lib/**/*.d.ts`,
     describe: 'Typescript source file(s)',
     type: 'string'
   })
@@ -151,12 +151,12 @@ function checkForMissingFilesAndFixFilenameCase() {
     // toc.yaml.
     const tocFilePath = `${docPath}/${filename}.html`;
     // Generated filename from Typedoc will be lowercase.
-    const generatedFilePath = `${docPath}/${filename.toLowerCase()}.html`;
+    const generatedFilePath = `${docPath}/${filename.toLowerCase().replace('admin.', '')}.html`;
     return fs.exists(generatedFilePath).then(exists => {
       if (exists) {
         // Store in a lookup table for link fixing.
         lowerToUpperLookup[
-          `${filename.toLowerCase()}.html`
+          `${filename.toLowerCase().replace('admin.', '')}.html`
         ] = `${filename}.html`;
         return fs.rename(generatedFilePath, tocFilePath);
       } else {
@@ -167,6 +167,7 @@ function checkForMissingFilesAndFixFilenameCase() {
       }
     });
   });
+  fileCheckPromises.push(fs.rename(`${docPath}/globals.html`, `${docPath}/admin.html`));
   return Promise.all(fileCheckPromises).then(() => filenames);
 }
 
@@ -272,7 +273,7 @@ function updateFirestoreHtml(contentBlock) {
  */
 function addFirestoreTypeAliases() {
   return new Promise((resolve, reject) => {
-    const fileStream = fs.createReadStream(`${repoPath}/src/index.d.ts`);
+    const fileStream = fs.createReadStream(`${repoPath}/lib/firestore/index.d.ts`);
     fileStream.on('error', (err) => {
       reject(err);
     });

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -46,7 +46,7 @@ const contentPath = path.resolve(`${__dirname}/content-sources/node`);
 const tempHomePath = path.resolve(`${contentPath}/HOME_TEMP.md`);
 const devsitePath = `/docs/reference/admin/node/`;
 
-const firestoreExcludes = ['v1', 'v1beta1', 'setLogFunction','DocumentData', 'enableLogging'];
+const firestoreExcludes = ['v1', 'v1beta1', 'setLogFunction','DocumentData'];
 const firestoreHtmlPath = `${docPath}/admin.firestore.html`;
 const firestoreHeader = `<section class="tsd-panel-group tsd-member-group ">
   <h2>Type aliases</h2>
@@ -57,6 +57,7 @@ const firestoreHeader = `<section class="tsd-panel-group tsd-member-group ">
   <ul>`;
 const firestoreFooter = '\n  </ul>\n</section>\n';
 
+const databaseExcludes = ['enableLogging'];
 const databaseHtmlPath = `${docPath}/admin.database.html`;
 const databaseHeader = `<section class="tsd-panel-group tsd-member-group ">
   <h2>Type aliases</h2>
@@ -166,7 +167,7 @@ function checkForMissingFilesAndFixFilenameCase() {
     // Preferred filename for devsite should be capitalized and taken from
     // toc.yaml.
     const tocFilePath = `${docPath}/${filename}.html`;
-    // Generated filename from Typedoc will be lowercase.
+    // Generated filename from Typedoc will be lowercase and won't have the admin prefix.
     const generatedFilePath = `${docPath}/${filename.toLowerCase().replace('admin.', '')}.html`;
     return fs.exists(generatedFilePath).then(exists => {
       if (exists) {
@@ -183,7 +184,7 @@ function checkForMissingFilesAndFixFilenameCase() {
       }
     });
   });
-  fileCheckPromises.push(fs.rename(`${docPath}/globals.html`, `${docPath}/admin.html`));
+
   return Promise.all(fileCheckPromises).then(() => filenames);
 }
 
@@ -345,7 +346,7 @@ function addDatabaseTypeAliases() {
       line = line.trim();
       if (line.startsWith('export import') && line.indexOf('rtdb.') >= 0) {
         const typeName = line.split(' ')[2];
-        if (firestoreExcludes.indexOf(typeName) === -1) {
+        if (databaseExcludes.indexOf(typeName) === -1) {
           contentBlock += `
           <li>
             <a href="/docs/reference/js/firebase.database.${typeName}.html">${typeName}</a>
@@ -409,6 +410,8 @@ Promise.all([
       moveFilesToRoot('enums'),
     ]);
   })
+  // Rename the globals file to be the top-level admin doc.
+  .then(() => fs.rename(`${docPath}/globals.html`, `${docPath}/admin.html`))
   // Check for files listed in TOC that are missing and warn if so.
   // Not blocking.
   .then(checkForMissingFilesAndFixFilenameCase)

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -116,7 +116,7 @@ function fixLinks(file) {
       .replace(/(modules|interfaces|classes|enums)\//g, '');
     let caseFixedLinks = flattenedLinks;
     for (const lower in lowerToUpperLookup) {
-      const re = new RegExp(lower, 'g');
+      const re = new RegExp('\\b' + lower, 'g');
       caseFixedLinks = caseFixedLinks.replace(re, lowerToUpperLookup[lower]);
     }
     return fs.writeFile(file, caseFixedLinks);

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -17,12 +17,12 @@
 import { app, FirebaseArrayIndexError } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.auth.Auth `Auth`} service for the default app or a
+ * Gets the {@link auth.Auth `Auth`} service for the default app or a
  * given app.
  *
  * `admin.auth()` can be called with no arguments to access the default app's
- * {@link admin.auth.Auth `Auth`} service or as `admin.auth(app)` to access the
- * {@link admin.auth.Auth `Auth`} service associated with a specific app.
+ * {@link auth.Auth `Auth`} service or as `admin.auth(app)` to access the
+ * {@link auth.Auth `Auth`} service associated with a specific app.
  *
  * @example
  * ```javascript
@@ -575,7 +575,7 @@ export namespace auth {
     [key: string]: any;
   }
 
-  /** Represents the result of the {@link admin.auth.getUsers()} API. */
+  /** Represents the result of the {@link auth.Auth.getUsers} API. */
   export interface GetUsersResult {
     /**
      * Set of user records, corresponding to the set of users that were
@@ -596,7 +596,7 @@ export namespace auth {
   export interface ListUsersResult {
 
     /**
-     * The list of {@link admin.auth.UserRecord `UserRecord`} objects for the
+     * The list of {@link auth.UserRecord `UserRecord`} objects for the
      * current downloaded batch.
      */
     users: UserRecord[];
@@ -840,7 +840,7 @@ export namespace auth {
     /**
      * The buffer of bytes representing the user's hashed password.
      * When a user is to be imported with a password hash,
-     * {@link admin.auth.UserImportOptions `UserImportOptions`} are required to be
+     * {@link auth.UserImportOptions `UserImportOptions`} are required to be
      * specified to identify the hashing algorithm used to generate this hash.
      */
     passwordHash?: Buffer;
@@ -1109,7 +1109,7 @@ export namespace auth {
   export interface ListTenantsResult {
 
     /**
-     * The list of {@link admin.auth.Tenant `Tenant`} objects for the downloaded batch.
+     * The list of {@link auth.Tenant `Tenant`} objects for the downloaded batch.
      */
     tenants: Tenant[];
 
@@ -1610,7 +1610,7 @@ export namespace auth {
      * Revokes all refresh tokens for an existing user.
      *
      * This API will update the user's
-     * {@link admin.auth.UserRecord#tokensValidAfterTime `tokensValidAfterTime`} to
+     * {@link auth.UserRecord#tokensValidAfterTime `tokensValidAfterTime`} to
      * the current UTC. It is important that the server on which this is called has
      * its clock set correctly and synchronized.
      *
@@ -1618,7 +1618,7 @@ export namespace auth {
      * new ID tokens for existing sessions from getting minted, existing ID tokens
      * may remain active until their natural expiration (one hour). To verify that
      * ID tokens are revoked, use
-     * {@link admin.auth.Auth#verifyIdToken `verifyIdToken(idToken, true)`}
+     * {@link auth.Auth#verifyIdToken `verifyIdToken(idToken, true)`}
      * where `checkRevoked` is set to true.
      *
      * @param uid The `uid` corresponding to the user whose refresh tokens
@@ -1633,7 +1633,7 @@ export namespace auth {
      * Imports the provided list of users into Firebase Auth.
      * A maximum of 1000 users are allowed to be imported one at a time.
      * When importing users with passwords,
-     * {@link admin.auth.UserImportOptions `UserImportOptions`} are required to be
+     * {@link auth.UserImportOptions `UserImportOptions`} are required to be
      * specified.
      * This operation is optimized for bulk imports and will ignore checks on `uid`,
      * `email` and other identifier uniqueness which could result in duplications.
@@ -1702,7 +1702,7 @@ export namespace auth {
     /**
      * Generates the out of band email action link to reset a user's password.
      * The link is generated for the user with the specified email address. The
-     * optional  {@link admin.auth.ActionCodeSettings `ActionCodeSettings`} object
+     * optional  {@link auth.ActionCodeSettings `ActionCodeSettings`} object
      * defines whether the link is to be handled by a mobile app or browser and the
      * additional state information to be passed in the deep link, etc.
      *
@@ -1756,7 +1756,7 @@ export namespace auth {
     /**
      * Generates the out of band email action link to verify the user's ownership
      * of the specified email. The
-     * {@link admin.auth.ActionCodeSettings `ActionCodeSettings`} object provided
+     * {@link auth.ActionCodeSettings `ActionCodeSettings`} object provided
      * as an argument to this method defines whether the link is to be handled by a
      * mobile app or browser along with additional state information to be passed in
      * the deep link, etc.
@@ -1810,7 +1810,7 @@ export namespace auth {
     /**
      * Generates the out of band email action link to sign in or sign up the owner
      * of the specified email. The
-     * {@link admin.auth.ActionCodeSettings `ActionCodeSettings`} object provided
+     * {@link auth.ActionCodeSettings `ActionCodeSettings`} object provided
      * as an argument to this method defines whether the link is to be handled by a
      * mobile app or browser along with additional state information to be passed in
      * the deep link, etc.

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -210,7 +210,7 @@ export namespace auth {
      * when uploading this user, as is typical when migrating from another Auth
      * system, this will be an empty string. If no password is set, this is
      * null. This is only available when the user is obtained from
-     * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listUsers `listUsers()`}.
+     * {@link auth.Auth.listUsers `listUsers()`}.
      *
      */
     passwordHash?: string;
@@ -221,7 +221,7 @@ export namespace auth {
      * upload this user, typical when migrating from another Auth system, this will
      * be an empty string. If no password is set, this is null. This is only
      * available when the user is obtained from
-     * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listUsers `listUsers()`}.
+     * {@link auth.Auth.listUsers `listUsers()`}.
      *
      */
     passwordSalt?: string;
@@ -230,14 +230,14 @@ export namespace auth {
      * The user's custom claims object if available, typically used to define
      * user roles and propagated to an authenticated user's ID token.
      * This is set via
-     * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#setCustomUserClaims `setCustomUserClaims()`}
+     * {@link auth.Auth.setCustomUserClaims `setCustomUserClaims()`}
      */
     customClaims?: { [key: string]: any };
 
     /**
      * The date the user's tokens are valid after, formatted as a UTC string.
      * This is updated every time the user's refresh token are revoked either
-     * from the {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#revokeRefreshTokens `revokeRefreshTokens()`}
+     * from the {@link auth.Auth.revokeRefreshTokens `revokeRefreshTokens()`}
      * API or from the Firebase Auth backend on big account changes (password
      * resets, password or email updates, etc).
      */
@@ -434,7 +434,7 @@ export namespace auth {
 
   /**
    * Interface representing a decoded Firebase ID token, returned from the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#verifyidtoken `verifyIdToken()`} method.
+   * {@link auth.Auth.verifyIdToken `verifyIdToken()`} method.
    *
    * Firebase ID tokens are OpenID Connect spec-compliant JSON Web Tokens (JWTs).
    * See the
@@ -590,7 +590,7 @@ export namespace auth {
 
   /**
    * Interface representing the object returned from a
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listUsers `listUsers()`} operation. Contains the list
+   * {@link auth.Auth.listUsers `listUsers()`} operation. Contains the list
    * of users for the current batch and the next page token if available.
    */
   export interface ListUsersResult {
@@ -613,7 +613,7 @@ export namespace auth {
 
   /**
    * Interface representing the user import options needed for
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#importUsers `importUsers()`} method. This is used to
+   * {@link auth.Auth.importUsers `importUsers()`} method. This is used to
    * provide the password hashing algorithm information.
    */
   export interface UserImportOptions {
@@ -679,7 +679,7 @@ export namespace auth {
 
   /**
    * Interface representing the response from the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#importUsers `importUsers()`} method for batch
+   * {@link auth.Auth.importUsers `importUsers()`} method for batch
    * importing users to Firebase Auth.
    */
   export interface UserImportResult {
@@ -703,7 +703,7 @@ export namespace auth {
 
   /**
    * Represents the result of the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#deleteUsers `deleteUsers()`}
+   * {@link auth.Auth.deleteUsers `deleteUsers()`}
    * API.
    */
   export interface DeleteUsersResult {
@@ -781,7 +781,7 @@ export namespace auth {
 
   /**
    * Interface representing a user to import to Firebase Auth via the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#importUsers `importUsers()`} method.
+   * {@link auth.Auth.importUsers `importUsers()`} method.
    */
   export interface UserImportRecord {
 
@@ -867,7 +867,7 @@ export namespace auth {
 
   /**
    * Interface representing the session cookie options needed for the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#createSessionCookie `createSessionCookie()`} method.
+   * {@link auth.Auth.createSessionCookie `createSessionCookie()`} method.
    */
   export interface SessionCookieOptions {
 
@@ -1102,7 +1102,7 @@ export namespace auth {
 
   /**
    * Interface representing the object returned from a
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listTenants `listTenants()`}
+   * {@link auth.TenantManager.listTenants `listTenants()`}
    * operation.
    * Contains the list of tenants for the current batch and the next page token if available.
    */
@@ -1122,7 +1122,7 @@ export namespace auth {
   /**
    * The filter interface used for listing provider configurations. This is used
    * when specifying how to list configured identity providers via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listProviderConfigs `listProviderConfigs()`}.
+   * {@link auth.Auth.listProviderConfigs `listProviderConfigs()`}.
    */
   export interface AuthProviderConfigFilter {
 
@@ -1175,7 +1175,7 @@ export namespace auth {
    * The
    * [SAML](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html)
    * Auth provider configuration interface. A SAML provider can be created via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#createProviderConfig `createProviderConfig()`}.
+   * {@link auth.Auth.createProviderConfig `createProviderConfig()`}.
    */
   export interface SAMLAuthProviderConfig extends AuthProviderConfig {
 
@@ -1220,7 +1220,7 @@ export namespace auth {
   /**
    * The [OIDC](https://openid.net/specs/openid-connect-core-1_0-final.html) Auth
    * provider configuration interface. An OIDC provider can be created via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#createProviderConfig `createProviderConfig()`}.
+   * {@link auth.Auth.createProviderConfig `createProviderConfig()`}.
    */
   export interface OIDCAuthProviderConfig extends AuthProviderConfig {
 
@@ -1254,7 +1254,7 @@ export namespace auth {
   /**
    * The request interface for updating a SAML Auth provider. This is used
    * when updating a SAML provider's configuration via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#updateProviderConfig `updateProviderConfig()`}.
+   * {@link auth.Auth.updateProviderConfig `updateProviderConfig()`}.
    */
   export interface SAMLUpdateAuthProviderRequest {
 
@@ -1304,7 +1304,7 @@ export namespace auth {
   /**
    * The request interface for updating an OIDC Auth provider. This is used
    * when updating an OIDC provider's configuration via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#updateProviderConfig `updateProviderConfig()`}.
+   * {@link auth.Auth.updateProviderConfig `updateProviderConfig()`}.
    */
   export interface OIDCUpdateAuthProviderRequest {
 
@@ -1336,7 +1336,7 @@ export namespace auth {
   /**
    * The response interface for listing provider configs. This is only available
    * when listing all identity providers' configurations via
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth#listProviderConfigs `listProviderConfigs()`}.
+   * {@link auth.Auth.listProviderConfigs `listProviderConfigs()`}.
    */
   export interface ListProviderConfigResults {
 
@@ -1610,7 +1610,7 @@ export namespace auth {
      * Revokes all refresh tokens for an existing user.
      *
      * This API will update the user's
-     * {@link auth.UserRecord#tokensValidAfterTime `tokensValidAfterTime`} to
+     * {@link auth.UserRecord.tokensValidAfterTime `tokensValidAfterTime`} to
      * the current UTC. It is important that the server on which this is called has
      * its clock set correctly and synchronized.
      *
@@ -1618,7 +1618,7 @@ export namespace auth {
      * new ID tokens for existing sessions from getting minted, existing ID tokens
      * may remain active until their natural expiration (one hour). To verify that
      * ID tokens are revoked, use
-     * {@link auth.Auth#verifyIdToken `verifyIdToken(idToken, true)`}
+     * {@link auth.Auth.verifyIdToken `verifyIdToken(idToken, true)`}
      * where `checkRevoked` is set to true.
      *
      * @param uid The `uid` corresponding to the user whose refresh tokens

--- a/src/credential/index.ts
+++ b/src/credential/index.ts
@@ -38,7 +38,7 @@ export namespace credential {
    *
    * In most cases, you will not need to implement this yourself and can instead
    * use the default implementations provided by
-   * {@link admin.credential `admin.credential`}.
+   * {@link credential `admin.credential`}.
    */
   export interface Credential {
     /**

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -19,13 +19,13 @@ import { ServerValue as sv } from '@firebase/database';
 import * as rtdb from '@firebase/database-types';
 
 /**
- * Gets the {@link admin.database.Database `Database`} service for the default
+ * Gets the {@link database.Database `Database`} service for the default
  * app or a given app.
  *
  * `admin.database()` can be called with no arguments to access the default
- * app's {@link admin.database.Database `Database`} service or as
+ * app's {@link database.Database `Database`} service or as
  * `admin.database(app)` to access the
- * {@link admin.database.Database `Database`} service associated with a specific
+ * {@link database.Database `Database`} service associated with a specific
  * app.
  *
  * `admin.database` is also a namespace that can be used to access global

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -51,8 +51,9 @@ import * as rtdb from '@firebase/database-types';
  */
 export declare function database(app?: app.App): database.Database;
 
-declare module '@firebase/database-types' {
-  interface FirebaseDatabase {
+/* eslint-disable @typescript-eslint/no-namespace */
+export namespace database {
+  export interface Database extends rtdb.FirebaseDatabase {
     /**
      * Gets the currently applied security rules as a string. The return value consists of
      * the rules source including comments.
@@ -78,12 +79,8 @@ declare module '@firebase/database-types' {
      */
     setRules(source: string | Buffer | object): Promise<void>;
   }
-}
 
-/* eslint-disable @typescript-eslint/no-namespace */
-export namespace database {
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  export import Database = rtdb.FirebaseDatabase;
   export import DataSnapshot = rtdb.DataSnapshot;
   export import EventType = rtdb.EventType;
   export import OnDisconnect = rtdb.OnDisconnect;
@@ -92,5 +89,9 @@ export namespace database {
   export import ThenableReference = rtdb.ThenableReference;
   export import enableLogging = rtdb.enableLogging;
 
+  /**
+   * [`ServerValue`](https://firebase.google.com/docs/reference/js/firebase.database.ServerValue)
+   * module from the `@firebase/database` package.
+   */
   export const ServerValue: rtdb.ServerValue = sv;
 }

--- a/src/firebase-namespace-api.ts
+++ b/src/firebase-namespace-api.ts
@@ -112,7 +112,7 @@ export interface FirebaseArrayIndexError {
 export interface AppOptions {
 
   /**
-   * A {@link admin.credential.Credential `Credential`} object used to
+   * A {@link credential.Credential `Credential`} object used to
    * authenticate the Admin SDK.
    *
    * See [Initialize the SDK](/docs/admin/setup#initialize_the_sdk) for detailed

--- a/src/instance-id/index.ts
+++ b/src/instance-id/index.ts
@@ -17,13 +17,13 @@
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.instanceId.InstanceId `InstanceId`} service for the
+ * Gets the {@link instanceId.InstanceId `InstanceId`} service for the
  * default app or a given app.
  *
  * `admin.instanceId()` can be called with no arguments to access the default
- * app's {@link admin.instanceId.InstanceId `InstanceId`} service or as
+ * app's {@link instanceId.InstanceId `InstanceId`} service or as
  * `admin.instanceId(app)` to access the
- * {@link admin.instanceId.InstanceId `InstanceId`} service associated with a
+ * {@link instanceId.InstanceId `InstanceId`} service associated with a
  * specific app.
  *
  * @example

--- a/src/machine-learning/index.ts
+++ b/src/machine-learning/index.ts
@@ -17,13 +17,13 @@
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.machineLearning.MachineLearning `MachineLearning`} service for the
+ * Gets the {@link machineLearning.MachineLearning `MachineLearning`} service for the
  * default app or a given app.
  *
  * `admin.machineLearning()` can be called with no arguments to access the
- * default app's {@link admin.machineLearning.MachineLearning
+ * default app's {@link machineLearning.MachineLearning
  * `MachineLearning`} service or as `admin.machineLearning(app)` to access
- * the {@link admin.machineLearning.MachineLearning `MachineLearning`}
+ * the {@link machineLearning.MachineLearning `MachineLearning`}
  * service associated with a specific app.
  *
  * @example
@@ -207,7 +207,7 @@ export namespace machineLearning {
    */
   export interface MachineLearning {
     /**
-     *  The {@link admin.app.App} associated with the current `MachineLearning`
+     *  The {@link app.App} associated with the current `MachineLearning`
      *  service instance.
      */
     app: app.App;

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -17,13 +17,13 @@
 import { app, FirebaseError, FirebaseArrayIndexError } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.messaging.Messaging `Messaging`} service for the
+ * Gets the {@link messaging.Messaging `Messaging`} service for the
  * default app or a given app.
  *
  * `admin.messaging()` can be called with no arguments to access the default
- * app's {@link admin.messaging.Messaging `Messaging`} service or as
+ * app's {@link messaging.Messaging `Messaging`} service or as
  * `admin.messaging(app)` to access the
- * {@link admin.messaging.Messaging `Messaging`} service associated with a
+ * {@link messaging.Messaging `Messaging`} service associated with a
  * specific app.
  *
  * @example
@@ -85,7 +85,7 @@ export namespace messaging {
   }
 
   /**
-   * A notification that can be included in {@link admin.messaging.Message}.
+   * A notification that can be included in {@link messaging.Message}.
    */
   export interface Notification {
     /**
@@ -114,7 +114,7 @@ export namespace messaging {
 
   /**
    * Represents the WebPush protocol options that can be included in an
-   * {@link admin.messaging.Message}.
+   * {@link messaging.Message}.
    */
   export interface WebpushConfig {
 
@@ -156,7 +156,7 @@ export namespace messaging {
 
   /**
    * Represents the WebPush-specific notification options that can be included in
-   * {@link admin.messaging.WebpushConfig}. This supports most of the standard
+   * {@link messaging.WebpushConfig}. This supports most of the standard
    * options as defined in the Web Notification
    * [specification](https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification).
    */
@@ -268,7 +268,7 @@ export namespace messaging {
 
   /**
    * Represents the APNs-specific options that can be included in an
-   * {@link admin.messaging.Message}. Refer to
+   * {@link messaging.Message}. Refer to
    * [Apple documentation](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html)
    * for various headers and payload fields supported by APNs.
    */
@@ -406,7 +406,7 @@ export namespace messaging {
 
   /**
    * Represents the Android-specific options that can be included in an
-   * {@link admin.messaging.Message}.
+   * {@link messaging.Message}.
    */
   export interface AndroidConfig {
 
@@ -454,7 +454,7 @@ export namespace messaging {
 
   /**
     * Represents the Android-specific notification options that can be included in
-    * {@link admin.messaging.AndroidConfig}.
+    * {@link messaging.AndroidConfig}.
     */
   export interface AndroidNotification {
     /**
@@ -634,7 +634,7 @@ export namespace messaging {
 
   /**
     * Represents settings to control notification LED that can be included in
-    * {@link admin.messaging.AndroidNotification}.
+    * {@link messaging.AndroidNotification}.
     */
   export interface LightSettings {
     /**
@@ -1141,7 +1141,7 @@ export namespace messaging {
 
   export interface Messaging {
     /**
-     * The {@link admin.app.App app} associated with the current `Messaging` service
+     * The {@link app.App app} associated with the current `Messaging` service
      * instance.
      *
      * @example

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -1002,7 +1002,7 @@ export namespace messaging {
 
   /**
    * Interface representing the server response from the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#sendToDeviceGroup `sendToDeviceGroup()`}
+   * {@link messaging.Messaging.sendToDeviceGroup `sendToDeviceGroup()`}
    * method.
    *
    * See
@@ -1029,7 +1029,7 @@ export namespace messaging {
 
   /**
    * Interface representing the server response from the legacy
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#sendToTopic `sendToTopic()`} method.
+   * {@link messaging.Messaging.sendToTopic `sendToTopic()`} method.
    *
    * See
    * [Send to a topic](/docs/cloud-messaging/admin/send-messages#send_to_a_topic)
@@ -1045,7 +1045,7 @@ export namespace messaging {
 
   /**
    * Interface representing the server response from the legacy
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#sendToCondition `sendToCondition()`} method.
+   * {@link messaging.Messaging.sendToCondition `sendToCondition()`} method.
    *
    * See
    * [Send to a condition](/docs/cloud-messaging/admin/send-messages#send_to_a_condition)
@@ -1061,10 +1061,8 @@ export namespace messaging {
 
   /**
    * Interface representing the server response from the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#subscribeToTopic `subscribeToTopic()`} and
-   * {@link
-   *   admin.messaging.Messaging#unsubscribeFromTopic
-   *   `unsubscribeFromTopic()`}
+   * {@link messaging.Messaging.subscribeToTopic `subscribeToTopic()`} and
+   * {@link messaging.Messaging.unsubscribeFromTopic `unsubscribeFromTopic()`}
    * methods.
    *
    * See
@@ -1093,8 +1091,8 @@ export namespace messaging {
 
   /**
    * Interface representing the server response from the
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#sendAll `sendAll()`} and
-   * {@link https://firebase.google.com/docs/reference/admin/node/admin.messaging.Messaging#sendMulticast `sendMulticast()`} methods.
+   * {@link messaging.Messaging.sendAll `sendAll()`} and
+   * {@link messaging.Messaging.sendMulticast `sendMulticast()`} methods.
    */
   export interface BatchResponse {
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -213,7 +213,7 @@ export class Messaging implements FirebaseServiceInterface, MessagingInterface {
   private readonly messagingRequestHandler: FirebaseMessagingRequestHandler;
 
   /**
-   * Gets the {@link admin.messaging.Messaging `Messaging`} service for the
+   * Gets the {@link messaging.Messaging `Messaging`} service for the
    * current app.
    *
    * @example

--- a/src/project-management/android-app.ts
+++ b/src/project-management/android-app.ts
@@ -182,7 +182,7 @@ export class AndroidApp implements AndroidAppInterface {
  * A SHA-1 or SHA-256 certificate.
  *
  * Do not call this constructor directly. Instead, use
- * [`projectManagement.shaCertificate()`](admin.projectManagement.ProjectManagement#shaCertificate).
+ * [`projectManagement.shaCertificate()`](projectManagement.ProjectManagement#shaCertificate).
  */
 export class ShaCertificate implements ShaCertificateInterface {
   /**

--- a/src/project-management/index.ts
+++ b/src/project-management/index.ts
@@ -17,13 +17,13 @@
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.projectManagement.ProjectManagement
+ * Gets the {@link projectManagement.ProjectManagement
  * `ProjectManagement`} service for the default app or a given app.
  *
  * `admin.projectManagement()` can be called with no arguments to access the
- * default app's {@link admin.projectManagement.ProjectManagement
+ * default app's {@link projectManagement.ProjectManagement
  * `ProjectManagement`} service, or as `admin.projectManagement(app)` to access
- * the {@link admin.projectManagement.ProjectManagement `ProjectManagement`}
+ * the {@link projectManagement.ProjectManagement `ProjectManagement`}
  * service associated with a specific app.
  *
  * @example
@@ -165,7 +165,7 @@ export namespace projectManagement {
    * A reference to a Firebase Android app.
    *
    * Do not call this constructor directly. Instead, use
-   * [`projectManagement.androidApp()`](admin.projectManagement.ProjectManagement#androidApp).
+   * [`projectManagement.androidApp()`](projectManagement.ProjectManagement#androidApp).
    */
   export interface AndroidApp {
     appId: string;
@@ -229,7 +229,7 @@ export namespace projectManagement {
    * A reference to a Firebase iOS app.
    *
    * Do not call this constructor directly. Instead, use
-   * [`projectManagement.iosApp()`](admin.projectManagement.ProjectManagement#iosApp).
+   * [`projectManagement.iosApp()`](projectManagement.ProjectManagement#iosApp).
    */
   export interface IosApp {
     appId: string;
@@ -266,7 +266,7 @@ export namespace projectManagement {
    * A SHA-1 or SHA-256 certificate.
    *
    * Do not call this constructor directly. Instead, use
-   * [`projectManagement.shaCertificate()`](admin.projectManagement.ProjectManagement#shaCertificate).
+   * [`projectManagement.shaCertificate()`](projectManagement.ProjectManagement#shaCertificate).
    */
   export interface ShaCertificate {
 
@@ -307,7 +307,7 @@ export namespace projectManagement {
    * The Firebase ProjectManagement service interface.
    *
    * Do not call this constructor directly. Instead, use
-   * [`admin.projectManagement()`](admin.projectManagement#projectManagement).
+   * [`admin.projectManagement()`](projectManagement#projectManagement).
    */
   export interface ProjectManagement {
     app: app.App;

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -47,7 +47,7 @@ class ProjectManagementInternals implements FirebaseServiceInternalsInterface {
  * The Firebase ProjectManagement service interface.
  *
  * Do not call this constructor directly. Instead, use
- * [`admin.projectManagement()`](admin.projectManagement#projectManagement).
+ * [`admin.projectManagement()`](projectManagement#projectManagement).
  */
 export class ProjectManagement implements FirebaseServiceInterface, ProjectManagementInterface {
   public readonly INTERNAL: ProjectManagementInternals = new ProjectManagementInternals();

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -17,13 +17,13 @@
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.remoteConfig.RemoteConfig `RemoteConfig`} service for the
+ * Gets the {@link remoteConfig.RemoteConfig `RemoteConfig`} service for the
  * default app or a given app.
  *
  * `admin.remoteConfig()` can be called with no arguments to access the default
- * app's {@link admin.remoteConfig.RemoteConfig `RemoteConfig`} service or as
+ * app's {@link remoteConfig.RemoteConfig `RemoteConfig`} service or as
  * `admin.remoteConfig(app)` to access the
- * {@link admin.remoteConfig.RemoteConfig `RemoteConfig`} service associated with a
+ * {@link remoteConfig.RemoteConfig `RemoteConfig`} service associated with a
  * specific app.
  *
  * @example
@@ -315,15 +315,12 @@ export namespace remoteConfig {
 
   /**
    * The Firebase `RemoteConfig` service interface.
-   *
-   * Do not call this constructor directly. Instead, use
-   * [`admin.remoteConfig()`](admin.remoteConfig#remoteConfig).
    */
   export interface RemoteConfig {
     app: app.App;
 
     /**
-     * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
+     * Gets the current active version of the {@link remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
      *
      * @return A promise that fulfills with a `RemoteConfigTemplate`.
@@ -331,7 +328,7 @@ export namespace remoteConfig {
     getTemplate(): Promise<RemoteConfigTemplate>;
 
     /**
-     * Gets the requested version of the {@link admin.remoteConfig.RemoteConfigTemplate
+     * Gets the requested version of the {@link remoteConfig.RemoteConfigTemplate
      * `RemoteConfigTemplate`} of the project.
      *
      * @param versionNumber Version number of the Remote Config template to look up.
@@ -341,7 +338,7 @@ export namespace remoteConfig {
     getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
 
     /**
-     * Validates a {@link admin.remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.
+     * Validates a {@link remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.
      *
      * @param template The Remote Config template to be validated.
      * @returns A promise that fulfills with the validated `RemoteConfigTemplate`.
@@ -384,7 +381,7 @@ export namespace remoteConfig {
     * All versions that correspond to non-active Remote Config templates (that is, all except the
     * template that is being fetched by clients) are also deleted if they are more than 90 days old.
     *
-    * @param options Optional {@link admin.remoteConfig.ListVersionsOptions `ListVersionsOptions`}
+    * @param options Optional {@link remoteConfig.ListVersionsOptions `ListVersionsOptions`}
     *    object for getting a list of template versions.
     * @return A promise that fulfills with a `ListVersionsResult`.
     */

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -62,7 +62,7 @@ export class RemoteConfig implements FirebaseServiceInterface, RemoteConfigInter
   }
 
   /**
-   * Gets the current active version of the {@link admin.remoteConfig.RemoteConfigTemplate
+   * Gets the current active version of the {@link remoteConfig.RemoteConfigTemplate
    * `RemoteConfigTemplate`} of the project.
    *
    * @return A promise that fulfills with a `RemoteConfigTemplate`.
@@ -75,7 +75,7 @@ export class RemoteConfig implements FirebaseServiceInterface, RemoteConfigInter
   }
 
   /**
-   * Gets the requested version of the {@link admin.remoteConfig.RemoteConfigTemplate
+   * Gets the requested version of the {@link remoteConfig.RemoteConfigTemplate
     * `RemoteConfigTemplate`} of the project.
    *
    * @param versionNumber Version number of the Remote Config template to look up.
@@ -90,7 +90,7 @@ export class RemoteConfig implements FirebaseServiceInterface, RemoteConfigInter
   }
 
   /**
-   * Validates a {@link admin.remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.
+   * Validates a {@link remoteConfig.RemoteConfigTemplate `RemoteConfigTemplate`}.
    *
    * @param template The Remote Config template to be validated.
    * @returns A promise that fulfills with the validated `RemoteConfigTemplate`.

--- a/src/security-rules/index.ts
+++ b/src/security-rules/index.ts
@@ -17,13 +17,13 @@
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.securityRules.SecurityRules
+ * Gets the {@link securityRules.SecurityRules
  * `SecurityRules`} service for the default app or a given app.
  *
  * `admin.securityRules()` can be called with no arguments to access the
- * default app's {@link admin.securityRules.SecurityRules
+ * default app's {@link securityRules.SecurityRules
  * `SecurityRules`} service, or as `admin.securityRules(app)` to access
- * the {@link admin.securityRules.SecurityRules `SecurityRules`}
+ * the {@link securityRules.SecurityRules `SecurityRules`}
  * service associated with a specific app.
  *
  * @example
@@ -51,7 +51,7 @@ export namespace securityRules {
   /**
    * A source file containing some Firebase security rules. The content includes raw
    * source code including text formatting, indentation and comments. Use the
-   * [`securityRules.createRulesFileFromSource()`](admin.securityRules.SecurityRules#createRulesFileFromSource)
+   * [`securityRules.createRulesFileFromSource()`](securityRules.SecurityRules#createRulesFileFromSource)
    * method to create new instances of this type.
    */
   export interface RulesFile {
@@ -65,8 +65,8 @@ export namespace securityRules {
   export interface RulesetMetadata {
     /**
      * Name of the `Ruleset` as a short string. This can be directly passed into APIs
-     * like [`securityRules.getRuleset()`](admin.securityRules.SecurityRules#getRuleset)
-     * and [`securityRules.deleteRuleset()`](admin.securityRules.SecurityRules#deleteRuleset).
+     * like {@link securityRules.SecurityRules.getRuleset `securityRules.getRuleset()`}
+     * and {@link securityRules.SecurityRules.deleteRuleset `securityRules.deleteRuleset()`}.
      */
     readonly name: string;
     /**
@@ -98,15 +98,12 @@ export namespace securityRules {
 
   /**
    * The Firebase `SecurityRules` service interface.
-   *
-   * Do not call this constructor directly. Instead, use
-   * [`admin.securityRules()`](admin.securityRules#securityRules).
    */
   export interface SecurityRules {
     app: app.App;
 
     /**
-     * Creates a {@link admin.securityRules.RulesFile `RuleFile`} with the given name
+     * Creates a {@link securityRules.RulesFile `RuleFile`} with the given name
      * and source. Throws an error if any of the arguments are invalid. This is a local
      * operation, and does not involve any network API calls.
      *
@@ -125,8 +122,8 @@ export namespace securityRules {
     createRulesFileFromSource(name: string, source: string | Buffer): RulesFile;
 
     /**
-     * Creates a new {@link admin.securityRules.Ruleset `Ruleset`} from the given
-     * {@link admin.securityRules.RulesFile `RuleFile`}.
+     * Creates a new {@link securityRules.Ruleset `Ruleset`} from the given
+     * {@link securityRules.RulesFile `RuleFile`}.
      *
      * @param file Rules file to include in the new `Ruleset`.
      * @returns A promise that fulfills with the newly created `Ruleset`.
@@ -134,7 +131,7 @@ export namespace securityRules {
     createRuleset(file: RulesFile): Promise<Ruleset>;
 
     /**
-     * Gets the {@link admin.securityRules.Ruleset `Ruleset`} identified by the given
+     * Gets the {@link securityRules.Ruleset `Ruleset`} identified by the given
      * name. The input name should be the short name string without the project ID
      * prefix. For example, to retrieve the `projects/project-id/rulesets/my-ruleset`,
      * pass the short name "my-ruleset". Rejects with a `not-found` error if the
@@ -146,7 +143,7 @@ export namespace securityRules {
     getRuleset(name: string): Promise<Ruleset>;
 
     /**
-     * Deletes the {@link admin.securityRules.Ruleset `Ruleset`} identified by the given
+     * Deletes the {@link securityRules.Ruleset `Ruleset`} identified by the given
      * name. The input name should be the short name string without the project ID
      * prefix. For example, to delete the `projects/project-id/rulesets/my-ruleset`,
      * pass the  short name "my-ruleset". Rejects with a `not-found` error if the
@@ -170,7 +167,7 @@ export namespace securityRules {
       pageSize?: number, nextPageToken?: string): Promise<RulesetMetadataList>;
 
     /**
-     * Gets the {@link admin.securityRules.Ruleset `Ruleset`} currently applied to
+     * Gets the {@link securityRules.Ruleset `Ruleset`} currently applied to
      * Cloud Firestore. Rejects with a `not-found` error if no ruleset is applied
      * on Firestore.
      *
@@ -179,7 +176,7 @@ export namespace securityRules {
     getFirestoreRuleset(): Promise<Ruleset>;
 
     /**
-     * Creates a new {@link admin.securityRules.Ruleset `Ruleset`} from the given
+     * Creates a new {@link securityRules.Ruleset `Ruleset`} from the given
      * source, and applies it to Cloud Firestore.
      *
      * @param source Rules source to apply.
@@ -188,7 +185,7 @@ export namespace securityRules {
     releaseFirestoreRulesetFromSource(source: string | Buffer): Promise<Ruleset>;
 
     /**
-     * Applies the specified {@link admin.securityRules.Ruleset `Ruleset`} ruleset
+     * Applies the specified {@link securityRules.Ruleset `Ruleset`} ruleset
      * to Cloud Firestore.
      *
      * @param ruleset Name of the ruleset to apply or a `RulesetMetadata` object
@@ -198,7 +195,7 @@ export namespace securityRules {
     releaseFirestoreRuleset(ruleset: string | RulesetMetadata): Promise<void>;
 
     /**
-     * Gets the {@link admin.securityRules.Ruleset `Ruleset`} currently applied to a
+     * Gets the {@link securityRules.Ruleset `Ruleset`} currently applied to a
      * Cloud Storage bucket. Rejects with a `not-found` error if no ruleset is applied
      * on the bucket.
      *
@@ -210,27 +207,27 @@ export namespace securityRules {
     getStorageRuleset(bucket?: string): Promise<Ruleset>;
 
     /**
-     * Creates a new {@link admin.securityRules.Ruleset `Ruleset`} from the given
+     * Creates a new {@link securityRules.Ruleset `Ruleset`} from the given
      * source, and applies it to a Cloud Storage bucket.
      *
      * @param source Rules source to apply.
      * @param bucket Optional name of the Cloud Storage bucket to apply the rules on. If
      *   not specified, applies the ruleset on the default bucket configured via
-     *   {@link admin.AppOptions `AppOptions`}.
+     *   {@link AppOptions `AppOptions`}.
      * @return A promise that fulfills when the ruleset is created and released.
      */
     releaseStorageRulesetFromSource(
       source: string | Buffer, bucket?: string): Promise<Ruleset>;
 
     /**
-     * Applies the specified {@link admin.securityRules.Ruleset `Ruleset`} ruleset
+     * Applies the specified {@link securityRules.Ruleset `Ruleset`} ruleset
      * to a Cloud Storage bucket.
      *
      * @param ruleset Name of the ruleset to apply or a `RulesetMetadata` object
      *   containing the name.
      * @param bucket Optional name of the Cloud Storage bucket to apply the rules on. If
      *   not specified, applies the ruleset on the default bucket configured via
-     *   {@link admin.AppOptions `AppOptions`}.
+     *   {@link AppOptions `AppOptions`}.
      * @return A promise that fulfills when the ruleset is released.
      */
     releaseStorageRuleset(

--- a/src/security-rules/security-rules.ts
+++ b/src/security-rules/security-rules.ts
@@ -83,7 +83,7 @@ export class Ruleset implements RulesetInterface {
  * The Firebase `SecurityRules` service interface.
  *
  * Do not call this constructor directly. Instead, use
- * [`admin.securityRules()`](admin.securityRules#securityRules).
+ * [`admin.securityRules()`](securityRules#securityRules).
  */
 export class SecurityRules implements FirebaseServiceInterface, SecurityRulesInterface {
 
@@ -221,7 +221,7 @@ export class SecurityRules implements FirebaseServiceInterface, SecurityRulesInt
   }
 
   /**
-   * Creates a {@link admin.securityRules.RulesFile `RuleFile`} with the given name
+   * Creates a {@link securityRules.RulesFile `RuleFile`} with the given name
    * and source. Throws an error if any of the arguments are invalid. This is a local
    * operation, and does not involve any network API calls.
    *
@@ -260,8 +260,8 @@ export class SecurityRules implements FirebaseServiceInterface, SecurityRulesInt
   }
 
   /**
-   * Creates a new {@link admin.securityRules.Ruleset `Ruleset`} from the given
-   * {@link admin.securityRules.RulesFile `RuleFile`}.
+   * Creates a new {@link securityRules.Ruleset `Ruleset`} from the given
+   * {@link securityRules.RulesFile `RuleFile`}.
    *
    * @param file Rules file to include in the new `Ruleset`.
    * @returns A promise that fulfills with the newly created `Ruleset`.
@@ -280,7 +280,7 @@ export class SecurityRules implements FirebaseServiceInterface, SecurityRulesInt
   }
 
   /**
-   * Deletes the {@link admin.securityRules.Ruleset `Ruleset`} identified by the given
+   * Deletes the {@link securityRules.Ruleset `Ruleset`} identified by the given
    * name. The input name should be the short name string without the project ID
    * prefix. For example, to delete the `projects/project-id/rulesets/my-ruleset`,
    * pass the  short name "my-ruleset". Rejects with a `not-found` error if the

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -18,13 +18,13 @@ import { Bucket } from '@google-cloud/storage';
 import { app } from '../firebase-namespace-api';
 
 /**
- * Gets the {@link admin.storage.Storage `Storage`} service for the
+ * Gets the {@link storage.Storage `Storage`} service for the
  * default app or a given app.
  *
  * `admin.storage()` can be called with no arguments to access the default
- * app's {@link admin.storage.Storage `Storage`} service or as
+ * app's {@link storage.Storage `Storage`} service or as
  * `admin.storage(app)` to access the
- * {@link admin.storage.Storage `Storage`} service associated with a
+ * {@link storage.Storage `Storage`} service associated with a
  * specific app.
  *
  * @example


### PR DESCRIPTION
Single API Extractor/API Documenter integration can take a while, I'm fixing our existing TypeDoc pipeline to work with the auto-generated typings.

* Updated the API docs generator to run against auto-generated d.ts files in the `lib/` directory.
* Updated the affected TOC entries.
* Adding RTDB type aliases to the generated HTML (in a manner similar to how Firestore type aliases are handled)
* Fixed a bunch of broken cross links.
* Defined `Database` as a type that extends the `@firebase/database` package, as opposed to using module augmentation. TypeDoc generates a much better HTML output for RTDB types with this change.

Preview at cl/336354281