### PR TITLE
fix(fcm): Support arbitrary custom values in the ApnsPayload

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -625,7 +625,7 @@ export namespace messaging {
     }
     export interface ApnsPayload {
         // (undocumented)
-        [customData: string]: object;
+        [customData: string]: any;
         aps: Aps;
     }
     export interface Aps {

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -299,7 +299,7 @@ export namespace messaging {
      * The `aps` dictionary to be included in the message.
      */
     aps: Aps;
-    [customData: string]: object;
+    [customData: string]: any;
   }
 
   /**


### PR DESCRIPTION
`ApnsPayload` can contain any valid JSON values.

Resolves #1023 