### PR TITLE
feat: Moved the credential APIs under firebase-admin/app

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -45,9 +45,12 @@ export namespace app {
     }
 }
 
+// @public (undocumented)
+export function applicationDefault(httpAgent?: Agent): Credential;
+
 // @public
 export interface AppOptions {
-    credential?: credential.Credential;
+    credential?: Credential;
     databaseAuthVariableOverride?: object | null;
     databaseURL?: string;
     httpAgent?: Agent;
@@ -397,13 +400,19 @@ export namespace auth {
 }
 
 // @public (undocumented)
+export function cert(serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
+
+// @public (undocumented)
+export interface Credential {
+    getAccessToken(): Promise<GoogleOAuthAccessToken>;
+}
+
+// @public (undocumented)
 export namespace credential {
-    export function applicationDefault(httpAgent?: Agent): Credential;
-    export function cert(serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
-    export interface Credential {
-        getAccessToken(): Promise<GoogleOAuthAccessToken>;
-    }
-    export function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;
+    export type Credential = Credential;
+    const applicationDefault: typeof applicationDefault;
+    const cert: typeof cert;
+    const refreshToken: typeof refreshToken;
 }
 
 // @public
@@ -929,6 +938,9 @@ export namespace projectManagement {
         shaHash: string;
     }
 }
+
+// @public (undocumented)
+export function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;
 
 // @public
 export function remoteConfig(app?: app.App): remoteConfig.RemoteConfig;

--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -17,7 +17,7 @@
 
 import { Agent } from 'http';
 
-import { credential } from '../credential/index';
+import { Credential } from './credential';
 
 /**
  * Available options to pass to [`initializeApp()`](admin#.initializeApp).
@@ -25,13 +25,13 @@ import { credential } from '../credential/index';
 export interface AppOptions {
 
   /**
-   * A {@link credential.Credential `Credential`} object used to
+   * A {@link Credential `Credential`} object used to
    * authenticate the Admin SDK.
    *
    * See [Initialize the SDK](/docs/admin/setup#initialize_the_sdk) for detailed
    * documentation and code samples.
    */
-  credential?: credential.Credential;
+  credential?: Credential;
 
   /**
    * The object to use as the [`auth`](/docs/reference/security/database/#auth)

--- a/src/app/credential-factory.ts
+++ b/src/app/credential-factory.ts
@@ -1,6 +1,6 @@
 /*!
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,35 +15,45 @@
  * limitations under the License.
  */
 
+import { Agent } from 'http';
+
+import { Credential, ServiceAccount } from './credential';
 import {
   ServiceAccountCredential, RefreshTokenCredential, getApplicationDefault
 } from './credential-internal';
-import { credential } from './index';
 
-let globalAppDefaultCred: credential.Credential;
+let globalAppDefaultCred: Credential | undefined;
 const globalCertCreds: { [key: string]: ServiceAccountCredential } = {};
 const globalRefreshTokenCreds: { [key: string]: RefreshTokenCredential } = {};
 
-export const applicationDefault: typeof credential.applicationDefault = (httpAgent?) => {
+export function applicationDefault(httpAgent?: Agent): Credential {
   if (typeof globalAppDefaultCred === 'undefined') {
     globalAppDefaultCred = getApplicationDefault(httpAgent);
   }
   return globalAppDefaultCred;
 }
 
-export const cert: typeof credential.cert = (serviceAccountPathOrObject, httpAgent?) => {
+export function cert(serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential {
   const stringifiedServiceAccount = JSON.stringify(serviceAccountPathOrObject);
   if (!(stringifiedServiceAccount in globalCertCreds)) {
-    globalCertCreds[stringifiedServiceAccount] = new ServiceAccountCredential(serviceAccountPathOrObject, httpAgent);
+    globalCertCreds[stringifiedServiceAccount] = new ServiceAccountCredential(
+      serviceAccountPathOrObject, httpAgent);
   }
   return globalCertCreds[stringifiedServiceAccount];
 }
 
-export const refreshToken: typeof credential.refreshToken = (refreshTokenPathOrObject, httpAgent) => {
+export function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential {
   const stringifiedRefreshToken = JSON.stringify(refreshTokenPathOrObject);
   if (!(stringifiedRefreshToken in globalRefreshTokenCreds)) {
     globalRefreshTokenCreds[stringifiedRefreshToken] = new RefreshTokenCredential(
       refreshTokenPathOrObject, httpAgent);
   }
   return globalRefreshTokenCreds[stringifiedRefreshToken];
+}
+
+/**
+ * Clears the global ADC cache. Exported for testing.
+ */
+export function clearGlobalAppDefaultCred(): void {
+  globalAppDefaultCred = undefined;
 }

--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -1,4 +1,5 @@
 /*!
+ * @license
  * Copyright 2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,12 +20,10 @@ import os = require('os');
 import path = require('path');
 
 import { Agent } from 'http';
-import { credential, GoogleOAuthAccessToken } from './index';
+import { Credential, GoogleOAuthAccessToken } from './credential';
 import { AppErrorCodes, FirebaseAppError } from '../utils/error';
 import { HttpClient, HttpRequestConfig, HttpError, HttpResponse } from '../utils/api-request';
 import * as util from '../utils/validator';
-
-import Credential = credential.Credential;
 
 const GOOGLE_TOKEN_AUDIENCE = 'https://accounts.google.com/o/oauth2/token';
 const GOOGLE_AUTH_TOKEN_HOST = 'accounts.google.com';

--- a/src/app/credential.ts
+++ b/src/app/credential.ts
@@ -1,0 +1,45 @@
+/*!
+ * @license
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ServiceAccount {
+  projectId?: string;
+  clientEmail?: string;
+  privateKey?: string;
+}
+
+/**
+ * Interface for Google OAuth 2.0 access tokens.
+ */
+export interface GoogleOAuthAccessToken {
+  access_token: string;
+  expires_in: number;
+}
+
+export interface Credential {
+  /**
+   * Returns a Google OAuth2 access token object used to authenticate with
+   * Firebase services.
+   *
+   * This object contains the following properties:
+   * * `access_token` (`string`): The actual Google OAuth2 access token.
+   * * `expires_in` (`number`): The number of seconds from when the token was
+   *   issued that it expires.
+   *
+   * @return A Google OAuth2 access token object.
+   */
+  getAccessToken(): Promise<GoogleOAuthAccessToken>;
+}

--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -16,7 +16,7 @@
  */
 
 import { AppOptions, app } from '../firebase-namespace-api';
-import { credential, GoogleOAuthAccessToken } from '../credential/index';
+import { Credential, GoogleOAuthAccessToken } from './credential';
 import { getApplicationDefault } from './credential-internal';
 import * as validator from '../utils/validator';
 import { deepCopy } from '../utils/deep-copy';
@@ -36,7 +36,6 @@ import { ProjectManagement } from '../project-management/project-management';
 import { SecurityRules } from '../security-rules/security-rules';
 import { RemoteConfig } from '../remote-config/remote-config';
 
-import Credential = credential.Credential;
 import Database = database.Database;
 
 /**

--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -17,7 +17,7 @@
 
 import { AppOptions, app } from '../firebase-namespace-api';
 import { credential, GoogleOAuthAccessToken } from '../credential/index';
-import { getApplicationDefault } from '../credential/credential-internal';
+import { getApplicationDefault } from './credential-internal';
 import * as validator from '../utils/validator';
 import { deepCopy } from '../utils/deep-copy';
 import { FirebaseNamespaceInternals } from './firebase-namespace';

--- a/src/app/firebase-namespace.ts
+++ b/src/app/firebase-namespace.ts
@@ -20,8 +20,8 @@ import fs = require('fs');
 import { AppErrorCodes, FirebaseAppError } from '../utils/error';
 import { AppOptions, app } from '../firebase-namespace-api';
 import { FirebaseApp } from './firebase-app';
-import { cert, refreshToken, applicationDefault } from '../credential/credential';
-import { getApplicationDefault } from '../credential/credential-internal';
+import { cert, refreshToken, applicationDefault } from './credential-factory';
+import { getApplicationDefault } from './credential-internal';
 
 import { auth } from '../auth/index';
 import { database } from '../database/index';

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -20,4 +20,7 @@ import { getSdkVersion } from '../utils';
 export { App, AppOptions } from './core'
 export { initializeApp, getApp, getApps, deleteApp } from './lifecycle';
 
+export { Credential, ServiceAccount, GoogleOAuthAccessToken } from './credential';
+export { applicationDefault, cert, refreshToken } from './credential-factory';
+
 export const SDK_VERSION = getSdkVersion();

--- a/src/auth/token-generator.ts
+++ b/src/auth/token-generator.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseApp } from '../app/firebase-app';
-import { ServiceAccountCredential } from '../credential/credential-internal';
+import { ServiceAccountCredential } from '../app/credential-internal';
 import { AuthClientErrorCode, FirebaseAuthError } from '../utils/error';
 import { AuthorizedHttpClient, HttpError, HttpRequestConfig, HttpClient } from '../utils/api-request';
 

--- a/src/credential/index.ts
+++ b/src/credential/index.ts
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-import { Agent } from 'http';
+import {
+  Credential as TCredential,
+  applicationDefault as applicationDefaultFn,
+  cert as certFn,
+  refreshToken as refreshTokenFn,
+} from '../app/index';
 
-export interface ServiceAccount {
-  projectId?: string;
-  clientEmail?: string;
-  privateKey?: string;
-}
-
-/**
- * Interface for Google OAuth 2.0 access tokens.
- */
-export interface GoogleOAuthAccessToken {
-  access_token: string;
-  expires_in: number;
-}
+export { ServiceAccount, GoogleOAuthAccessToken } from '../app/index';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace credential {
@@ -40,20 +33,7 @@ export namespace credential {
    * use the default implementations provided by
    * {@link credential `admin.credential`}.
    */
-  export interface Credential {
-    /**
-     * Returns a Google OAuth2 access token object used to authenticate with
-     * Firebase services.
-     *
-     * This object contains the following properties:
-     * * `access_token` (`string`): The actual Google OAuth2 access token.
-     * * `expires_in` (`number`): The number of seconds from when the token was
-     *   issued that it expires.
-     *
-     * @return A Google OAuth2 access token object.
-     */
-    getAccessToken(): Promise<GoogleOAuthAccessToken>;
-  }
+  export type Credential = TCredential;
 
   /**
    * Returns a credential created from the
@@ -89,7 +69,7 @@ export namespace credential {
    * @return {!admin.credential.Credential} A credential authenticated via Google
    *   Application Default Credentials that can be used to initialize an app.
    */
-  export declare function applicationDefault(httpAgent?: Agent): Credential;
+  export const applicationDefault = applicationDefaultFn;
 
   /**
    * Returns a credential created from the provided service account that grants
@@ -136,8 +116,7 @@ export namespace credential {
    * @return A credential authenticated via the
    *   provided service account that can be used to initialize an app.
    */
-  export declare function cert(
-    serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
+  export const cert = certFn;
 
   /**
    * Returns a credential created from the provided refresh token that grants
@@ -172,6 +151,5 @@ export namespace credential {
    * @return A credential authenticated via the
    *   provided service account that can be used to initialize an app.
    */
-  export declare function refreshToken(
-    refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;
+  export const refreshToken = refreshTokenFn;
 }

--- a/src/firestore/firestore-internal.ts
+++ b/src/firestore/firestore-internal.ts
@@ -17,7 +17,7 @@
 
 import { FirebaseApp } from '../app/firebase-app';
 import { FirebaseFirestoreError } from '../utils/error';
-import { ServiceAccountCredential, isApplicationDefault } from '../credential/credential-internal';
+import { ServiceAccountCredential, isApplicationDefault } from '../app/credential-internal';
 import { Firestore, Settings } from '@google-cloud/firestore';
 
 import * as validator from '../utils/validator';

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -17,7 +17,7 @@
 
 import { FirebaseApp } from '../app/firebase-app';
 import { FirebaseError } from '../utils/error';
-import { ServiceAccountCredential, isApplicationDefault } from '../credential/credential-internal';
+import { ServiceAccountCredential, isApplicationDefault } from '../app/credential-internal';
 import { Bucket, Storage as StorageClient } from '@google-cloud/storage';
 import * as utils from '../utils/index';
 import * as validator from '../utils/validator';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,7 +18,7 @@
 import { App } from '../app/index';
 import {
   ServiceAccountCredential, ComputeEngineCredential
-} from '../credential/credential-internal';
+} from '../app/credential-internal';
 import * as validator from './validator';
 
 let sdkVersion: string;

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -28,8 +28,7 @@ import * as jwt from 'jsonwebtoken';
 import { AppOptions } from '../../src/firebase-namespace-api';
 import { FirebaseNamespace } from '../../src/app/firebase-namespace';
 import { FirebaseApp } from '../../src/app/firebase-app';
-import { credential as _credential, GoogleOAuthAccessToken } from '../../src/credential/index';
-import { ServiceAccountCredential } from '../../src/credential/credential-internal';
+import { Credential, GoogleOAuthAccessToken, cert } from '../../src/app/index';
 
 const ALGORITHM = 'RS256' as const;
 const ONE_HOUR_IN_SECONDS = 60 * 60;
@@ -51,7 +50,7 @@ export const databaseAuthVariableOverride = { 'some#string': 'some#val' };
 
 export const storageBucket = 'bucketName.appspot.com';
 
-export const credential = new ServiceAccountCredential(path.resolve(__dirname, './mock.key.json'));
+export const credential = cert(path.resolve(__dirname, './mock.key.json'));
 
 export const appOptions: AppOptions = {
   credential,
@@ -80,7 +79,7 @@ export const appOptionsAuthDB: AppOptions = {
   databaseURL,
 };
 
-export class MockCredential implements _credential.Credential {
+export class MockCredential implements Credential {
   public getAccessToken(): Promise<GoogleOAuthAccessToken> {
     return Promise.resolve({
       access_token: 'mock-token', // eslint-disable-line @typescript-eslint/camelcase

--- a/test/unit/app/credential-internal.spec.ts
+++ b/test/unit/app/credential-internal.spec.ts
@@ -32,12 +32,12 @@ import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
 import {
-  GoogleOAuthAccessToken, credential
-} from '../../../src/credential/index';
+  GoogleOAuthAccessToken, Credential
+} from '../../../src/app/index';
 import {
   RefreshTokenCredential, ServiceAccountCredential,
   ComputeEngineCredential, getApplicationDefault, isApplicationDefault
-} from '../../../src/credential/credential-internal';
+} from '../../../src/app/credential-internal';
 import { HttpClient } from '../../../src/utils/api-request';
 import { Agent } from 'https';
 import { FirebaseAppError } from '../../../src/utils/error';
@@ -556,7 +556,7 @@ describe('Credential', () => {
     });
 
     it('should return false for custom credential', () => {
-      const c: credential.Credential = {
+      const c: Credential = {
         getAccessToken: () => {
           throw new Error();
         },

--- a/test/unit/app/firebase-app.spec.ts
+++ b/test/unit/app/firebase-app.spec.ts
@@ -26,8 +26,8 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 
-import { GoogleOAuthAccessToken } from '../../../src/credential/index';
-import { ServiceAccountCredential } from '../../../src/credential/credential-internal';
+import { GoogleOAuthAccessToken } from '../../../src/app/index';
+import { ServiceAccountCredential } from '../../../src/app/credential-internal';
 import { FirebaseApp, FirebaseAccessToken } from '../../../src/app/firebase-app';
 import {
   FirebaseNamespace, FirebaseNamespaceInternals, FIREBASE_CONFIG_VAR

--- a/test/unit/app/firebase-namespace.spec.ts
+++ b/test/unit/app/firebase-namespace.spec.ts
@@ -17,6 +17,8 @@
 
 'use strict';
 
+import path = require('path');
+
 import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
@@ -65,6 +67,8 @@ import { ProjectManagement as ProjectManagementImpl } from '../../../src/project
 import { RemoteConfig as RemoteConfigImpl } from '../../../src/remote-config/remote-config';
 import { SecurityRules as SecurityRulesImpl } from '../../../src/security-rules/security-rules';
 import { Storage as StorageImpl } from '../../../src/storage/storage';
+
+import { clearGlobalAppDefaultCred } from '../../../src/app/credential-factory';
 
 import App = app.App;
 import Auth = auth.Auth;
@@ -461,7 +465,7 @@ describe('FirebaseNamespace', () => {
     });
   });
 
-  describe('#machine-learning()', () => {
+  describe('#machineLearning()', () => {
     it('should throw when called before initializating an app', () => {
       expect(() => {
         firebaseNamespace.machineLearning();
@@ -758,5 +762,40 @@ describe('FirebaseNamespace', () => {
       const service2: RemoteConfig = firebaseNamespace.remoteConfig();
       expect(service1).to.equal(service2);
     });
+  });
+
+  describe('credentials', () => {
+    it('should create a service account credential from object', () => {
+      const mockCertificateObject = mocks.certificateObject;
+      const credential = firebaseNamespace.credential.cert(mockCertificateObject);
+      expect(credential).to.deep.include({
+        projectId: mockCertificateObject.project_id,
+        clientEmail: mockCertificateObject.client_email,
+        privateKey: mockCertificateObject.private_key,
+        implicit: false,
+      });
+    });
+
+    it('should create a refresh token credential from object', () => {
+      const mockRefreshToken = mocks.refreshToken;
+      const credential = firebaseNamespace.credential.refreshToken(mockRefreshToken);
+      expect(credential).to.deep.include({
+        implicit: false,
+      });
+    });
+
+    it('should create application default credentials from environment', () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.resolve(__dirname, '../../resources/mock.key.json');
+      const mockCertificateObject = mocks.certificateObject;
+      const credential = firebaseNamespace.credential.applicationDefault();
+      expect(credential).to.deep.include({
+        projectId: mockCertificateObject.project_id,
+        clientEmail: mockCertificateObject.client_email,
+        privateKey: mockCertificateObject.private_key,
+        implicit: true,
+      });
+    });
+
+    after(clearGlobalAppDefaultCred);
   });
 });

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -42,7 +42,7 @@ import {
 } from '../../../src/auth/auth-config';
 import { deepCopy } from '../../../src/utils/deep-copy';
 import { TenantManager } from '../../../src/auth/tenant-manager';
-import { ServiceAccountCredential } from '../../../src/credential/credential-internal';
+import { ServiceAccountCredential } from '../../../src/app/credential-internal';
 import { HttpClient } from '../../../src/utils/api-request';
 import { auth } from '../../../src/auth/index';
 

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -29,7 +29,7 @@ import {
   BLACKLISTED_CLAIMS, FirebaseTokenGenerator, ServiceAccountSigner, IAMSigner, EmulatedSigner
 } from '../../../src/auth/token-generator';
 
-import { ServiceAccountCredential } from '../../../src/credential/credential-internal';
+import { ServiceAccountCredential } from '../../../src/app/credential-internal';
 import { AuthorizedHttpClient, HttpClient } from '../../../src/utils/api-request';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import * as utils from '../utils';

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -31,7 +31,7 @@ import * as mocks from '../../resources/mocks';
 import { FirebaseTokenGenerator, ServiceAccountSigner } from '../../../src/auth/token-generator';
 import * as verifier from '../../../src/auth/token-verifier';
 
-import { ServiceAccountCredential } from '../../../src/credential/credential-internal';
+import { ServiceAccountCredential } from '../../../src/app/credential-internal';
 import { AuthClientErrorCode } from '../../../src/utils/error';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import { Algorithm } from 'jsonwebtoken';

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -31,7 +31,7 @@ import * as firebaseAdmin from '../../src/index';
 import { FirebaseApp, FirebaseAppInternals } from '../../src/app/firebase-app';
 import {
   RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault
-} from '../../src/credential/credential-internal';
+} from '../../src/app/credential-internal';
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -24,7 +24,7 @@ import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import {
   ComputeEngineCredential, RefreshTokenCredential
-} from '../../../src/credential/credential-internal';
+} from '../../../src/app/credential-internal';
 import { FirestoreService, getFirestoreOptions } from '../../../src/firestore/firestore-internal';
 
 describe('Firestore', () => {

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -17,6 +17,7 @@
 
 // General
 import './firebase.spec';
+import './app/credential-internal.spec';
 import './app/index.spec';
 import './app/firebase-app.spec';
 import './app/firebase-namespace.spec';
@@ -38,9 +39,6 @@ import './auth/action-code-settings-builder.spec';
 import './auth/auth-config.spec';
 import './auth/tenant.spec';
 import './auth/tenant-manager.spec';
-
-// Credential
-import './credential/credential.spec';
 
 // Database
 import './database/database.spec';

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../src/utils/index';
 import { isNonEmptyString } from '../../../src/utils/validator';
 import { FirebaseApp } from '../../../src/app/firebase-app';
-import { ComputeEngineCredential } from '../../../src/credential/credential-internal';
+import { ComputeEngineCredential } from '../../../src/app/credential-internal';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';
 import { FirebaseAppError } from '../../../src/utils/error';


### PR DESCRIPTION
* Exposed `ServiceAccount`, `GoogleOAuthAccessToken`, `cert()`, `applicationDefault()` and `refreshToken()` APIs from the `app` submodule.
* Moved credential implementations under the same submodule.
* Aliased the new APIs from the existing `admin.credential` namespace for backward compatibility.