### PR TITLE
chore: Enabled quotes rule in eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
         'ignoreUrls': true
       }
     ],
-    "object-curly-spacing": [2, "always"],
+    'object-curly-spacing': [2, 'always'],
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       {
@@ -54,6 +54,7 @@ module.exports = {
       }
     ],
     'no-unused-vars': 'off', // Must be disabled to enable the next rule
-    '@typescript-eslint/no-unused-vars': ['error']
+    '@typescript-eslint/no-unused-vars': ['error'],
+    'quotes': ['error', 'single']
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,6 @@ module.exports = {
     ],
     'no-unused-vars': 'off', // Must be disabled to enable the next rule
     '@typescript-eslint/no-unused-vars': ['error'],
-    'quotes': ['error', 'single']
+    'quotes': ['error', 'single', {'avoidEscape': true}]
   }
 };

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -266,7 +266,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: Wri
       !validator.isNonEmptyString(request.mfaEnrollmentId)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_UID,
-      `The second factor "uid" must be a valid non-empty string.`,
+      'The second factor "uid" must be a valid non-empty string.',
     );
   }
   if (typeof request.displayName !== 'undefined' &&
@@ -282,7 +282,7 @@ function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: Wri
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
       `The second factor "enrollmentTime" for "${authFactorInfoIdentifier}" must be a valid ` +
-      `UTC date string.`);
+      'UTC date string.');
   }
   // Validate required fields depending on second factor type.
   if (typeof request.phoneInfo !== 'undefined') {
@@ -291,14 +291,14 @@ function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: Wri
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_PHONE_NUMBER,
         `The second factor "phoneNumber" for "${authFactorInfoIdentifier}" must be a non-empty ` +
-        `E.164 standard compliant identifier string.`);
+        'E.164 standard compliant identifier string.');
     }
   } else {
     // Invalid second factor. For example, a phone second factor may have been provided without
     // a phone number. A TOTP based second factor may require a secret key, etc.
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_ENROLLED_FACTORS,
-      `MFAInfo object provided is invalid.`);
+      'MFAInfo object provided is invalid.');
   }
 }
 
@@ -601,7 +601,7 @@ export const FIREBASE_AUTH_DOWNLOAD_ACCOUNT = new ApiSettings('/accounts:batchGe
         request.maxResults > MAX_DOWNLOAD_ACCOUNT_PAGE_SIZE) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `Required "maxResults" must be a positive integer that does not exceed ` +
+        'Required "maxResults" must be a positive integer that does not exceed ' +
         `${MAX_DOWNLOAD_ACCOUNT_PAGE_SIZE}.`,
       );
     }
@@ -742,14 +742,14 @@ export const FIREBASE_AUTH_SIGN_UP_NEW_USER = new ApiSettings('/accounts', 'POST
     if (typeof request.customAttributes !== 'undefined') {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `"customAttributes" cannot be set when creating a new user.`,
+        '"customAttributes" cannot be set when creating a new user.',
       );
     }
     // signupNewUser does not support validSince.
     if (typeof request.validSince !== 'undefined') {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `"validSince" cannot be set when creating a new user.`,
+        '"validSince" cannot be set when creating a new user.',
       );
     }
     // Throw error when tenantId is passed in POST body.
@@ -852,7 +852,7 @@ const LIST_OAUTH_IDP_CONFIGS = new ApiSettings('/oauthIdpConfigs', 'GET')
         request.pageSize > MAX_LIST_PROVIDER_CONFIGURATION_PAGE_SIZE) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `Required "maxResults" must be a positive integer that does not exceed ` +
+        'Required "maxResults" must be a positive integer that does not exceed ' +
         `${MAX_LIST_PROVIDER_CONFIGURATION_PAGE_SIZE}.`,
       );
     }
@@ -915,7 +915,7 @@ const LIST_INBOUND_SAML_CONFIGS = new ApiSettings('/inboundSamlConfigs', 'GET')
         request.pageSize > MAX_LIST_PROVIDER_CONFIGURATION_PAGE_SIZE) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `Required "maxResults" must be a positive integer that does not exceed ` +
+        'Required "maxResults" must be a positive integer that does not exceed ' +
         `${MAX_LIST_PROVIDER_CONFIGURATION_PAGE_SIZE}.`,
       );
     }
@@ -1471,7 +1471,7 @@ export abstract class AbstractAuthRequestHandler {
       return Promise.reject(
         new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          "`actionCodeSettings` is required when `requestType` === 'EMAIL_SIGNIN'",
+          '`actionCodeSettings` is required when `requestType` === \'EMAIL_SIGNIN\'',
         ),
       );
     }
@@ -1865,7 +1865,7 @@ const LIST_TENANTS = new ApiSettings('/tenants', 'GET')
         request.pageSize > MAX_LIST_TENANT_PAGE_SIZE) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `Required "maxResults" must be a positive non-zero number that does not exceed ` +
