### PR TITLE
fix: Renaming service functions to getAuth and getInstanceId

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -84,7 +84,7 @@ export class Auth extends BaseAuth {
     }
 
 // @public
-export function auth(app?: App): Auth;
+export function auth(app?: App): auth.Auth;
 
 // @public (undocumented)
 export namespace auth {
@@ -400,6 +400,12 @@ export function getApp(name?: string): App;
 // @public (undocumented)
 export function getApps(): App[];
 
+// @public (undocumented)
+export function getAuth(app?: App): Auth;
+
+// @public (undocumented)
+export function getInstanceId(app?: App): InstanceId;
+
 // @public
 export interface GetUsersResult {
     notFound: UserIdentifier[];
@@ -427,7 +433,7 @@ export class InstanceId {
     }
 
 // @public
-export function instanceId(app?: App): InstanceId;
+export function instanceId(app?: App): instanceId.InstanceId;
 
 // @public (undocumented)
 export namespace instanceId {

--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -277,7 +277,7 @@ export class FirebaseApp implements app.App {
    * @return The Auth service instance of this app.
    */
   public auth(): Auth {
-    const fn = require('../auth/index').auth;
+    const fn = require('../auth/index').getAuth;
     return fn(this);
   }
 
@@ -332,7 +332,7 @@ export class FirebaseApp implements app.App {
    * @return The InstanceId service instance of this app.
    */
   public instanceId(): InstanceId {
-    const fn = require('../instance-id/index').instanceId;
+    const fn = require('../instance-id/index').getInstanceId;
     return fn(this);
   }
 

--- a/src/auth/auth-namespace.ts
+++ b/src/auth/auth-namespace.ts
@@ -95,6 +95,15 @@ import {
   UserRecord as TUserRecord,
 } from './user-record';
 
+export function getAuth(app?: App): Auth {
+  if (typeof app === 'undefined') {
+    app = getApp();
+  }
+
+  const firebaseApp: FirebaseApp = app as FirebaseApp;
+  return firebaseApp.getOrInitService('auth', (app) => new Auth(app));
+}
+
 /**
  * Gets the {@link auth.Auth `Auth`} service for the default app or a
  * given app.
@@ -116,14 +125,7 @@ import {
  * ```
  *
  */
-export function auth(app?: App): Auth {
-  if (typeof app === 'undefined') {
-    app = getApp();
-  }
-
-  const firebaseApp: FirebaseApp = app as FirebaseApp;
-  return firebaseApp.getOrInitService('auth', (app) => new Auth(app));
-}
+export declare function auth(app?: App): auth.Auth;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace auth {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -91,4 +91,4 @@ export {
   UserRecord,
 } from './user-record';
 
-export { auth } from './auth-namespace';
+export { getAuth, auth } from './auth-namespace';

--- a/src/instance-id/index.ts
+++ b/src/instance-id/index.ts
@@ -20,6 +20,15 @@ import { InstanceId } from './instance-id';
 
 export { InstanceId };
 
+export function getInstanceId(app?: App): InstanceId {
+  if (typeof app === 'undefined') {
+    app = getApp();
+  }
+
+  const firebaseApp: FirebaseApp = app as FirebaseApp;
+  return firebaseApp.getOrInitService('instanceId', (app) => new InstanceId(app));
+}
+
 /**
  * Gets the {@link instanceId.InstanceId `InstanceId`} service for the
  * default app or a given app.
@@ -50,14 +59,7 @@ export { InstanceId };
  *   no app is provided or the `InstanceId` service associated with the
  *   provided app.
  */
-export function instanceId(app?: App): InstanceId {
-  if (typeof app === 'undefined') {
-    app = getApp();
-  }
-
-  const firebaseApp: FirebaseApp = app as FirebaseApp;
-  return firebaseApp.getOrInitService('instanceId', (app) => new InstanceId(app));
-}
+export declare function instanceId(app?: App): instanceId.InstanceId;
 
 import { InstanceId as TInstanceId } from './instance-id';
 

--- a/test/unit/auth/index.spec.ts
+++ b/test/unit/auth/index.spec.ts
@@ -23,7 +23,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';
-import { getInstanceId, InstanceId } from '../../../src/instance-id/index';
+import { getAuth, Auth } from '../../../src/auth/index';
 
 chai.should();
 chai.use(sinonChai);
@@ -35,7 +35,7 @@ describe('InstanceId', () => {
   let mockApp: App;
   let mockCredentialApp: App;
 
-  const noProjectIdError = 'Failed to determine project ID for InstanceId. Initialize the SDK '
+  const noProjectIdError = 'Failed to determine project ID for Auth. Initialize the SDK '
   + 'with service account credentials or set project ID as an app option. Alternatively set the '
   + 'GOOGLE_CLOUD_PROJECT environment variable.';
 
@@ -44,10 +44,10 @@ describe('InstanceId', () => {
     mockCredentialApp = mocks.mockCredentialApp();
   });
 
-  describe('getInstanceId()', () => {
+  describe('getAuth()', () => {
     it('should throw when default app is not available', () => {
       expect(() => {
-        return getInstanceId();
+        return getAuth();
       }).to.throw('The default Firebase app does not exist.');
     });
 
@@ -55,21 +55,21 @@ describe('InstanceId', () => {
       // Project ID not set in the environment.
       delete process.env.GOOGLE_CLOUD_PROJECT;
       delete process.env.GCLOUD_PROJECT;
-      const iid = getInstanceId(mockCredentialApp);
-      return iid.deleteInstanceId('iid')
+      const auth = getAuth(mockCredentialApp);
+      return auth.getUser('uid')
         .should.eventually.rejectedWith(noProjectIdError);
     });
 
     it('should not throw given a valid app', () => {
       expect(() => {
-        return getInstanceId(mockApp);
+        return getAuth(mockApp);
       }).not.to.throw();
     });
 
     it('should return the same instance for a given app instance', () => {
-      const iid1: InstanceId = getInstanceId(mockApp);
-      const iid2: InstanceId = getInstanceId(mockApp);
-      expect(iid1).to.equal(iid2);
+      const auth1: Auth = getAuth(mockApp);
+      const auth2: Auth = getAuth(mockApp);
+      expect(auth1).to.equal(auth2);
     });
   });
 });

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -30,6 +30,7 @@ import './utils/api-request.spec';
 
 // Auth
 import './auth/auth.spec';
+import './auth/index.spec';
 import './auth/user-record.spec';
 import './auth/token-generator.spec';
 import './auth/token-verifier.spec';


### PR DESCRIPTION
* Renaming the service accessor functions to be consistent with the approved API proposal.
* Added some unit tests for the `getAuth()` function.