### PR TITLE
feat(rtdb): Added firebase-admin/database module entrypoint

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -6,8 +6,15 @@
 
 import { Agent } from 'http';
 import { Bucket } from '@google-cloud/storage';
+import { DataSnapshot } from '@firebase/database-types';
+import { EventType } from '@firebase/database-types';
+import { FirebaseDatabase } from '@firebase/database-types';
 import * as _firestore from '@google-cloud/firestore';
+import { OnDisconnect } from '@firebase/database-types';
+import { Query } from '@firebase/database-types';
+import { Reference } from '@firebase/database-types';
 import * as rtdb from '@firebase/database-types';
+import { ThenableReference } from '@firebase/database-types';
 
 // @public
 export interface ActionCodeSettings {
@@ -274,26 +281,38 @@ export namespace credential {
     const refreshToken: typeof refreshToken;
 }
 
+// @public (undocumented)
+export interface Database extends FirebaseDatabase {
+    getRules(): Promise<string>;
+    getRulesJSON(): Promise<object>;
+    setRules(source: string | Buffer | object): Promise<void>;
+}
+
 // @public
-export function database(app?: app.App): database.Database;
+export function database(app?: App): database.Database;
 
 // @public (undocumented)
 export namespace database {
     // (undocumented)
-    export interface Database extends rtdb.FirebaseDatabase {
-        getRules(): Promise<string>;
-        getRulesJSON(): Promise<object>;
-        setRules(source: string | Buffer | object): Promise<void>;
-    }
-    import DataSnapshot = rtdb.DataSnapshot;
-    import EventType = rtdb.EventType;
-    import OnDisconnect = rtdb.OnDisconnect;
-    import Query = rtdb.Query;
-    import Reference = rtdb.Reference;
-    import ThenableReference = rtdb.ThenableReference;
-    import enableLogging = rtdb.enableLogging;
+    export type Database = Database;
+    // (undocumented)
+    export type DataSnapshot = rtdb.DataSnapshot;
+    // (undocumented)
+    export type EventType = rtdb.EventType;
+    // (undocumented)
+    export type OnDisconnect = rtdb.OnDisconnect;
+    // (undocumented)
+    export type Query = rtdb.Query;
+    // (undocumented)
+    export type Reference = rtdb.Reference;
+    // (undocumented)
+    export type ThenableReference = rtdb.ThenableReference;
+    const // (undocumented)
+    enableLogging: typeof rtdb.enableLogging;
     const ServerValue: rtdb.ServerValue;
 }
+
+export { DataSnapshot }
 
 // @public
 export interface DecodedIdToken {
@@ -343,6 +362,11 @@ export interface EmailSignInProviderConfig {
     enabled: boolean;
     passwordRequired?: boolean;
 }
+
+// @public (undocumented)
+export const enableLogging: typeof rtdb.enableLogging;
+
+export { EventType }
 
 // @public
 export interface FirebaseArrayIndexError {
@@ -402,6 +426,12 @@ export function getApps(): App[];
 
 // @public (undocumented)
 export function getAuth(app?: App): Auth;
+
+// @public (undocumented)
+export function getDatabase(app?: App): Database;
+
+// @public (undocumented)
+export function getDatabaseWithUrl(url: string, app?: App): Database;
 
 // @public (undocumented)
 export function getInstanceId(app?: App): InstanceId;
@@ -866,6 +896,8 @@ export interface OIDCUpdateAuthProviderRequest {
     issuer?: string;
 }
 
+export { OnDisconnect }
+
 // @public
 export interface PhoneIdentifier {
     // (undocumented)
@@ -950,6 +982,10 @@ export interface ProviderIdentifier {
     // (undocumented)
     providerUid: string;
 }
+
+export { Query }
+
+export { Reference }
 
 // @public (undocumented)
 export function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;
@@ -1101,6 +1137,9 @@ export namespace securityRules {
 }
 
 // @public (undocumented)
+export const ServerValue: rtdb.ServerValue;
+
+// @public (undocumented)
 export interface ServiceAccount {
     // (undocumented)
     clientEmail?: string;
@@ -1162,6 +1201,8 @@ export class TenantManager {
     listTenants(maxResults?: number, pageToken?: string): Promise<ListTenantsResult>;
     updateTenant(tenantId: string, tenantOptions: UpdateTenantRequest): Promise<Tenant>;
 }
+
+export { ThenableReference }
 
 // @public
 export interface UidIdentifier {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,6 +89,7 @@ gulp.task('compile', function() {
     'lib/core.d.ts',
     'lib/app/*.d.ts',
     'lib/auth/*.d.ts',
+    'lib/database/*.d.ts',
     'lib/instance-id/*.d.ts',
     '!lib/utils/index.d.ts',
   ];

--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -27,16 +27,13 @@ import { Auth } from '../auth/auth';
 import { MachineLearning } from '../machine-learning/machine-learning';
 import { Messaging } from '../messaging/messaging';
 import { Storage } from '../storage/storage';
-import { database } from '../database/index';
-import { DatabaseService } from '../database/database-internal';
+import { Database } from '../database/index';
 import { Firestore } from '@google-cloud/firestore';
 import { FirestoreService } from '../firestore/firestore-internal';
 import { InstanceId } from '../instance-id/index';
 import { ProjectManagement } from '../project-management/project-management';
 import { SecurityRules } from '../security-rules/security-rules';
 import { RemoteConfig } from '../remote-config/remote-config';
-
-import Database = database.Database;
 
 /**
  * Type representing a callback which is called every time an app lifecycle event occurs.
@@ -287,11 +284,8 @@ export class FirebaseApp implements app.App {
    * @return The Database service instance of this app.
    */
   public database(url?: string): Database {
-    const service: DatabaseService = this.ensureService_('database', () => {
-      const dbService: typeof DatabaseService = require('../database/database-internal').DatabaseService;
-      return new dbService(this);
-    });
-    return service.getDatabase(url);
+    const fn = require('../database/index').getDatabaseWithUrl;
+    return fn(url, this);
   }
 
   /**

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -14,9 +14,48 @@
  * limitations under the License.
  */
 
-import { app } from '../firebase-namespace-api';
-import { ServerValue as sv } from '@firebase/database';
 import * as rtdb from '@firebase/database-types';
+import {
+  enableLogging as enableLoggingFunc,
+  ServerValue as serverValueConst,
+} from '@firebase/database';
+
+import { App, getApp } from '../app';
+import { FirebaseApp } from '../app/firebase-app';
+import { Database, DatabaseService } from './database';
+import { Database as TDatabase } from './database';
+
+export { Database };
+export {
+  DataSnapshot,
+  EventType,
+  OnDisconnect,
+  Query,
+  Reference,
+  ThenableReference,
+} from '@firebase/database-types';
+
+export const enableLogging: typeof rtdb.enableLogging = enableLoggingFunc;
+export const ServerValue: rtdb.ServerValue = serverValueConst;
+
+export function getDatabase(app?: App): Database {
+  return getDatabaseInstance({ app });
+}
+
+export function getDatabaseWithUrl(url: string, app?: App): Database {
+  return getDatabaseInstance({ url, app });
+}
+
+function  getDatabaseInstance(options: { url?: string; app?: App }): Database {
+  let { app } = options;
+  if (typeof app === 'undefined') {
+    app = getApp();
+  }
+
+  const firebaseApp: FirebaseApp = app as FirebaseApp;
+  const dbService = firebaseApp.getOrInitService('database', (app) => new DatabaseService(app));
+  return dbService.getDatabase(options.url);
+}
 
 /**
  * Gets the {@link database.Database `Database`} service for the default
@@ -49,49 +88,23 @@ import * as rtdb from '@firebase/database-types';
  * @return The default `Database` service if no app
  *   is provided or the `Database` service associated with the provided app.
  */
-export declare function database(app?: app.App): database.Database;
+export declare function database(app?: App): database.Database;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace database {
-  export interface Database extends rtdb.FirebaseDatabase {
-    /**
-     * Gets the currently applied security rules as a string. The return value consists of
-     * the rules source including comments.
-     *
-     * @return A promise fulfilled with the rules as a raw string.
-     */
-    getRules(): Promise<string>;
+  export type Database = TDatabase;
+  export type DataSnapshot = rtdb.DataSnapshot;
+  export type EventType = rtdb.EventType;
+  export type OnDisconnect = rtdb.OnDisconnect;
+  export type Query = rtdb.Query;
+  export type Reference = rtdb.Reference;
+  export type ThenableReference = rtdb.ThenableReference;
 
-    /**
-     * Gets the currently applied security rules as a parsed JSON object. Any comments in
-     * the original source are stripped away.
-     *
-     * @return A promise fulfilled with the parsed rules object.
-     */
-    getRulesJSON(): Promise<object>;
-
-    /**
-     * Sets the specified rules on the Firebase Realtime Database instance. If the rules source is
-     * specified as a string or a Buffer, it may include comments.
-     *
-     * @param source Source of the rules to apply. Must not be `null` or empty.
-     * @return Resolves when the rules are set on the Realtime Database.
-     */
-    setRules(source: string | Buffer | object): Promise<void>;
-  }
-
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  export import DataSnapshot = rtdb.DataSnapshot;
-  export import EventType = rtdb.EventType;
-  export import OnDisconnect = rtdb.OnDisconnect;
-  export import Query = rtdb.Query;
-  export import Reference = rtdb.Reference;
-  export import ThenableReference = rtdb.ThenableReference;
-  export import enableLogging = rtdb.enableLogging;
+  export declare const enableLogging: typeof rtdb.enableLogging;
 
   /**
    * [`ServerValue`](https://firebase.google.com/docs/reference/js/firebase.database.ServerValue)
    * module from the `@firebase/database` package.
    */
-  export const ServerValue: rtdb.ServerValue = sv;
+  export declare const ServerValue: rtdb.ServerValue;
 }

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -23,12 +23,10 @@ import * as sinon from 'sinon';
 
 import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/app/firebase-app';
-import { DatabaseService } from '../../../src/database/database-internal';
-import { database } from '../../../src/database/index';
+import { DatabaseService } from '../../../src/database/database';
+import { Database } from '../../../src/database/index';
 import * as utils from '../utils';
 import { HttpClient, HttpRequestConfig } from '../../../src/utils/api-request';
-
-import Database = database.Database;
 
 describe('Database', () => {
   let mockApp: FirebaseApp;

--- a/test/unit/database/index.spec.ts
+++ b/test/unit/database/index.spec.ts
@@ -23,7 +23,9 @@ import * as chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';
-import { getDatabase, getDatabaseWithUrl, Database } from '../../../src/database/index';
+import {
+  getDatabase, getDatabaseWithUrl, Database, ServerValue, enableLogging ,
+} from '../../../src/database/index';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 
 chai.should();
@@ -83,5 +85,16 @@ describe('Database', () => {
       expect(db1).to.equal(db2);
       expect(db1).to.not.equal(db3);
     });
+  });
+
+  it('should expose ServerValue sentinel', () => {
+    expect(() => ServerValue.increment(1)).to.not.throw();
+  });
+
+  it('should expose enableLogging global function', () => {
+    expect(() => {
+      enableLogging(console.log);
+      enableLogging(false);
+    }).to.not.throw();
   });
 });

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -43,6 +43,7 @@ import './auth/tenant-manager.spec';
 
 // Database
 import './database/database.spec';
+import './database/index.spec';
 
 // Messaging
 import './messaging/messaging.spec';


### PR DESCRIPTION
* Added `getDatabase()` and `getDatabaseWithUrl()` entry functions.
* Exported `Database` type with the methods for managing security rules.
* Exported other public interface types from `@firebase/database-types` package.
* Exported `enableLogging` and `ServerValue` members from the `@firebase/database` package.