+        'Required "maxResults" must be a positive non-zero number that does not exceed ' +
         `the allowed ${MAX_LIST_TENANT_PAGE_SIZE}.`,
       );
     }

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -145,7 +145,7 @@ class AuthResourceUrlBuilder {
   constructor(protected app: FirebaseApp, protected version: string = 'v1') {
     const emulatorHost = process.env.FIREBASE_AUTH_EMULATOR_HOST;
     if (emulatorHost) {
-      this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT, { 
+      this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT, {
         host: emulatorHost
       });
     } else {
@@ -212,7 +212,7 @@ class TenantAwareAuthResourceUrlBuilder extends AuthResourceUrlBuilder {
     super(app, version);
     const emulatorHost = process.env.FIREBASE_AUTH_EMULATOR_HOST
     if (emulatorHost) {
-      this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_TENANT_URL_FORMAT, { 
+      this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_TENANT_URL_FORMAT, {
         host: emulatorHost
       });
     } else {
@@ -1471,7 +1471,7 @@ export abstract class AbstractAuthRequestHandler {
       return Promise.reject(
         new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          '`actionCodeSettings` is required when `requestType` === \'EMAIL_SIGNIN\'',
+          "`actionCodeSettings` is required when `requestType` === 'EMAIL_SIGNIN'",
         ),
       );
     }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -564,7 +564,7 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
     return Promise.reject(
       new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `"AuthProviderConfigFilter.type" must be either "saml' or "oidc"`));
+        '"AuthProviderConfigFilter.type" must be either "saml\' or "oidc"'));
   }
 
   /**

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -564,7 +564,7 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
     return Promise.reject(
       new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        '"AuthProviderConfigFilter.type" must be either "saml\' or "oidc"'));
+        '"AuthProviderConfigFilter.type" must be either "saml" or "oidc"'));
   }
 
   /**

--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -220,8 +220,8 @@ export class IAMSigner implements CryptoSigner {
     }).catch((err) => {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_CREDENTIAL,
-        `Failed to determine service account. Make sure to initialize ` +
-        `the SDK with a service account credential. Alternatively specify a service ` +
+        'Failed to determine service account. Make sure to initialize ' +
+        'the SDK with a service account credential. Alternatively specify a service ' +
         `account with iam.serviceAccounts.signBlob permission. Original error: ${err}`,
       );
     });

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -83,47 +83,47 @@ export class FirebaseTokenVerifier {
     if (!validator.isURL(clientCertUrl)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The provided public client certificate URL is an invalid URL.`,
+        'The provided public client certificate URL is an invalid URL.',
       );
     } else if (!validator.isNonEmptyString(algorithm)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The provided JWT algorithm is an empty string.`,
+        'The provided JWT algorithm is an empty string.',
       );
     } else if (!validator.isURL(issuer)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The provided JWT issuer is an invalid URL.`,
+        'The provided JWT issuer is an invalid URL.',
       );
     } else if (!validator.isNonNullObject(tokenInfo)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The provided JWT information is not an object or null.`,
+        'The provided JWT information is not an object or null.',
       );
     } else if (!validator.isURL(tokenInfo.url)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The provided JWT verification documentation URL is invalid.`,
+        'The provided JWT verification documentation URL is invalid.',
       );
     } else if (!validator.isNonEmptyString(tokenInfo.verifyApiName)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The JWT verify API name must be a non-empty string.`,
+        'The JWT verify API name must be a non-empty string.',
       );
     } else if (!validator.isNonEmptyString(tokenInfo.jwtName)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The JWT public full name must be a non-empty string.`,
+        'The JWT public full name must be a non-empty string.',
       );
     } else if (!validator.isNonEmptyString(tokenInfo.shortName)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The JWT public short name must be a non-empty string.`,
+        'The JWT public short name must be a non-empty string.',
       );
     } else if (!validator.isNonNullObject(tokenInfo.expiredErrorCode) || !('code' in tokenInfo.expiredErrorCode)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,
-        `The JWT expiration error code must be a non-null ErrorInfo object.`,
+        'The JWT expiration error code must be a non-null ErrorInfo object.',
       );
     }
     this.shortNameArticle = tokenInfo.shortName.charAt(0).match(/[aeiou]/i) ? 'an' : 'a';
@@ -164,7 +164,7 @@ export class FirebaseTokenVerifier {
     if (!validator.isNonEmptyString(projectId)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_CREDENTIAL,
-        `Must initialize app with a cert credential or set your Firebase project ID as the ` +
+        'Must initialize app with a cert credential or set your Firebase project ID as the ' +
         `GOOGLE_CLOUD_PROJECT environment variable to call ${this.tokenInfo.verifyApiName}.`,
       );
     }
@@ -177,7 +177,7 @@ export class FirebaseTokenVerifier {
     const payload = fullDecodedToken && fullDecodedToken.payload;
 
     const projectIdMatchMessage = ` Make sure the ${this.tokenInfo.shortName} comes from the same ` +
-      `Firebase project as the service account used to authenticate this SDK.`;
+      'Firebase project as the service account used to authenticate this SDK.';
     const verifyJwtTokenDocsMessage = ` See ${this.tokenInfo.url} ` +
       `for details on how to retrieve ${this.shortNameArticle} ${this.tokenInfo.shortName}.`;
 
@@ -201,16 +201,16 @@ export class FirebaseTokenVerifier {
 
       errorMessage += verifyJwtTokenDocsMessage;
     } else if (header.alg !== this.algorithm) {
-      errorMessage = `${this.tokenInfo.jwtName} has incorrect algorithm. Expected "` + this.algorithm + `" but got ` +
-        `"` + header.alg + `".` + verifyJwtTokenDocsMessage;
+      errorMessage = `${this.tokenInfo.jwtName} has incorrect algorithm. Expected "` + this.algorithm + '" but got ' +
+        '"' + header.alg + '".' + verifyJwtTokenDocsMessage;
     } else if (payload.aud !== projectId) {
       errorMessage = `${this.tokenInfo.jwtName} has incorrect "aud" (audience) claim. Expected "` +
-        projectId + `" but got "` + payload.aud + `".` + projectIdMatchMessage +
+        projectId + '" but got "' + payload.aud + '".' + projectIdMatchMessage +
         verifyJwtTokenDocsMessage;
     } else if (payload.iss !== this.issuer + projectId) {
       errorMessage = `${this.tokenInfo.jwtName} has incorrect "iss" (issuer) claim. Expected ` +
-        `"${this.issuer}"` + projectId + `" but got "` +
-        payload.iss + `".` + projectIdMatchMessage + verifyJwtTokenDocsMessage;
+        `"${this.issuer}"` + projectId + '" but got "' +
+        payload.iss + '".' + projectIdMatchMessage + verifyJwtTokenDocsMessage;
     } else if (typeof payload.sub !== 'string') {
       errorMessage = `${this.tokenInfo.jwtName} has no "sub" (subject) claim.` + verifyJwtTokenDocsMessage;
     } else if (payload.sub === '') {
@@ -236,7 +236,7 @@ export class FirebaseTokenVerifier {
             AuthClientErrorCode.INVALID_ARGUMENT,
             `${this.tokenInfo.jwtName} has "kid" claim which does not correspond to a known public key. ` +
             `Most likely the ${this.tokenInfo.shortName} is expired, so get a fresh token from your ` +
-            `client app and try again.`,
+            'client app and try again.',
           ),
         );
       } else {
@@ -257,7 +257,7 @@ export class FirebaseTokenVerifier {
     const verifyJwtTokenDocsMessage = ` See ${this.tokenInfo.url} ` +
       `for details on how to retrieve ${this.shortNameArticle} ${this.tokenInfo.shortName}.`;
     return new Promise((resolve, reject) => {
-      jwt.verify(jwtToken, publicKey || "", {
+      jwt.verify(jwtToken, publicKey || '', {
         algorithms: [this.algorithm],
       }, (error: jwt.VerifyErrors | null, decodedToken: object | undefined) => {
         if (error) {

--- a/src/auth/user-import-builder.ts
+++ b/src/auth/user-import-builder.ts
@@ -103,7 +103,7 @@ export function convertMultiFactorInfoToServerFormat(multiFactorInfo: UpdateMult
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
         `The second factor "enrollmentTime" for "${multiFactorInfo.uid}" must be a valid ` +
-        `UTC date string.`);
+        'UTC date string.');
     }
   }
   // Currently only phone second factors are supported.
@@ -334,14 +334,14 @@ export class UserImportBuilder {
     if (!validator.isNonNullObject(options.hash)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.MISSING_HASH_ALGORITHM,
-        `"hash.algorithm" is missing from the provided "UserImportOptions".`,
+        '"hash.algorithm" is missing from the provided "UserImportOptions".',
       );
     }
     if (typeof options.hash.algorithm === 'undefined' ||
         !validator.isNonEmptyString(options.hash.algorithm)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_HASH_ALGORITHM,
-        `"hash.algorithm" must be a string matching the list of supported algorithms.`,
+        '"hash.algorithm" must be a string matching the list of supported algorithms.',
       );
     }
 
@@ -354,7 +354,7 @@ export class UserImportBuilder {
       if (!validator.isBuffer(options.hash.key)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_KEY,
-          `A non-empty "hash.key" byte buffer must be provided for ` +
+          'A non-empty "hash.key" byte buffer must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -390,7 +390,7 @@ export class UserImportBuilder {
       if (isNaN(rounds) || rounds < 0 || rounds > 120000) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_ROUNDS,
-          `A valid "hash.rounds" number between 0 and 120000 must be provided for ` +
+          'A valid "hash.rounds" number between 0 and 120000 must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -404,7 +404,7 @@ export class UserImportBuilder {
       if (!validator.isBuffer(options.hash.key)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_KEY,
-          `A "hash.key" byte buffer must be provided for ` +
+          'A "hash.key" byte buffer must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -412,7 +412,7 @@ export class UserImportBuilder {
       if (isNaN(rounds) || rounds <= 0 || rounds > 8) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_ROUNDS,
-          `A valid "hash.rounds" number between 1 and 8 must be provided for ` +
+          'A valid "hash.rounds" number between 1 and 8 must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -420,7 +420,7 @@ export class UserImportBuilder {
       if (isNaN(memoryCost) || memoryCost <= 0 || memoryCost > 14) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_MEMORY_COST,
-          `A valid "hash.memoryCost" number between 1 and 14 must be provided for ` +
+          'A valid "hash.memoryCost" number between 1 and 14 must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -428,7 +428,7 @@ export class UserImportBuilder {
             !validator.isBuffer(options.hash.saltSeparator)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_SALT_SEPARATOR,
-          `"hash.saltSeparator" must be a byte buffer.`,
+          '"hash.saltSeparator" must be a byte buffer.',
         );
       }
       populatedOptions = {
@@ -451,7 +451,7 @@ export class UserImportBuilder {
       if (isNaN(cpuMemCost)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_MEMORY_COST,
-          `A valid "hash.memoryCost" number must be provided for ` +
+          'A valid "hash.memoryCost" number must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -459,7 +459,7 @@ export class UserImportBuilder {
       if (isNaN(parallelization)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_PARALLELIZATION,
-          `A valid "hash.parallelization" number must be provided for ` +
+          'A valid "hash.parallelization" number must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -467,7 +467,7 @@ export class UserImportBuilder {
       if (isNaN(blockSize)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_BLOCK_SIZE,
-          `A valid "hash.blockSize" number must be provided for ` +
+          'A valid "hash.blockSize" number must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }
@@ -475,7 +475,7 @@ export class UserImportBuilder {
       if (isNaN(dkLen)) {
         throw new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_DERIVED_KEY_LENGTH,
-          `A valid "hash.derivedKeyLength" number must be provided for ` +
+          'A valid "hash.derivedKeyLength" number must be provided for ' +
             `hash algorithm ${options.hash.algorithm}.`,
         );
       }

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -247,7 +247,7 @@ export class FirebaseApp implements app.App {
     if (!validator.isNonNullObject(this.options_)) {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_APP_OPTIONS,
-        `Invalid Firebase app options passed as the first argument to initializeApp() for the ` +
+        'Invalid Firebase app options passed as the first argument to initializeApp() for the ' +
         `app named "${this.name_}". Options must be a non-null object.`,
       );
     }
@@ -261,9 +261,9 @@ export class FirebaseApp implements app.App {
     if (typeof credential !== 'object' || credential === null || typeof credential.getAccessToken !== 'function') {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_APP_OPTIONS,
-        `Invalid Firebase app options passed as the first argument to initializeApp() for the ` +
+        'Invalid Firebase app options passed as the first argument to initializeApp() for the ' +
         `app named "${this.name_}". The "credential" property must be an object which implements ` +
-        `the Credential interface.`,
+        'the Credential interface.',
       );
     }
 

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -164,7 +164,7 @@ export class FirebaseNamespaceInternals {
     if (typeof appName === 'undefined') {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_APP_NAME,
-        `No Firebase app name provided. App name must be a non-empty string.`,
+        'No Firebase app name provided. App name must be a non-empty string.',
       );
     }
 
@@ -189,7 +189,7 @@ export class FirebaseNamespaceInternals {
     appHook?: AppHook): FirebaseServiceNamespace<FirebaseServiceInterface> {
     let errorMessage;
     if (typeof serviceName === 'undefined') {
-      errorMessage = `No service name provided. Service name must be a non-empty string.`;
+      errorMessage = 'No service name provided. Service name must be a non-empty string.';
     } else if (typeof serviceName !== 'string' || serviceName === '') {
       errorMessage = `Invalid service name "${serviceName}" provided. Service name must be a non-empty string.`;
     } else if (serviceName in this.serviceFactories) {

--- a/src/machine-learning/machine-learning.ts
+++ b/src/machine-learning/machine-learning.ts
@@ -368,8 +368,8 @@ export class Model implements ModelInterface {
     }
 
     // Remove '@type' field. We don't need it.
-    if ((tmpModel as any)["@type"]) {
-      delete (tmpModel as any)["@type"];
+    if ((tmpModel as any)['@type']) {
+      delete (tmpModel as any)['@type'];
     }
     return tmpModel;
   }

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -824,7 +824,7 @@ export class Messaging implements FirebaseServiceInterface, MessagingInterface {
         throw new FirebaseMessagingError(
           MessagingClientErrorCode.INVALID_PAYLOAD,
           `Messaging payload contains an invalid "${payloadKey}" property. Valid properties are ` +
-          `"data" and "notification".`,
+          '"data" and "notification".',
         );
       } else {
         containsDataOrNotificationKey = true;
@@ -845,7 +845,7 @@ export class Messaging implements FirebaseServiceInterface, MessagingInterface {
         throw new FirebaseMessagingError(
           MessagingClientErrorCode.INVALID_PAYLOAD,
           `Messaging payload contains an invalid value for the "${payloadKey}" property. ` +
-          `Value must be an object.`,
+          'Value must be an object.',
         );
       }
 
@@ -855,7 +855,7 @@ export class Messaging implements FirebaseServiceInterface, MessagingInterface {
           throw new FirebaseMessagingError(
             MessagingClientErrorCode.INVALID_PAYLOAD,
             `Messaging payload contains an invalid value for the "${payloadKey}.${subKey}" ` +
-            `property. Values must be strings.`,
+            'property. Values must be strings.',
           );
         } else if (payloadKey === 'data' && /^google\./.test(subKey)) {
           // Validate the data payload does not contain keys which start with 'google.'.

--- a/src/project-management/android-app.ts
+++ b/src/project-management/android-app.ts
@@ -113,7 +113,7 @@ export class AndroidApp implements AndroidAppInterface {
               validator.isNonEmptyString(certificateJson[requiredField]),
               responseData,
               `getShaCertificates()'s responseData.certificates[].${requiredField} must be a `
-                      + `non-empty string.`);
+                      + 'non-empty string.');
           });
 
           return new ShaCertificate(certificateJson.shaHash, certificateJson.name);
@@ -171,7 +171,7 @@ export class AndroidApp implements AndroidAppInterface {
         assertServerResponse(
           validator.isBase64String(base64ConfigFileContents),
           responseData,
-          `getConfig()'s responseData.configFileContents must be a base64 string.`);
+          'getConfig()\'s responseData.configFileContents must be a base64 string.');
 
         return Buffer.from(base64ConfigFileContents, 'base64').toString('utf8');
       });

--- a/src/project-management/ios-app.ts
+++ b/src/project-management/ios-app.ts
@@ -102,7 +102,7 @@ export class IosApp implements IosAppInterface {
         assertServerResponse(
           validator.isBase64String(base64ConfigFileContents),
           responseData,
-          `getConfig()'s responseData.configFileContents must be a base64 string.`);
+          'getConfig()\'s responseData.configFileContents must be a base64 string.');
 
         return Buffer.from(base64ConfigFileContents, 'base64').toString('utf8');
       });

--- a/src/project-management/project-management-api-request-internal.ts
+++ b/src/project-management/project-management-api-request-internal.ts
@@ -173,11 +173,11 @@ export class ProjectManagementRequestHandler {
         assertServerResponse(
           validator.isNonNullObject(responseData),
           responseData,
-          `createAndroidApp's responseData must be a non-null object.`);
+          'createAndroidApp\'s responseData must be a non-null object.');
         assertServerResponse(
           validator.isNonEmptyString(responseData.name),
           responseData,
-          `createAndroidApp's responseData.name must be a non-empty string.`);
+          'createAndroidApp\'s responseData.name must be a non-empty string.');
         return this.pollRemoteOperationWithExponentialBackoff(responseData.name);
       });
   }
@@ -200,11 +200,11 @@ export class ProjectManagementRequestHandler {
         assertServerResponse(
           validator.isNonNullObject(responseData),
           responseData,
-          `createIosApp's responseData must be a non-null object.`);
+          'createIosApp\'s responseData must be a non-null object.');
         assertServerResponse(
           validator.isNonEmptyString(responseData.name),
           responseData,
-          `createIosApp's responseData.name must be a non-empty string.`);
+          'createIosApp\'s responseData.name must be a non-empty string.');
         return this.pollRemoteOperationWithExponentialBackoff(responseData.name);
       });
   }

--- a/src/project-management/project-management.ts
+++ b/src/project-management/project-management.ts
@@ -153,7 +153,7 @@ export class ProjectManagement implements FirebaseServiceInterface, ProjectManag
         assertServerResponse(
           validator.isNonEmptyString(responseData.appId),
           responseData,
-          `"responseData.appId" field must be present in createAndroidApp()'s response data.`);
+          '"responseData.appId" field must be present in createAndroidApp()\'s response data.');
         return new AndroidApp(responseData.appId, this.requestHandler);
       });
   }
@@ -181,7 +181,7 @@ export class ProjectManagement implements FirebaseServiceInterface, ProjectManag
         assertServerResponse(
           validator.isNonEmptyString(responseData.appId),
           responseData,
-          `"responseData.appId" field must be present in createIosApp()'s response data.`);
+          '"responseData.appId" field must be present in createIosApp()\'s response data.');
         return new IosApp(responseData.appId, this.requestHandler);
       });
   }
@@ -229,11 +229,11 @@ export class ProjectManagement implements FirebaseServiceInterface, ProjectManag
       assertServerResponse(
         validator.isNonEmptyString(appJson.appId),
         responseData,
-        `"apps[].appId" field must be present in the listAppMetadata() response data.`);
+        '"apps[].appId" field must be present in the listAppMetadata() response data.');
       assertServerResponse(
         validator.isNonEmptyString(appJson.platform),
         responseData,
-        `"apps[].platform" field must be present in the listAppMetadata() response data.`);
+        '"apps[].platform" field must be present in the listAppMetadata() response data.');
       const metadata: AppMetadata = {
         appId: appJson.appId,
         platform: (AppPlatform as any)[appJson.platform] || AppPlatform.PLATFORM_UNKNOWN,

--- a/src/remote-config/remote-config-api-client-internal.ts
+++ b/src/remote-config/remote-config-api-client-internal.ts
@@ -410,7 +410,7 @@ interface Error {
 
 const ERROR_CODE_MAPPING: { [key: string]: RemoteConfigErrorCode } = {
   ABORTED: 'aborted',
-  ALREADY_EXISTS: `already-exists`,
+  ALREADY_EXISTS: 'already-exists',
   INVALID_ARGUMENT: 'invalid-argument',
   INTERNAL: 'internal-error',
   FAILED_PRECONDITION: 'failed-precondition',

--- a/test/integration/machine-learning.spec.ts
+++ b/test/integration/machine-learning.spec.ts
@@ -576,13 +576,13 @@ function getAutoMLModelReference(): Promise<string> {
   }
   catch (error) {
     // Returning an empty string will result in skipping the test.
-    return Promise.resolve("");
+    return Promise.resolve('');
   }
 
   const parent = automl.locationPath(projectId, 'us-central1');
-  return automl.listModels({ parent, filter:"displayName=admin_sdk_integ_test1" })
+  return automl.listModels({ parent, filter:'displayName=admin_sdk_integ_test1' })
     .then(([models]: [any]) => {
-      let modelRef = "";
+      let modelRef = '';
       for (const model of models) {
         modelRef = model.name;
       }

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -84,7 +84,7 @@ describe('admin.remoteConfig', () => {
 
   it('verify that the etag is read-only', () => {
     expect(() => {
-      (currentTemplate as any).etag = "new-etag";
+      (currentTemplate as any).etag = 'new-etag';
     }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
   });
 
@@ -273,7 +273,7 @@ describe('admin.remoteConfig', () => {
       const newTemplate = admin.remoteConfig().createTemplateFromJSON(jsonString);
       expect(newTemplate.etag).to.equal(sourceTemplate.etag);
       expect(() => {
-        (currentTemplate as any).etag = "new-etag";
+        (currentTemplate as any).etag = 'new-etag';
       }).to.throw(
         'Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter'
       );

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -268,7 +268,7 @@ export const messaging = {
   topic: 'mock-topic',
   topicWithPrefix: '/topics/mock-topic',
   topicWithPrivatePrefix: '/topics/private/mock-topic',
-  condition: "'mock-topic-0' in topics || ('mock-topic-1' in topics && 'mock-topic-2' in topics)",
+  condition: '\'mock-topic-0\' in topics || (\'mock-topic-1\' in topics && \'mock-topic-2\' in topics)',
   messageId: 1212121212,
   multicastId: 1234567890,
   notificationKey: 'mock-notification-key',

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -268,7 +268,7 @@ export const messaging = {
   topic: 'mock-topic',
   topicWithPrefix: '/topics/mock-topic',
   topicWithPrivatePrefix: '/topics/private/mock-topic',
-  condition: '\'mock-topic-0\' in topics || (\'mock-topic-1\' in topics && \'mock-topic-2\' in topics)',
+  condition: "'mock-topic-0' in topics || ('mock-topic-1' in topics && 'mock-topic-2' in topics)",
   messageId: 1212121212,
   multicastId: 1234567890,
   notificationKey: 'mock-notification-key',

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -622,7 +622,7 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
         const largeClaims = JSON.stringify({ key: createRandomString(991) });
         expect(() => {
           return requestValidator({ localId: '1234', customAttributes: largeClaims });
-        }).to.throw(`Developer claims payload should not exceed 1000 characters.`);
+        }).to.throw('Developer claims payload should not exceed 1000 characters.');
       });
       RESERVED_CLAIMS.forEach((invalidClaim) => {
         it(`should fail with customAttributes containing blacklisted claim: ${invalidClaim}`, () => {
@@ -641,7 +641,7 @@ describe('FIREBASE_AUTH_SET_ACCOUNT_INFO', () => {
             auth_time: 'time', // eslint-disable-line @typescript-eslint/camelcase
           };
           return requestValidator({ localId: '1234', customAttributes: JSON.stringify(claims) });
-        }).to.throw(`Developer claims "auth_time", "sub" are reserved and cannot be specified.`);
+        }).to.throw('Developer claims "auth_time", "sub" are reserved and cannot be specified.');
       });
       it('should fail with invalid validSince', () => {
         expect(() => {
@@ -1384,7 +1384,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should throw on invalid options without making an underlying API call', () => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_HASH_ALGORITHM,
-          `Unsupported hash algorithm provider "invalid".`,
+          'Unsupported hash algorithm provider "invalid".',
         );
         const invalidOptions = {
           hash: {
@@ -1404,7 +1404,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should throw when 1001 UserImportRecords are provided', () => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.MAXIMUM_USER_COUNT_EXCEEDED,
-          `A maximum of 1000 users can be imported at once.`,
+          'A maximum of 1000 users can be imported at once.',
         );
         const stub = sinon.stub(HttpClient.prototype, 'send');
         stubs.push(stub);
@@ -1666,7 +1666,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               index: 9,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.FORBIDDEN_CLAIM,
-                `Developer claim "aud" is reserved and cannot be specified.`,
+                'Developer claim "aud" is reserved and cannot be specified.',
               ),
             },
             { index: 10, error: new FirebaseAuthError(AuthClientErrorCode.INVALID_PASSWORD_HASH) },
@@ -1675,28 +1675,28 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               index: 12,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_UID,
-                `The provider "uid" for "google.com" must be a valid non-empty string.`,
+                'The provider "uid" for "google.com" must be a valid non-empty string.',
               ),
             },
             {
               index: 13,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_DISPLAY_NAME,
-                `The provider "displayName" for "google.com" must be a valid string.`,
+                'The provider "displayName" for "google.com" must be a valid string.',
               ),
             },
             {
               index: 14,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_EMAIL,
-                `The provider "email" for "google.com" must be a valid email string.`,
+                'The provider "email" for "google.com" must be a valid email string.',
               ),
             },
             {
               index: 15,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_PHOTO_URL,
-                `The provider "photoURL" for "google.com" must be a valid URL string.`,
+                'The provider "photoURL" for "google.com" must be a valid URL string.',
               ),
             },
             { index: 16, error: new FirebaseAuthError(AuthClientErrorCode.INVALID_PROVIDER_ID) },
@@ -1705,29 +1705,29 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               index: 18,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_UID,
-                `The second factor "uid" must be a valid non-empty string.`,
+                'The second factor "uid" must be a valid non-empty string.',
               ),
             },
             {
               index: 19,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_DISPLAY_NAME,
-                `The second factor "displayName" for "mfaUid1" must be a valid string.`,
+                'The second factor "displayName" for "mfaUid1" must be a valid string.',
               ),
             },
             {
               index: 20,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
-                `The second factor "enrollmentTime" for "mfaUid2" must be a valid UTC date string.`,
+                'The second factor "enrollmentTime" for "mfaUid2" must be a valid UTC date string.',
               ),
             },
             {
               index: 21,
               error: new FirebaseAuthError(
                 AuthClientErrorCode.INVALID_PHONE_NUMBER,
-                `The second factor "phoneNumber" for "mfaUid3" must be a non-empty ` +
-                `E.164 standard compliant identifier string.`,
+                'The second factor "phoneNumber" for "mfaUid3" must be a non-empty ' +
+                'E.164 standard compliant identifier string.',
               ),
             },
             {
@@ -1758,7 +1758,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         });
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INTERNAL_ERROR,
-          `An internal error has occurred. Raw server response: ` +
+          'An internal error has occurred. Raw server response: ' +
           `"${JSON.stringify(expectedServerError.response.data)}"`,
         );
         const stub = sinon.stub(HttpClient.prototype, 'send').rejects(expectedServerError);
@@ -1838,8 +1838,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should be rejected given an invalid maxResults', () => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          `Required "maxResults" must be a positive integer that does not ` +
-          `exceed 1000.`,
+          'Required "maxResults" must be a positive integer that does not ' +
+          'exceed 1000.',
         );
 
         const requestHandler = handler.init(mockApp);
@@ -2227,7 +2227,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           name: 'invalid second factor uid',
           error: new FirebaseAuthError(
             AuthClientErrorCode.INVALID_UID,
-            `The second factor "uid" must be a valid non-empty string.`,
+            'The second factor "uid" must be a valid non-empty string.',
           ),
           secondFactor: {
             uid: ['enrollmentId'],
@@ -2240,7 +2240,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           name: 'invalid second factor display name',
           error: new FirebaseAuthError(
             AuthClientErrorCode.INVALID_DISPLAY_NAME,
-            `The second factor "displayName" for "enrolledSecondFactor1" must be a valid string.`,
+            'The second factor "displayName" for "enrolledSecondFactor1" must be a valid string.',
           ),
           secondFactor: {
             uid: 'enrolledSecondFactor1',
@@ -2253,8 +2253,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           name: 'invalid second factor phone number',
           error: new FirebaseAuthError(
             AuthClientErrorCode.INVALID_PHONE_NUMBER,
-            `The second factor "phoneNumber" for "enrolledSecondFactor1" must be a non-empty ` +
-            `E.164 standard compliant identifier string.`),
+            'The second factor "phoneNumber" for "enrolledSecondFactor1" must be a non-empty ' +
+            'E.164 standard compliant identifier string.'),
           secondFactor: {
             uid: 'enrolledSecondFactor1',
             phoneNumber: 'invalid',
@@ -2266,8 +2266,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           name: 'invalid second factor enrollment time',
           error: new FirebaseAuthError(
             AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
-            `The second factor "enrollmentTime" for "enrolledSecondFactor1" must be a valid ` +
-            `UTC date string.`),
+            'The second factor "enrollmentTime" for "enrolledSecondFactor1" must be a valid ' +
+            'UTC date string.'),
           secondFactor: {
             uid: 'enrolledSecondFactor1',
             phoneNumber: '+16505557348',
@@ -2445,7 +2445,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         // Expected error when invalid claims are provided.
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.FORBIDDEN_CLAIM,
-          `Developer claim "aud" is reserved and cannot be specified.`,
+          'Developer claim "aud" is reserved and cannot be specified.',
         );
         const requestHandler = handler.init(mockApp);
         const blacklistedClaims = { admin: true, aud: 'bla' };
@@ -2724,7 +2724,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             name: 'invalid second factor display name',
             error: new FirebaseAuthError(
               AuthClientErrorCode.INVALID_DISPLAY_NAME,
-              `The second factor "displayName" for "+16505557348" must be a valid string.`,
+              'The second factor "displayName" for "+16505557348" must be a valid string.',
             ),
             secondFactor: {
               phoneNumber: '+16505557348',
@@ -2736,8 +2736,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             name: 'invalid second factor phone number',
             error: new FirebaseAuthError(
               AuthClientErrorCode.INVALID_PHONE_NUMBER,
-              `The second factor "phoneNumber" for "invalid" must be a non-empty ` +
-              `E.164 standard compliant identifier string.`),
+              'The second factor "phoneNumber" for "invalid" must be a non-empty ' +
+              'E.164 standard compliant identifier string.'),
             secondFactor: {
               phoneNumber: 'invalid',
               displayName: 'Spouse\'s phone number',
@@ -3106,7 +3106,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         const invalidRequestType = 'invalid';
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          `"invalid" is not a supported email action request type.`,
+          '"invalid" is not a supported email action request type.',
         );
 
         const requestHandler = handler.init(mockApp);
@@ -3313,8 +3313,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should be rejected given an invalid maxResults', () => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          `Required "maxResults" must be a positive integer that does not ` +
-          `exceed 100.`,
+          'Required "maxResults" must be a positive integer that does not ' +
+          'exceed 100.',
         );
 
         const requestHandler = handler.init(mockApp);
@@ -3802,8 +3802,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
       it('should be rejected given an invalid maxResults', () => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_ARGUMENT,
-          `Required "maxResults" must be a positive integer that does not ` +
-          `exceed 100.`,
+          'Required "maxResults" must be a positive integer that does not ' +
+          'exceed 100.',
         );
 
         const requestHandler = handler.init(mockApp);
@@ -4345,8 +4345,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         it('should be rejected given an invalid maxResults', () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_ARGUMENT,
-            `Required "maxResults" must be a positive non-zero number that does not ` +
-            `exceed the allowed 1000.`,
+            'Required "maxResults" must be a positive non-zero number that does not ' +
+            'exceed the allowed 1000.',
           );
 
           const requestHandler = handler.init(mockApp) as AuthRequestHandler;
@@ -4561,7 +4561,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           });
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INTERNAL_ERROR,
-            `An internal error has occurred. Raw server response: ` +
+            'An internal error has occurred. Raw server response: ' +
             `"${JSON.stringify(expectedServerError.response.data)}"`,
           );
           const stub = sinon.stub(HttpClient.prototype, 'send').rejects(expectedServerError);
@@ -4755,7 +4755,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           });
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INTERNAL_ERROR,
-            `An internal error has occurred. Raw server response: ` +
+            'An internal error has occurred. Raw server response: ' +
             `"${JSON.stringify(expectedServerError.response.data)}"`,
           );
           const stub = sinon.stub(HttpClient.prototype, 'send').rejects(expectedServerError);

--- a/test/unit/auth/auth-config.spec.ts
+++ b/test/unit/auth/auth-config.spec.ts
@@ -625,7 +625,7 @@ describe('SAMLConfig', () => {
       const invalidClientRequest = deepCopy(clientRequest) as any;
       invalidClientRequest.unsupported = 'value';
       expect(() => SAMLConfig.validate(invalidClientRequest))
-        .to.throw(`"unsupported" is not a valid SAML config parameter.`);
+        .to.throw('"unsupported" is not a valid SAML config parameter.');
     });
 
     const invalidProviderIds = [
@@ -904,7 +904,7 @@ describe('OIDCConfig', () => {
       const invalidClientRequest = deepCopy(clientRequest) as any;
       invalidClientRequest.unsupported = 'value';
       expect(() => OIDCConfig.validate(invalidClientRequest))
-        .to.throw(`"unsupported" is not a valid OIDC config parameter.`);
+        .to.throw('"unsupported" is not a valid OIDC config parameter.');
     });
 
     const invalidProviderIds = [

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -431,7 +431,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       // Set auth_time of token to expected user's tokensValidAfterTime.
       expect(
         expectedUserRecord.tokensValidAfterTime,
-        'getValidUserRecord didn\'t properly set tokensValueAfterTime',
+        "getValidUserRecord didn't properly set tokensValueAfterTime",
       ).to.exist;
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime!);
       // Set expected uid to expected user's.
@@ -675,7 +675,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       const expectedUserRecord = getValidUserRecord(getValidGetAccountInfoResponse(tenantId));
       // Set auth_time of token to expected user's tokensValidAfterTime.
       if (!expectedUserRecord.tokensValidAfterTime) {
-        throw new Error('getValidUserRecord didn\'t properly set tokensValidAfterTime.');
+        throw new Error("getValidUserRecord didn't properly set tokensValidAfterTime.");
       }
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime);
       // Set expected uid to expected user's.
@@ -1159,7 +1159,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       });
 
       it('should throw when given a non array parameter', () => {
-        const nonArrayValues = [ null, undefined, 42, 3.14, 'i\'m not an array', {} ];
+        const nonArrayValues = [ null, undefined, 42, 3.14, "i'm not an array", {} ];
         nonArrayValues.forEach((v) => {
           expect(() => auth.getUsers(v as any))
             .to.throw(FirebaseAuthError)
@@ -2086,7 +2086,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       const expectedUserRecord = getValidUserRecord(getValidGetAccountInfoResponse(tenantId));
       // Set auth_time of token to expected user's tokensValidAfterTime.
       if (!expectedUserRecord.tokensValidAfterTime) {
-        throw new Error('getValidUserRecord didn\'t properly set tokensValidAfterTime.');
+        throw new Error("getValidUserRecord didn't properly set tokensValidAfterTime.");
       }
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime);
       // Set expected uid to expected user's.
@@ -3226,7 +3226,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
         const unsignedToken = mocks.generateIdToken({
           algorithm: 'none'
         });
-        
+
         await expect(mockAuth.verifyIdToken(unsignedToken))
           .to.be.rejectedWith('Firebase ID token has incorrect algorithm. Expected "RS256"');
       });
@@ -3236,7 +3236,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
 
         let claims = {};
         if (testConfig.Auth === TenantAwareAuth) {
-          claims = { 
+          claims = {
             firebase: {
               tenant: TENANT_ID
             }
@@ -3246,7 +3246,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
         const unsignedToken = mocks.generateIdToken({
           algorithm: 'none'
         }, claims);
-        
+
         const decoded = await mockAuth.verifyIdToken(unsignedToken);
         expect(decoded).to.be.ok;
       });

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -431,7 +431,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       // Set auth_time of token to expected user's tokensValidAfterTime.
       expect(
         expectedUserRecord.tokensValidAfterTime,
-        "getValidUserRecord didn't properly set tokensValueAfterTime",
+        'getValidUserRecord didn\'t properly set tokensValueAfterTime',
       ).to.exist;
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime!);
       // Set expected uid to expected user's.
@@ -675,7 +675,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       const expectedUserRecord = getValidUserRecord(getValidGetAccountInfoResponse(tenantId));
       // Set auth_time of token to expected user's tokensValidAfterTime.
       if (!expectedUserRecord.tokensValidAfterTime) {
-        throw new Error("getValidUserRecord didn't properly set tokensValidAfterTime.");
+        throw new Error('getValidUserRecord didn\'t properly set tokensValidAfterTime.');
       }
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime);
       // Set expected uid to expected user's.
@@ -1159,7 +1159,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       });
 
       it('should throw when given a non array parameter', () => {
-        const nonArrayValues = [ null, undefined, 42, 3.14, "i'm not an array", {} ];
+        const nonArrayValues = [ null, undefined, 42, 3.14, 'i\'m not an array', {} ];
         nonArrayValues.forEach((v) => {
           expect(() => auth.getUsers(v as any))
             .to.throw(FirebaseAuthError)
@@ -2086,7 +2086,7 @@ AUTH_CONFIGS.forEach((testConfig) => {
       const expectedUserRecord = getValidUserRecord(getValidGetAccountInfoResponse(tenantId));
       // Set auth_time of token to expected user's tokensValidAfterTime.
       if (!expectedUserRecord.tokensValidAfterTime) {
-        throw new Error("getValidUserRecord didn't properly set tokensValidAfterTime.");
+        throw new Error('getValidUserRecord didn\'t properly set tokensValidAfterTime.');
       }
       const validSince = new Date(expectedUserRecord.tokensValidAfterTime);
       // Set expected uid to expected user's.

--- a/test/unit/auth/tenant.spec.ts
+++ b/test/unit/auth/tenant.spec.ts
@@ -164,7 +164,7 @@ describe('Tenant', () => {
         tenantOptionsClientRequest.unsupported = 'value';
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest);
-        }).to.throw(`"unsupported" is not a valid UpdateTenantRequest parameter.`);
+        }).to.throw('"unsupported" is not a valid UpdateTenantRequest parameter.');
       });
 
       const invalidTenantNames = [null, NaN, 0, 1, true, false, '', [], [1, 'a'], {}, { a: 1 }, _.noop];
@@ -211,7 +211,7 @@ describe('Tenant', () => {
         tenantOptionsClientRequest.multiFactorConfig.factorIds = ['invalid'];
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
-        }).to.throw(`"invalid" is not a valid "AuthFactorType".`,);
+        }).to.throw('"invalid" is not a valid "AuthFactorType".',);
       });
 
       it('should throw on invalid testPhoneNumbers attribute', () => {
@@ -219,7 +219,7 @@ describe('Tenant', () => {
         tenantOptionsClientRequest.testPhoneNumbers = { 'invalid': '123456' };
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
-        }).to.throw(`"invalid" is not a valid E.164 standard compliant phone number.`);
+        }).to.throw('"invalid" is not a valid E.164 standard compliant phone number.');
       });
 
       it('should throw on null testPhoneNumbers attribute', () => {
@@ -231,7 +231,7 @@ describe('Tenant', () => {
 
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
-        }).to.throw(`"CreateTenantRequest.testPhoneNumbers" must be a non-null object.`);
+        }).to.throw('"CreateTenantRequest.testPhoneNumbers" must be a non-null object.');
       });
 
       const nonObjects = [null, NaN, 0, 1, true, false, '', 'a', [], [1, 'a'], _.noop];
@@ -248,7 +248,7 @@ describe('Tenant', () => {
         tenantOptionsClientRequest.unsupported = 'value';
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
-        }).to.throw(`"unsupported" is not a valid CreateTenantRequest parameter.`);
+        }).to.throw('"unsupported" is not a valid CreateTenantRequest parameter.');
       });
 
       const invalidTenantNames = [null, NaN, 0, 1, true, false, '', [], [1, 'a'], {}, { a: 1 }, _.noop];

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -131,7 +131,7 @@ describe('CryptoSigner', () => {
       const input = Buffer.from('input');
       const signRequest = {
         method: 'POST',
-        url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-service-account:signBlob`,
+        url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-service-account:signBlob',
         headers: { Authorization: `Bearer ${mockAccessToken}` },
         data: { payload: input.toString('base64') },
       };
@@ -182,12 +182,12 @@ describe('CryptoSigner', () => {
       const response = { signedBlob: Buffer.from('testsignature').toString('base64') };
       const metadataRequest = {
         method: 'GET',
-        url: `http://metadata/computeMetadata/v1/instance/service-accounts/default/email`,
+        url: 'http://metadata/computeMetadata/v1/instance/service-accounts/default/email',
         headers: { 'Metadata-Flavor': 'Google' },
       };
       const signRequest = {
         method: 'POST',
-        url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/discovered-service-account:signBlob`,
+        url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/discovered-service-account:signBlob',
         headers: { Authorization: `Bearer ${mockAccessToken}` },
         data: { payload: input.toString('base64') },
       };

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -109,7 +109,7 @@ function createTokenVerifier(
   app: FirebaseApp, 
   options: { algorithm?: Algorithm } = {}
 ): verifier.FirebaseTokenVerifier {
-  const algorithm = options.algorithm || "RS256";
+  const algorithm = options.algorithm || 'RS256';
   return new verifier.FirebaseTokenVerifier(
     'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
     algorithm,

--- a/test/unit/auth/user-import-builder.spec.ts
+++ b/test/unit/auth/user-import-builder.spec.ts
@@ -200,7 +200,7 @@ describe('UserImportBuilder', () => {
     it('should throw when an invalid hash algorithm is provided', () => {
       const expectedError = new FirebaseAuthError(
         AuthClientErrorCode.INVALID_HASH_ALGORITHM,
-        `Unsupported hash algorithm provider "invalid".`,
+        'Unsupported hash algorithm provider "invalid".',
       );
       const invalidOptions = {
         hash: {
@@ -229,7 +229,7 @@ describe('UserImportBuilder', () => {
           it(`should throw when non-Buffer ${JSON.stringify(key)} hash key is provided`, () => {
             const expectedError = new FirebaseAuthError(
               AuthClientErrorCode.INVALID_HASH_KEY,
-              `A non-empty "hash.key" byte buffer must be provided for ` +
+              'A non-empty "hash.key" byte buffer must be provided for ' +
               `hash algorithm ${algorithm}.`,
             );
             const invalidOptions = {
@@ -337,7 +337,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(key)} key provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_KEY,
-            `A "hash.key" byte buffer must be provided for ` +
+            'A "hash.key" byte buffer must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -358,7 +358,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(rounds)} rounds provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_ROUNDS,
-            `A valid "hash.rounds" number between 1 and 8 must be provided for ` +
+            'A valid "hash.rounds" number between 1 and 8 must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -379,7 +379,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(memoryCost)} memoryCost provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_MEMORY_COST,
-            `A valid "hash.memoryCost" number between 1 and 14 must be provided for ` +
+            'A valid "hash.memoryCost" number between 1 and 14 must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -400,7 +400,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(saltSeparator)} saltSeparator provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_SALT_SEPARATOR,
-            `"hash.saltSeparator" must be a byte buffer.`,
+            '"hash.saltSeparator" must be a byte buffer.',
           );
           const invalidOptions = {
             hash: {
@@ -468,7 +468,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(memoryCost)} memoryCost provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_MEMORY_COST,
-            `A valid "hash.memoryCost" number must be provided for ` +
+            'A valid "hash.memoryCost" number must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -490,7 +490,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(parallelization)} parallelization provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_MEMORY_COST,
-            `A valid "hash.parallelization" number must be provided for ` +
+            'A valid "hash.parallelization" number must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -512,7 +512,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(blockSize)} blockSize provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_BLOCK_SIZE,
-            `A valid "hash.blockSize" number must be provided for ` +
+            'A valid "hash.blockSize" number must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -534,7 +534,7 @@ describe('UserImportBuilder', () => {
         it(`should throw when ${JSON.stringify(derivedKeyLength)} dkLen provided`, () => {
           const expectedError = new FirebaseAuthError(
             AuthClientErrorCode.INVALID_HASH_DERIVED_KEY_LENGTH,
-            `A valid "hash.derivedKeyLength" number must be provided for ` +
+            'A valid "hash.derivedKeyLength" number must be provided for ' +
             `hash algorithm ${algorithm}.`,
           );
           const invalidOptions = {
@@ -864,8 +864,8 @@ describe('UserImportBuilder', () => {
             index: 8,
             error: new FirebaseAuthError(
               AuthClientErrorCode.INVALID_ENROLLMENT_TIME,
-              `The second factor "enrollmentTime" for "enrollmentId1" must be a valid ` +
-              `UTC date string.`),
+              'The second factor "enrollmentTime" for "enrollmentId1" must be a valid ' +
+              'UTC date string.'),
           },
           {
             index: 9,

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -144,7 +144,7 @@ describe('FirebaseApp', () => {
     it('should be read-only', () => {
       expect(() => {
         (mockApp as any).name = 'foo';
-      }).to.throw(`Cannot set property name of #<FirebaseApp> which has only a getter`);
+      }).to.throw('Cannot set property name of #<FirebaseApp> which has only a getter');
     });
   });
 
@@ -164,7 +164,7 @@ describe('FirebaseApp', () => {
     it('should be read-only', () => {
       expect(() => {
         (mockApp as any).options = {};
-      }).to.throw(`Cannot set property options of #<FirebaseApp> which has only a getter`);
+      }).to.throw('Cannot set property options of #<FirebaseApp> which has only a getter');
     });
 
     it('should not return an object which can mutate the underlying options', () => {
@@ -186,28 +186,28 @@ describe('FirebaseApp', () => {
       process.env[FIREBASE_CONFIG_VAR] = './test/resources/non_existant.json';
       expect(() => {
         firebaseNamespace.initializeApp();
-      }).to.throw(`Failed to parse app options file: Error: ENOENT: no such file or directory`);
+      }).to.throw('Failed to parse app options file: Error: ENOENT: no such file or directory');
     });
 
     it('should throw when the environment variable contains bad json', () => {
       process.env[FIREBASE_CONFIG_VAR] = '{,,';
       expect(() => {
         firebaseNamespace.initializeApp();
-      }).to.throw(`Failed to parse app options file: SyntaxError: Unexpected token ,`);
+      }).to.throw('Failed to parse app options file: SyntaxError: Unexpected token ,');
     });
 
     it('should throw when the environment variable points to an empty file', () => {
       process.env[FIREBASE_CONFIG_VAR] = './test/resources/firebase_config_empty.json';
       expect(() => {
         firebaseNamespace.initializeApp();
-      }).to.throw(`Failed to parse app options file`);
+      }).to.throw('Failed to parse app options file');
     });
 
     it('should throw when the environment variable points to bad json', () => {
       process.env[FIREBASE_CONFIG_VAR] = './test/resources/firebase_config_bad.json';
       expect(() => {
         firebaseNamespace.initializeApp();
-      }).to.throw(`Failed to parse app options file`);
+      }).to.throw('Failed to parse app options file');
     });
 
     it('should ignore a bad config key in the config file', () => {

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -133,7 +133,7 @@ describe('FirebaseNamespace', () => {
     it('should be read-only', () => {
       expect(() => {
         (firebaseNamespace as any).apps = 'foo';
-      }).to.throw(`Cannot set property apps of #<FirebaseNamespace> which has only a getter`);
+      }).to.throw('Cannot set property apps of #<FirebaseNamespace> which has only a getter');
     });
   });
 
@@ -150,7 +150,7 @@ describe('FirebaseNamespace', () => {
     it('should throw given empty string app name', () => {
       expect(() => {
         return firebaseNamespace.app('');
-      }).to.throw(`Invalid Firebase app name "" provided. App name must be a non-empty string.`);
+      }).to.throw('Invalid Firebase app name "" provided. App name must be a non-empty string.');
     });
 
     it('should throw given an app name which does not correspond to an existing app', () => {
@@ -203,7 +203,7 @@ describe('FirebaseNamespace', () => {
     it('should throw given empty string app name', () => {
       expect(() => {
         firebaseNamespace.initializeApp(mocks.appOptions, '');
-      }).to.throw(`Invalid Firebase app name "" provided. App name must be a non-empty string.`);
+      }).to.throw('Invalid Firebase app name "" provided. App name must be a non-empty string.');
     });
 
     it('should throw given a name corresponding to an existing app', () => {
@@ -282,7 +282,7 @@ describe('FirebaseNamespace', () => {
     it('should throw given empty string app name', () => {
       expect(() => {
         firebaseNamespace.INTERNAL.removeApp('');
-      }).to.throw(`Invalid Firebase app name "" provided. App name must be a non-empty string.`);
+      }).to.throw('Invalid Firebase app name "" provided. App name must be a non-empty string.');
     });
 
     it('should throw given an app name which does not correspond to an existing app', () => {
@@ -294,14 +294,14 @@ describe('FirebaseNamespace', () => {
     it('should throw given no app name if the default app does not exist', () => {
       expect(() => {
         (firebaseNamespace as any).INTERNAL.removeApp();
-      }).to.throw(`No Firebase app name provided. App name must be a non-empty string.`);
+      }).to.throw('No Firebase app name provided. App name must be a non-empty string.');
     });
 
     it('should throw given no app name even if the default app exists', () => {
       firebaseNamespace.initializeApp(mocks.appOptions);
       expect(() => {
         (firebaseNamespace as any).INTERNAL.removeApp();
-      }).to.throw(`No Firebase app name provided. App name must be a non-empty string.`);
+      }).to.throw('No Firebase app name provided. App name must be a non-empty string.');
     });
 
     it('should remove the app corresponding to the provided app name from the namespace\'s app list', () => {
@@ -348,7 +348,7 @@ describe('FirebaseNamespace', () => {
     it('should throw given no service name', () => {
       expect(() => {
         firebaseNamespace.INTERNAL.registerService(undefined as unknown as string, mocks.firebaseServiceFactory);
-      }).to.throw(`No service name provided. Service name must be a non-empty string.`);
+      }).to.throw('No service name provided. Service name must be a non-empty string.');
     });
 
     const invalidServiceNames = [null, NaN, 0, 1, true, false, [], ['a'], {}, { a: 1 }, _.noop];
@@ -363,7 +363,7 @@ describe('FirebaseNamespace', () => {
     it('should throw given an empty string service name', () => {
       expect(() => {
         firebaseNamespace.INTERNAL.registerService('', mocks.firebaseServiceFactory);
-      }).to.throw(`Invalid service name "" provided. Service name must be a non-empty string.`);
+      }).to.throw('Invalid service name "" provided. Service name must be a non-empty string.');
     });
 
     it('should throw given a service name which has already been registered', () => {

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -316,9 +316,9 @@ describe('MachineLearningApiClient', () => {
     const GCS_MASK_LIST = ['displayName', 'tfliteModel.gcsTfliteUri'];
     const AUTOML_MASK_LIST = ['displayName', 'tfliteModel.automlModel'];
 
-    const NAME_ONLY_UPDATE_MASK_STRING = "updateMask=displayName";
-    const GCS_UPDATE_MASK_STRING = "updateMask=displayName,tfliteModel.gcsTfliteUri";
-    const AUTOML_UPDATE_MASK_STRING = "updateMask=displayName,tfliteModel.automlModel";
+    const NAME_ONLY_UPDATE_MASK_STRING = 'updateMask=displayName';
+    const GCS_UPDATE_MASK_STRING = 'updateMask=displayName,tfliteModel.gcsTfliteUri';
+    const AUTOML_UPDATE_MASK_STRING = 'updateMask=displayName,tfliteModel.automlModel';
 
     const invalidOptions: any[] = [null, undefined];
     invalidOptions.forEach((option) => {
@@ -462,13 +462,13 @@ describe('MachineLearningApiClient', () => {
       });
     });
 
-    it(`should reject when called with prefixed name`, () => {
+    it('should reject when called with prefixed name', () => {
       return apiClient.getModel('projects/foo/models/bar')
         .should.eventually.be.rejected.and.have.property(
           'message', 'Model ID must not contain any "/" characters.');
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.getModel(MODEL_ID)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -821,13 +821,13 @@ describe('MachineLearningApiClient', () => {
       });
     });
 
-    it(`should reject when called with prefixed name`, () => {
+    it('should reject when called with prefixed name', () => {
       return apiClient.deleteModel('projects/foo/rulesets/bar')
         .should.eventually.be.rejected.and.have.property(
           'message', 'Model ID must not contain any "/" characters.');
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.deleteModel(MODEL_ID)
         .should.eventually.be.rejectedWith(noProjectId);
     });

--- a/test/unit/messaging/batch-requests.spec.ts
+++ b/test/unit/messaging/batch-requests.spec.ts
@@ -51,15 +51,15 @@ function createMultipartResponse(success: object[], failures: object[] = []): Ht
   const multipart: Buffer[] = [];
   success.forEach((part) => {
     let payload = '';
-    payload += `HTTP/1.1 200 OK\r\n`;
-    payload += `Content-type: application/json\r\n\r\n`;
+    payload += 'HTTP/1.1 200 OK\r\n';
+    payload += 'Content-type: application/json\r\n\r\n';
     payload += `${JSON.stringify(part)}\r\n`;
     multipart.push(Buffer.from(payload, 'utf-8'));
   });
   failures.forEach((part) => {
     let payload = '';
-    payload += `HTTP/1.1 500 Internal Server Error\r\n`;
-    payload += `Content-type: application/json\r\n\r\n`;
+    payload += 'HTTP/1.1 500 Internal Server Error\r\n';
+    payload += 'Content-type: application/json\r\n\r\n';
     payload += `${JSON.stringify(part)}\r\n`;
     multipart.push(Buffer.from(payload, 'utf-8'));
   });

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -110,15 +110,15 @@ function createMultipartPayloadWithErrors(
   success.forEach((part) => {
     payload += `--${boundary}\r\n`;
     payload += 'Content-type: application/http\r\n\r\n';
-    payload += `HTTP/1.1 200 OK\r\n`;
-    payload += `Content-type: application/json\r\n\r\n`;
+    payload += 'HTTP/1.1 200 OK\r\n';
+    payload += 'Content-type: application/json\r\n\r\n';
     payload += `${JSON.stringify(part)}\r\n`;
   });
   failures.forEach((part) => {
     payload += `--${boundary}\r\n`;
     payload += 'Content-type: application/http\r\n\r\n';
-    payload += `HTTP/1.1 500 Internal Server Error\r\n`;
-    payload += `Content-type: application/json\r\n\r\n`;
+    payload += 'HTTP/1.1 500 Internal Server Error\r\n';
+    payload += 'Content-type: application/json\r\n\r\n';
     payload += `${JSON.stringify(part)}\r\n`;
   });
   payload += `--${boundary}--\r\n`;
@@ -2449,7 +2449,7 @@ describe('Messaging', () => {
       });
     });
 
-    it(`should throw given an empty vibrateTimingsMillis array`, () => {
+    it('should throw given an empty vibrateTimingsMillis array', () => {
       const message: Message = {
         condition: 'topic-name',
         android: {
@@ -2483,7 +2483,7 @@ describe('Messaging', () => {
       });
     });
 
-    it(`should throw given a negative light on duration`, () => {
+    it('should throw given a negative light on duration', () => {
       const message: Message = {
         condition: 'topic-name',
         android: {
@@ -2502,7 +2502,7 @@ describe('Messaging', () => {
         'android.notification.lightSettings.lightOnDurationMillis must be a non-negative duration in milliseconds');
     });
 
-    it(`should throw given a negative light off duration`, () => {
+    it('should throw given a negative light off duration', () => {
       const message: Message = {
         condition: 'topic-name',
         android: {
@@ -2649,7 +2649,7 @@ describe('Messaging', () => {
     });
 
     invalidImages.forEach((imageUrl) => {
-      it(`should throw given invalid URL string for imageUrl`, () => {
+      it('should throw given invalid URL string for imageUrl', () => {
         expect(() => {
           messaging.send({ apns: { fcmOptions: { imageUrl } }, topic: 'test' });
         }).to.throw('imageUrl must be a valid URL string');
@@ -2688,7 +2688,7 @@ describe('Messaging', () => {
         }).to.throw('apns.payload.aps must be a non-null object');
       });
     });
-    it(`should throw given APNS payload with duplicate fields`, () => {
+    it('should throw given APNS payload with duplicate fields', () => {
       expect(() => {
         messaging.send({
           apns: {

--- a/test/unit/project-management/android-app.spec.ts
+++ b/test/unit/project-management/android-app.spec.ts
@@ -362,7 +362,7 @@ describe('AndroidApp', () => {
         .should.eventually.be.rejected
         .and.have.property(
           'message',
-          `getConfig()'s responseData.configFileContents must be a base64 string. `
+          'getConfig()\'s responseData.configFileContents must be a base64 string. '
                   + `Response data: ${JSON.stringify(apiResponse, null, 2)}`);
     });
 

--- a/test/unit/project-management/ios-app.spec.ts
+++ b/test/unit/project-management/ios-app.spec.ts
@@ -209,7 +209,7 @@ describe('IosApp', () => {
         .should.eventually.be.rejected
         .and.have.property(
           'message',
-          `getConfig()'s responseData.configFileContents must be a base64 string. `
+          'getConfig()\'s responseData.configFileContents must be a base64 string. '
                   + `Response data: ${JSON.stringify(apiResponse, null, 2)}`);
     });
 

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -49,9 +49,9 @@ describe('RemoteConfigApiClient', () => {
   };
 
   const VALIDATION_ERROR_MESSAGES = [
-    "[VALIDATION_ERROR]: [foo] are not valid condition names. All keys in all conditional value" +
-    " maps must be valid condition names.",
-    "[VERSION_MISMATCH]: Expected version 6, found 8 for project: 123456789012"
+    '[VALIDATION_ERROR]: [foo] are not valid condition names. All keys in all conditional value' +
+    ' maps must be valid condition names.',
+    '[VERSION_MISMATCH]: Expected version 6, found 8 for project: 123456789012'
   ];
 
   const EXPECTED_HEADERS = {
@@ -180,7 +180,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('getTemplate', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.getTemplate()
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -211,7 +211,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('getTemplateAtVersion', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.getTemplateAtVersion(65)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -262,7 +262,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('validateTemplate', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.validateTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -341,7 +341,7 @@ describe('RemoteConfigApiClient', () => {
             error: {
               code: 400,
               message: message,
-              status: "FAILED_PRECONDITION"
+              status: 'FAILED_PRECONDITION'
             }
           }, 400));
         stubs.push(stub);
@@ -353,7 +353,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('publishTemplate', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.publishTemplate(REMOTE_CONFIG_TEMPLATE)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -436,7 +436,7 @@ describe('RemoteConfigApiClient', () => {
             error: {
               code: 400,
               message: message,
-              status: "FAILED_PRECONDITION"
+              status: 'FAILED_PRECONDITION'
             }
           }, 400));
         stubs.push(stub);
@@ -448,7 +448,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('rollback', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.rollback('60')
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -503,7 +503,7 @@ describe('RemoteConfigApiClient', () => {
   });
 
   describe('listVersions', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.listVersions()
         .should.eventually.be.rejectedWith(noProjectId);
     });

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -489,7 +489,7 @@ describe('RemoteConfig', () => {
       expect(newTemplate.etag).to.equal('etag-123456789012-5');
       // verify that the etag is read-only
       expect(() => {
-        (newTemplate as any).etag = "new-etag";
+        (newTemplate as any).etag = 'new-etag';
       }).to.throw(
         'Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
 
@@ -552,7 +552,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return rcOperation()
         .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameters must be a non-null object`);
+          'message', 'Remote Config parameters must be a non-null object');
     });
 
     it('should reject when API response does not contain valid parameter groups', () => {
@@ -564,7 +564,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return rcOperation()
         .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config parameter groups must be a non-null object`);
+          'message', 'Remote Config parameter groups must be a non-null object');
     });
 
     it('should reject when API response does not contain valid conditions', () => {
@@ -576,7 +576,7 @@ describe('RemoteConfig', () => {
       stubs.push(stub);
       return rcOperation()
         .should.eventually.be.rejected.and.have.property(
-          'message', `Remote Config conditions must be an array`);
+          'message', 'Remote Config conditions must be an array');
     });
   }
 
@@ -643,7 +643,7 @@ describe('RemoteConfig', () => {
           expect(template.etag).to.equal('etag-123456789012-5');
           // verify that etag is read-only
           expect(() => {
-            (template as any).etag = "new-etag";
+            (template as any).etag = 'new-etag';
           }).to.throw(
             'Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
 

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -90,13 +90,13 @@ describe('SecurityRulesApiClient', () => {
       });
     });
 
-    it(`should reject when called with prefixed name`, () => {
+    it('should reject when called with prefixed name', () => {
       return apiClient.getRuleset('projects/foo/rulesets/bar')
         .should.eventually.be.rejected.and.have.property(
           'message', 'Ruleset name must not contain any "/" characters.');
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.getRuleset(RULESET_NAME)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -180,7 +180,7 @@ describe('SecurityRulesApiClient', () => {
       });
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.createRuleset({
         source: {
           files: [RULES_FILE],
@@ -328,7 +328,7 @@ describe('SecurityRulesApiClient', () => {
       });
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.listRulesets()
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -427,7 +427,7 @@ describe('SecurityRulesApiClient', () => {
   });
 
   describe('getRelease', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.getRelease(RELEASE_NAME)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -491,7 +491,7 @@ describe('SecurityRulesApiClient', () => {
   });
 
   describe('updateRelease', () => {
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.updateRelease(RELEASE_NAME, RULESET_NAME)
         .should.eventually.be.rejectedWith(noProjectId);
     });
@@ -570,13 +570,13 @@ describe('SecurityRulesApiClient', () => {
       });
     });
 
-    it(`should reject when called with prefixed name`, () => {
+    it('should reject when called with prefixed name', () => {
       return apiClient.deleteRuleset('projects/foo/rulesets/bar')
         .should.eventually.be.rejected.and.have.property(
           'message', 'Ruleset name must not contain any "/" characters.');
     });
 
-    it(`should reject when project id is not available`, () => {
+    it('should reject when project id is not available', () => {
       return clientWithoutProjectId.deleteRuleset(RULESET_NAME)
         .should.eventually.be.rejectedWith(noProjectId);
     });


### PR DESCRIPTION
Enabled the quotes rule in ESLint config to enforce single-quoted string literals throughout the codebase. Fixed all violations automatically via `eslint --fix`.