### PR TITLE
fix: Adding es2018 libraries to the build

### DIFF
--- a/test/integration/typescript/tsconfig.json
+++ b/test/integration/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "target": "es5",
     "noImplicitAny": false,
-    "lib": ["es2015"],
+    "lib": ["es2018"],
     "outDir": "lib",
     "typeRoots": [
       "node_modules/@types"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,8 @@
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     //"strictPropertyInitialization": true,
-    "lib": ["es2015"],
+    "lib": ["es2018"],
     "outDir": "lib",
-    // We manually craft typings in src/index.d.ts instead of auto-generating them.
-    // "declaration": true,
     "rootDir": "."
   },
   "files": [


### PR DESCRIPTION
Latest versions of GCP dependencies like Firestore require `es2018` libraries included in the tsc build. This helps avoid build errors like https://github.com/firebase/firebase-admin-node/actions/runs/342357542