### PR TITLE
Fix type for cert(...) function, to support standard downloadable serviceAccount.json

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -395,7 +395,7 @@ export namespace auth {
 // @public (undocumented)
 export namespace credential {
     export function applicationDefault(httpAgent?: Agent): Credential;
-    export function cert(serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
+    export function cert(serviceAccountPathOrObject: string | ServiceAccount | ServiceAccountJson, httpAgent?: Agent): Credential;
     export interface Credential {
         getAccessToken(): Promise<GoogleOAuthAccessToken>;
     }
@@ -1042,12 +1042,22 @@ export namespace securityRules {
 
 // @public (undocumented)
 export interface ServiceAccount {
-    // (undocumented)
-    clientEmail?: string;
-    // (undocumented)
-    privateKey?: string;
-    // (undocumented)
-    projectId?: string;
+  // (undocumented)
+  clientEmail?: string;
+  // (undocumented)
+  privateKey?: string;
+  // (undocumented)
+  projectId?: string;
+}
+
+// @public (undocumented)
+export interface ServiceAccountJson {
+  // (undocumented)
+  client_email?: string;
+  // (undocumented)
+  private_key?: string;
+  // (undocumented)
+  project_id?: string;
 }
 
 // @public

--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -1042,22 +1042,22 @@ export namespace securityRules {
 
 // @public (undocumented)
 export interface ServiceAccount {
-  // (undocumented)
-  clientEmail?: string;
-  // (undocumented)
-  privateKey?: string;
-  // (undocumented)
-  projectId?: string;
+    // (undocumented)
+    clientEmail?: string;
+    // (undocumented)
+    privateKey?: string;
+    // (undocumented)
+    projectId?: string;
 }
 
 // @public (undocumented)
 export interface ServiceAccountJson {
-  // (undocumented)
-  client_email?: string;
-  // (undocumented)
-  private_key?: string;
-  // (undocumented)
-  project_id?: string;
+    // (undocumented)
+    client_email?: string;
+    // (undocumented)
+    private_key?: string;
+    // (undocumented)
+    project_id?: string;
 }
 
 // @public

--- a/src/credential/index.ts
+++ b/src/credential/index.ts
@@ -23,6 +23,15 @@ export interface ServiceAccount {
 }
 
 /**
+ * Interface matching downloadable serviceAccount.json
+ */
+export interface ServiceAccountJson {
+  project_id?: string;
+  client_email?: string;
+  private_key?: string;
+}
+
+/**
  * Interface for Google OAuth 2.0 access tokens.
  */
 export interface GoogleOAuthAccessToken {
@@ -137,7 +146,7 @@ export namespace credential {
    *   provided service account that can be used to initialize an app.
    */
   export declare function cert(
-    serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
+    serviceAccountPathOrObject: string | ServiceAccount | ServiceAccountJson, httpAgent?: Agent): Credential;
 
   /**
    * Returns a credential created from the provided refresh token that grants


### PR DESCRIPTION
### Motivation

The JavaScript implementation of cert(...) **already supports snake_case** account objects. I suspect this is the most popular format for non-Cloud-Function usage since **GCP & Firebase console provide downloadable account configs as snake_case**.

Every single TypeScript client of the Node Admin SDK must navigate this type error, which occurs at the very start of their SDK journey. It has already been raised as an issue 3 separate times. It's a trivial fix that increases the accuracy & readability of the codebase.

### Issues

  * https://github.com/firebase/firebase-admin-node/issues/522
  * https://github.com/firebase/firebase-admin-node/issues/624
  * https://github.com/firebase/firebase-admin-node/issues/903

### Testing

  * Make sure all existing tests pass => *crosses fingers*
  * If you fixed a bug ... add a new test => n/a (compile-time)

### API Changes

  * This isn't a change; rather the API is already supporting snake_case and the TypeScript description is simply deficient
