### PR TITLE
Adds @license JSDoc tag to license comments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/credential/credential.ts
+++ b/src/credential/credential.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/default-namespace.ts
+++ b/src/default-namespace.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/firebase-namespace.ts
+++ b/src/firebase-namespace.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/firebase-service.ts
+++ b/src/firebase-service.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/firestore/firestore-internal.ts
+++ b/src/firestore/firestore-internal.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/instance-id/instance-id-request-internal.ts
+++ b/src/instance-id/instance-id-request-internal.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/messaging/messaging-api-request-internal.ts
+++ b/src/messaging/messaging-api-request-internal.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/deep-copy.ts
+++ b/src/utils/deep-copy.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/integration/typescript/src/example.test.ts
+++ b/test/integration/typescript/src/example.test.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/integration/typescript/src/example.ts
+++ b/test/integration/typescript/src/example.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -934,7 +935,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               data,
               headers: expectedHeaders,
               timeout,
-            });          
+            });
           });
       });
 
@@ -954,7 +955,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               data,
               headers: expectedHeadersEmulator,
               timeout,
-            });          
+            });
           });
       });
     });

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -311,7 +312,7 @@ describe('FirebaseTokenGenerator', () => {
   describe('Emulator', () => {
     const signer = new EmulatedSigner();
     const tokenGenerator = new FirebaseTokenGenerator(signer);
-    
+
     it('should generate a valid unsigned token', async () => {
       const uid = 'uid123';
       const claims = { foo: 'bar' };

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/credential/credential.spec.ts
+++ b/test/unit/credential/credential.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/firebase-app.spec.ts
+++ b/test/unit/firebase-app.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/firebase-namespace.spec.ts
+++ b/test/unit/firebase-namespace.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/instance-id/instance-id-request.spec.ts
+++ b/test/unit/instance-id/instance-id-request.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/instance-id/instance-id.spec.ts
+++ b/test/unit/instance-id/instance-id.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils/error.spec.ts
+++ b/test/unit/utils/error.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils/validator.spec.ts
+++ b/test/unit/utils/validator.spec.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Hi, just hoping to get this license tag submitted upstream to help this code play a bit better with the NodeJS import tools internally (at Google). The change will help a Google3 import script know that a comment block is, in fact, a license comment block.

There's a few trailing whitespaces my editor really wanted to remove too, lmk if I should revert them, and if you need more context.

