### PR TITLE
Improve token verification logic with Auth Emulator.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,9 +176,9 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.2.tgz",
-      "integrity": "sha512-2n32PBi6x9jVhc0E/ewKLUCYYTzFEXL4PNkvrrlGKbzeTBEkkyzfgUX7OV9UF5wUOG+gurtUthuur1zspZ/9hg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.2.tgz",
+      "integrity": "sha512-68TlDL0yh3kF8PiCzI8m8RWd/bf/xCLUsdz1NZ2Dwea0sp6e2WAhu0sem1GfhwuEwL+Ns4jCdX7qbe/OQlkVEA==",
       "dev": true,
       "requires": {
         "@firebase/auth-types": "0.10.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@firebase/app": "^0.6.13",
-    "@firebase/auth": "^0.15.2",
+    "@firebase/auth": "^0.16.2",
     "@firebase/auth-types": "^0.10.1",
     "@microsoft/api-extractor": "^7.11.2",
     "@types/bcrypt": "^2.0.0",

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -2117,10 +2117,6 @@ function emulatorHost(): string | undefined {
 /**
  * When true the SDK should communicate with the Auth Emulator for all API
  * calls and also produce unsigned tokens.
- *
- * This alone does <b>NOT<b> short-circuit ID Token verification.
- * For security reasons that must be explicitly disabled through
- * setJwtVerificationEnabled(false);
  */
 export function useEmulator(): boolean {
   return !!emulatorHost();

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -115,10 +115,11 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
    *     verification.
    */
   public verifyIdToken(idToken: string, checkRevoked = false): Promise<DecodedIdToken> {
-    return this.idTokenVerifier.verifyJWT(idToken)
+    const isEmulator = useEmulator();
+    return this.idTokenVerifier.verifyJWT(idToken, isEmulator)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
-        if (checkRevoked || useEmulator()) {
+        if (checkRevoked || isEmulator) {
           return this.verifyDecodedJWTNotRevoked(
             decodedIdToken,
             AuthClientErrorCode.ID_TOKEN_REVOKED);
@@ -443,10 +444,11 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
    */
   public verifySessionCookie(
     sessionCookie: string, checkRevoked = false): Promise<DecodedIdToken> {
-    return this.sessionCookieVerifier.verifyJWT(sessionCookie)
+    const isEmulator = useEmulator();
+    return this.sessionCookieVerifier.verifyJWT(sessionCookie, isEmulator)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
-        if (checkRevoked || useEmulator()) {
+        if (checkRevoked || isEmulator) {
           return this.verifyDecodedJWTNotRevoked(
             decodedIdToken,
             AuthClientErrorCode.SESSION_COOKIE_REVOKED);

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -118,12 +118,12 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
     return this.idTokenVerifier.verifyJWT(idToken)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
-        if (!checkRevoked && !useEmulator()) {
-          return decodedIdToken;
+        if (checkRevoked || useEmulator()) {
+          return this.verifyDecodedJWTNotRevoked(
+            decodedIdToken,
+            AuthClientErrorCode.ID_TOKEN_REVOKED);
         }
-        return this.verifyDecodedJWTNotRevoked(
-          decodedIdToken,
-          AuthClientErrorCode.ID_TOKEN_REVOKED);
+        return decodedIdToken;
       });
   }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -446,12 +446,12 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
     return this.sessionCookieVerifier.verifyJWT(sessionCookie)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
-        if (!checkRevoked) {
-          return decodedIdToken;
+        if (checkRevoked || useEmulator()) {
+          return this.verifyDecodedJWTNotRevoked(
+            decodedIdToken,
+            AuthClientErrorCode.SESSION_COOKIE_REVOKED);
         }
-        return this.verifyDecodedJWTNotRevoked(
-          decodedIdToken,
-          AuthClientErrorCode.SESSION_COOKIE_REVOKED);
+        return decodedIdToken;
       });
   }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -29,7 +29,7 @@ import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
 import { auth } from './index';
 import {
-  FirebaseTokenVerifier, createSessionCookieVerifier, createIdTokenVerifier, ALGORITHM_RS256
+  FirebaseTokenVerifier, createSessionCookieVerifier, createIdTokenVerifier
 } from './token-verifier';
 import {
   SAMLConfig, OIDCConfig, OIDCConfigServerResponse, SAMLConfigServerResponse,
@@ -118,7 +118,7 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
     return this.idTokenVerifier.verifyJWT(idToken)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
-        if (!checkRevoked) {
+        if (!checkRevoked && !useEmulator()) {
           return decodedIdToken;
         }
         return this.verifyDecodedJWTNotRevoked(
@@ -674,28 +674,6 @@ export class BaseAuth<T extends AbstractAuthRequestHandler> implements BaseAuthI
         // All checks above passed. Return the decoded token.
         return decodedIdToken;
       });
-  }
-
-  /**
-   * Enable or disable ID token verification. This is used to safely short-circuit token verification with the
-   * Auth emulator. When disabled ONLY unsigned tokens will pass verification, production tokens will not pass.
-   *
-   * WARNING: This is a dangerous method that will compromise your app's security and break your app in
-   * production. Developers should never call this method, it is for internal testing use only.
-   *
-   * @internal
-   */
-  // @ts-expect-error: this method appears unused but is used privately.
-  private setJwtVerificationEnabled(enabled: boolean): void {
-    if (!enabled && !useEmulator()) {
-      // We only allow verification to be disabled in conjunction with
-      // the emulator environment variable.
-      throw new Error('This method is only available when connected to the Authentication emulator.');
-    }
-
-    const algorithm = enabled ? ALGORITHM_RS256 : 'none';
-    this.idTokenVerifier.setAlgorithm(algorithm);
-    this.sessionCookieVerifier.setAlgorithm(algorithm);
   }
 }
 

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -216,9 +216,8 @@ export class FirebaseTokenVerifier {
       return Promise.reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_ARGUMENT, errorMessage));
     }
 
-    // When the algorithm is set to 'none' there will be no signature and therefore we don't check
-    // the public keys.
     if (useEmulator()) {
+      // Signature checks skipped for emulator; no need to fetch public keys.
       return this.verifyJwtSignatureWithKey(jwtToken, null);
     }
 

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -135,11 +135,11 @@ export class FirebaseTokenVerifier {
    * Verifies the format and signature of a Firebase Auth JWT token.
    *
    * @param {string} jwtToken The Firebase Auth JWT token to verify.
-   * @param {boolean} isEmulator Whether to accept Auth Emulator tokens.
+   * @param {boolean=} isEmulator Whether to accept Auth Emulator tokens.
    * @return {Promise<DecodedIdToken>} A promise fulfilled with the decoded claims of the Firebase Auth ID
    *                           token.
    */
-  public verifyJWT(jwtToken: string, isEmulator: boolean): Promise<DecodedIdToken> {
+  public verifyJWT(jwtToken: string, isEmulator = false): Promise<DecodedIdToken> {
     if (!validator.isString(jwtToken)) {
       throw new FirebaseAuthError(
         AuthClientErrorCode.INVALID_ARGUMENT,

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -37,6 +37,8 @@ chai.use(chaiAsPromised);
 
 const expect = chai.expect;
 
+const authEmulatorHost = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
 const newUserUid = generateRandomString(20);
 const nonexistentUid = generateRandomString(20);
 const newMultiFactorUserUid = generateRandomString(20);
@@ -102,6 +104,9 @@ describe('admin.auth', () => {
       apiKey,
       authDomain: projectId + '.firebaseapp.com',
     });
+    if (authEmulatorHost) {
+      (clientAuth() as any).useEmulator('http://' + authEmulatorHost);
+    }
     return cleanup();
   });
 
@@ -137,7 +142,10 @@ describe('admin.auth', () => {
       });
   });
 
-  it('createUser() creates a new user with enrolled second factors', () => {
+  it('createUser() creates a new user with enrolled second factors', function () {
+    if (authEmulatorHost) {
+      return this.skip(); // Not yet supported in Auth Emulator.
+    }
     const enrolledFactors = [
       {
         phoneNumber: '+16505550001',
@@ -353,7 +361,7 @@ describe('admin.auth', () => {
 
             const metadata = userRecord!.metadata;
             expect(metadata.lastRefreshTime).to.exist;
-            expect(isUTCString(metadata.lastRefreshTime!));
+            expect(isUTCString(metadata.lastRefreshTime!)).to.be.true;
             const creationTime = new Date(metadata.creationTime).getTime();
             const lastRefreshTime = new Date(metadata.lastRefreshTime!).getTime();
             expect(creationTime).lte(lastRefreshTime);
@@ -410,7 +418,7 @@ describe('admin.auth', () => {
       });
   });
 
-  it('revokeRefreshTokens() invalidates existing sessions and ID tokens', () => {
+  it('revokeRefreshTokens() invalidates existing sessions and ID tokens', async () => {
     let currentIdToken: string;
     let currentUser: User;
     // Sign in with an email and password account.
@@ -433,9 +441,14 @@ describe('admin.auth', () => {
         ), 1000));
       })
       .then(() => {
-        // verifyIdToken without checking revocation should still succeed.
-        return admin.auth().verifyIdToken(currentIdToken)
-          .should.eventually.be.fulfilled;
+        const verifyingIdToken = admin.auth().verifyIdToken(currentIdToken)
+        if (!authEmulatorHost) {
+          // verifyIdToken without checking revocation should still succeed.
+          return verifyingIdToken.should.eventually.be.fulfilled;
+        } else {
+          // Check revocation is forced in emulator-mode and this should throw.
+          return verifyingIdToken.should.eventually.be.rejected;
+        }
       })
       .then(() => {
         // verifyIdToken while checking for revocation should fail.
@@ -522,6 +535,27 @@ describe('admin.auth', () => {
 
   it('updateUser() updates the user record with the given parameters', () => {
     const updatedDisplayName = 'Updated User ' + newUserUid;
+    return admin.auth().updateUser(newUserUid, {
+      email: updatedEmail,
+      phoneNumber: updatedPhone,
+      emailVerified: true,
+      displayName: updatedDisplayName,
+    })
+      .then((userRecord) => {
+        expect(userRecord.emailVerified).to.be.true;
+        expect(userRecord.displayName).to.equal(updatedDisplayName);
+        // Confirm expected email.
+        expect(userRecord.email).to.equal(updatedEmail);
+        // Confirm expected phone number.
+        expect(userRecord.phoneNumber).to.equal(updatedPhone);
+      });
+  });
+
+  it('updateUser() creates, updates, and removes second factors', function () {
+    if (authEmulatorHost) {
+      return this.skip(); // Not yet supported in Auth Emulator.
+    }
+
     const now = new Date(1476235905000).toUTCString();
     // Update user with enrolled second factors.
     const enrolledFactors = [
@@ -541,21 +575,11 @@ describe('admin.auth', () => {
       },
     ];
     return admin.auth().updateUser(newUserUid, {
-      email: updatedEmail,
-      phoneNumber: updatedPhone,
-      emailVerified: true,
-      displayName: updatedDisplayName,
       multiFactor: {
         enrolledFactors,
       },
     })
       .then((userRecord) => {
-        expect(userRecord.emailVerified).to.be.true;
-        expect(userRecord.displayName).to.equal(updatedDisplayName);
-        // Confirm expected email.
-        expect(userRecord.email).to.equal(updatedEmail);
-        // Confirm expected phone number.
-        expect(userRecord.phoneNumber).to.equal(updatedPhone);
         // Confirm second factors added to user.
         const actualUserRecord: {[key: string]: any} = userRecord.toJSON();
         expect(actualUserRecord.multiFactor.enrolledFactors.length).to.equal(2);
@@ -654,6 +678,49 @@ describe('admin.auth', () => {
     return admin.auth().verifyIdToken('invalid-token')
       .should.eventually.be.rejected.and.have.property('code', 'auth/argument-error');
   });
+
+  if (authEmulatorHost) {
+    describe('Auth emulator support', () => {
+      const uid = 'authEmulatorUser';
+      before(() => {
+        return admin.auth().createUser({
+          uid,
+          email: 'lastRefreshTimeUser@example.com',
+          password: 'p4ssword',
+        });
+      });
+      after(() => {
+        return admin.auth().deleteUser(uid);
+      });
+
+      it('verifyIdToken() succeeds when called with an unsigned token', () => {
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          audience: projectId,
+          issuer: 'https://securetoken.google.com/' + projectId,
+          subject: uid,
+        });
+        return admin.auth().verifyIdToken(unsignedToken);
+      });
+
+      it('verifyIdToken() fails when called with a token with wrong project', () => {
+        const unsignedToken = mocks.generateIdToken({algorithm: 'none', audience: 'nosuch'});
+        return admin.auth().verifyIdToken(unsignedToken)
+          .should.eventually.be.rejected.and.have.property('code', 'auth/argument-error');
+      });
+
+      it('verifyIdToken() fails when called with a token that does not belong to a user', () => {
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          audience: projectId,
+          issuer: 'https://securetoken.google.com/' + projectId,
+          subject: 'nosuch',
+        });
+        return admin.auth().verifyIdToken(unsignedToken)
+          .should.eventually.be.rejected.and.have.property('code', 'auth/user-not-found');
+      });
+    });
+  }
 
   describe('Link operations', () => {
     const uid = generateRandomString(20).toLowerCase();
@@ -1253,7 +1320,10 @@ describe('admin.auth', () => {
     };
 
     // Clean up temp configurations used for test.
-    before(() => {
+    before(function () {
+      if (authEmulatorHost) {
+        return this.skip(); // Not implemented.
+      }
       return removeTempConfigs().then(() => admin.auth().createProviderConfig(authProviderConfig1));
     });
 
@@ -1385,7 +1455,10 @@ describe('admin.auth', () => {
     };
 
     // Clean up temp configurations used for test.
-    before(() => {
+    before(function () {
+      if (authEmulatorHost) {
+        return this.skip(); // Not implemented.
+      }
       return removeTempConfigs().then(() => admin.auth().createProviderConfig(authProviderConfig1));
     });
 
@@ -1484,7 +1557,6 @@ describe('admin.auth', () => {
   it('deleteUser() deletes the user with the given UID', () => {
     return Promise.all([
       admin.auth().deleteUser(newUserUid),
-      admin.auth().deleteUser(newMultiFactorUserUid),
       admin.auth().deleteUser(uidFromCreateUserWithoutUid),
     ]).should.eventually.be.fulfilled;
   });
@@ -1555,6 +1627,12 @@ describe('admin.auth', () => {
     const uid = sessionCookieUids[0];
     const uid2 = sessionCookieUids[1];
     const uid3 = sessionCookieUids[2];
+
+    before(function () {
+      if (authEmulatorHost) {
+        return this.skip();  // Not implemented yet.
+      }
+    });
 
     it('creates a valid Firebase session cookie', () => {
       return admin.auth().createCustomToken(uid, { admin: true, groupId: '1234' })
@@ -1824,7 +1902,10 @@ describe('admin.auth', () => {
     ];
 
     fixtures.forEach((fixture) => {
-      it(`successfully imports users with ${fixture.name} to Firebase Auth.`, () => {
+      it(`successfully imports users with ${fixture.name} to Firebase Auth.`, function () {
+        if (authEmulatorHost) {
+          return this.skip(); // Auth Emulator does not support real hashes.
+        }
         importUserRecord = {
           uid: randomUid,
           email: randomUid + '@example.com',
@@ -1893,10 +1974,13 @@ describe('admin.auth', () => {
             expect(JSON.stringify(actualUserRecord[key]))
               .to.be.equal(JSON.stringify((importUserRecord as any)[key]));
           }
-        }).should.eventually.be.fulfilled;
+        });
     });
 
-    it('successfully imports users with enrolled second factors', () => {
+    it('successfully imports users with enrolled second factors', function () {
+      if (authEmulatorHost) {
+        return this.skip(); // Not yet implemented.
+      }
       const uid = generateRandomString(20).toLowerCase();
       const email = uid + '@example.com';
       const now = new Date(1476235905000).toUTCString();
@@ -1958,25 +2042,41 @@ describe('admin.auth', () => {
 
     it('fails when invalid users are provided', () => {
       const users = [
-        { uid: generateRandomString(20).toLowerCase(), phoneNumber: '+1error' },
         { uid: generateRandomString(20).toLowerCase(), email: 'invalid' },
-        { uid: generateRandomString(20).toLowerCase(), phoneNumber: '+1invalid' },
         { uid: generateRandomString(20).toLowerCase(), emailVerified: 'invalid' } as any,
       ];
       return admin.auth().importUsers(users)
         .then((result) => {
           expect(result.successCount).to.equal(0);
-          expect(result.failureCount).to.equal(4);
-          expect(result.errors.length).to.equal(4);
+          expect(result.failureCount).to.equal(2);
+          expect(result.errors.length).to.equal(2);
+          expect(result.errors[0].index).to.equal(0);
+          expect(result.errors[0].error.code).to.equals('auth/invalid-email');
+          expect(result.errors[1].index).to.equal(1);
+          expect(result.errors[1].error.code).to.equals('auth/invalid-email-verified');
+        });
+    });
+
+    it('fails when users with invalid phone numbers are provided', function () {
+      if (authEmulatorHost) {
+        // Auth Emulator's phoneNumber validation is also lax and won't throw.
+        return this.skip();
+      }
+      const users = [
+        // These phoneNumbers passes local (lax) validator but fails remotely.
+        { uid: generateRandomString(20).toLowerCase(), phoneNumber: '+1error' },
+        { uid: generateRandomString(20).toLowerCase(), phoneNumber: '+1invalid' },
+      ];
+      return admin.auth().importUsers(users)
+        .then((result) => {
+          expect(result.successCount).to.equal(0);
+          expect(result.failureCount).to.equal(2);
+          expect(result.errors.length).to.equal(2);
           expect(result.errors[0].index).to.equal(0);
           expect(result.errors[0].error.code).to.equals('auth/invalid-user-import');
           expect(result.errors[1].index).to.equal(1);
-          expect(result.errors[1].error.code).to.equals('auth/invalid-email');
-          expect(result.errors[2].index).to.equal(2);
-          expect(result.errors[2].error.code).to.equals('auth/invalid-user-import');
-          expect(result.errors[3].index).to.equal(3);
-          expect(result.errors[3].error.code).to.equals('auth/invalid-email-verified');
-        }).should.eventually.be.fulfilled;
+          expect(result.errors[1].error.code).to.equals('auth/invalid-user-import');
+        });
     });
   });
 });
@@ -2132,12 +2232,11 @@ function safeDelete(uid: string): Promise<void> {
  * @param {string[]} uids The list of user identifiers to delete.
  * @return {Promise} A promise that resolves when delete operation resolves.
  */
-function deleteUsersWithDelay(uids: string[]): Promise<admin.auth.DeleteUsersResult> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000);
-  }).then(() => {
-    return admin.auth().deleteUsers(uids);
-  });
+async function deleteUsersWithDelay(uids: string[]): Promise<admin.auth.DeleteUsersResult> {
+  if (!authEmulatorHost) {
+    await new Promise((resolve) => { setTimeout(resolve, 1000); });
+  }
+  return admin.auth().deleteUsers(uids);
 }
 
 /**

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -442,12 +442,12 @@ describe('admin.auth', () => {
       })
       .then(() => {
         const verifyingIdToken = admin.auth().verifyIdToken(currentIdToken)
-        if (!authEmulatorHost) {
-          // verifyIdToken without checking revocation should still succeed.
-          return verifyingIdToken.should.eventually.be.fulfilled;
-        } else {
+        if (authEmulatorHost) {
           // Check revocation is forced in emulator-mode and this should throw.
           return verifyingIdToken.should.eventually.be.rejected;
+        } else {
+          // verifyIdToken without checking revocation should still succeed.
+          return verifyingIdToken.should.eventually.be.fulfilled;
         }
       })
       .then(() => {

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -704,7 +704,7 @@ describe('admin.auth', () => {
       });
 
       it('verifyIdToken() fails when called with a token with wrong project', () => {
-        const unsignedToken = mocks.generateIdToken({algorithm: 'none', audience: 'nosuch'});
+        const unsignedToken = mocks.generateIdToken({ algorithm: 'none', audience: 'nosuch' });
         return admin.auth().verifyIdToken(unsignedToken)
           .should.eventually.be.rejected.and.have.property('code', 'auth/argument-error');
       });

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -47,7 +47,7 @@ export function skipForEmulator(): void {
 
 before(() => {
   let getCredential: () => {credential?: admin.credential.Credential};
-  let client_email;
+  let serviceAccountId: string;
 
   /* tslint:disable:no-console */
   if (isEmulator) {
@@ -58,7 +58,7 @@ before(() => {
     getCredential = () => ({});
     projectId = process.env.GCLOUD_PROJECT!;
     apiKey = 'fake-api-key';
-    client_email = 'fake-client-email@example.com';
+    serviceAccountId = 'fake-client-email@example.com';
   } else {
     let serviceAccount: any;
     try {
@@ -82,9 +82,9 @@ before(() => {
       ));
       throw error;
     }
-    getCredential = () => ({credential: admin.credential.cert(serviceAccount)});
+    getCredential = () => ({ credential: admin.credential.cert(serviceAccount) });
     projectId = serviceAccount.project_id;
-    client_email = serviceAccount.client_email;
+    serviceAccountId = serviceAccount.client_email;
   }
   /* tslint:enable:no-console */
 
@@ -123,7 +123,7 @@ before(() => {
   }
   noServiceAccountApp = admin.initializeApp({
     ...noServiceAccountAppCreds,
-    serviceAccountId: client_email,
+    serviceAccountId,
     projectId,
   }, 'noServiceAccount');
 

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -37,13 +37,6 @@ export let noServiceAccountApp: admin.app.App;
 export let cmdArgs: any;
 
 export const isEmulator = !!process.env.FIREBASE_EMULATOR_HUB;
-export function skipForEmulator(): void {
-  before(function () {
-    if (isEmulator) {
-      this.skip();
-    }
-  });
-}
 
 before(() => {
   let getCredential: () => {credential?: admin.credential.Credential};

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -36,51 +36,79 @@ export let noServiceAccountApp: admin.app.App;
 
 export let cmdArgs: any;
 
-before(() => {
-  /* tslint:disable:no-console */
-  let serviceAccount: any;
-  try {
-    serviceAccount = require('../resources/key.json');
-  } catch (error) {
-    console.log(chalk.red(
-      'The integration test suite requires a service account JSON file for a ' +
-      'Firebase project to be saved to `test/resources/key.json`.',
-      error,
-    ));
-    throw error;
-  }
+export const isEmulator = !!process.env.FIREBASE_EMULATOR_HUB;
+export function skipForEmulator(): void {
+  before(function () {
+    if (isEmulator) {
+      this.skip();
+    }
+  });
+}
 
-  try {
-    apiKey = fs.readFileSync(path.join(__dirname, '../resources/apikey.txt')).toString().trim();
-  } catch (error) {
-    console.log(chalk.red(
-      'The integration test suite requires an API key for a ' +
-      'Firebase project to be saved to `test/resources/apikey.txt`.',
-      error,
+before(() => {
+  let getCredential: () => {credential?: admin.credential.Credential};
+  let client_email;
+
+  /* tslint:disable:no-console */
+  if (isEmulator) {
+    console.log(chalk.yellow(
+      'Running integration tests against Emulator Suite. ' +
+      'Some tests may be skipped due to lack of emulator support.',
     ));
-    throw error;
+    getCredential = () => ({});
+    projectId = process.env.GCLOUD_PROJECT!;
+    apiKey = 'fake-api-key';
+    client_email = 'fake-client-email@example.com';
+  } else {
+    let serviceAccount: any;
+    try {
+      serviceAccount = require('../resources/key.json');
+    } catch (error) {
+      console.log(chalk.red(
+        'The integration test suite requires a service account JSON file for a ' +
+        'Firebase project to be saved to `test/resources/key.json`.',
+        error,
+      ));
+      throw error;
+    }
+
+    try {
+      apiKey = fs.readFileSync(path.join(__dirname, '../resources/apikey.txt')).toString().trim();
+    } catch (error) {
+      console.log(chalk.red(
+        'The integration test suite requires an API key for a ' +
+        'Firebase project to be saved to `test/resources/apikey.txt`.',
+        error,
+      ));
+      throw error;
+    }
+    getCredential = () => ({credential: admin.credential.cert(serviceAccount)});
+    projectId = serviceAccount.project_id;
+    client_email = serviceAccount.client_email;
   }
   /* tslint:enable:no-console */
 
-  projectId = serviceAccount.project_id;
   databaseUrl = 'https://' + projectId + '.firebaseio.com';
   storageBucket = projectId + '.appspot.com';
 
   defaultApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+    ...getCredential(),
+    projectId,
     databaseURL: databaseUrl,
     storageBucket,
   });
 
   nullApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+    ...getCredential(),
+    projectId,
     databaseURL: databaseUrl,
     databaseAuthVariableOverride: null,
     storageBucket,
   }, 'null');
 
   nonNullApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+    ...getCredential(),
+    projectId,
     databaseURL: databaseUrl,
     databaseAuthVariableOverride: {
       uid: generateRandomString(20),
@@ -88,9 +116,14 @@ before(() => {
     storageBucket,
   }, 'nonNull');
 
+  const noServiceAccountAppCreds = getCredential();
+  if (noServiceAccountAppCreds.credential) {
+    noServiceAccountAppCreds.credential = new CertificatelessCredential(
+      noServiceAccountAppCreds.credential)
+  }
   noServiceAccountApp = admin.initializeApp({
-    credential: new CertificatelessCredential(admin.credential.cert(serviceAccount)),
-    serviceAccountId: serviceAccount.client_email,
+    ...noServiceAccountAppCreds,
+    serviceAccountId: client_email,
     projectId,
   }, 'noServiceAccount');
 

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -3193,16 +3193,22 @@ AUTH_CONFIGS.forEach((testConfig) => {
     describe('auth emulator support', () => {
 
       let mockAuth = testConfig.init(mocks.app());
+      const userRecord = getValidUserRecord(getValidGetAccountInfoResponse());
+      const validSince = new Date(userRecord.tokensValidAfterTime!);
 
       const stubs: sinon.SinonStub[] = [];
+      let clock: sinon.SinonFakeTimers;
+
       beforeEach(() => {
         process.env.FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099';
         mockAuth = testConfig.init(mocks.app());
+        clock = sinon.useFakeTimers(validSince.getTime());
       });
 
       afterEach(() => {
         _.forEach(stubs, (s) => s.restore());
         delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+        clock.restore();
       });
 
       it('createCustomToken() generates an unsigned token', async () => {
@@ -3215,6 +3221,65 @@ AUTH_CONFIGS.forEach((testConfig) => {
 
         // Make sure this doesn't throw
         jwt.verify(token, '', { algorithms: ['none'] });
+      });
+
+      it('verifyIdToken() should reject revoked ID tokens', () => {
+        const uid = userRecord.uid;
+        // One second before validSince.
+        const oneSecBeforeValidSince = Math.floor(validSince.getTime() / 1000 - 1);
+        const getUserStub = sinon.stub(testConfig.Auth.prototype, 'getUser')
+          .resolves(userRecord);
+        stubs.push(getUserStub);
+
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          subject: uid,
+        }, {
+          iat: oneSecBeforeValidSince,
+          auth_time: oneSecBeforeValidSince, // eslint-disable-line @typescript-eslint/camelcase
+        });
+
+        // verifyIdToken should force checking revocation in emulator mode,
+        // even if checkRevoked=false.
+        return mockAuth.verifyIdToken(unsignedToken, false)
+          .then(() => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            // Confirm expected error returned.
+            expect(error).to.have.property('code', 'auth/id-token-revoked');
+            // Confirm underlying API called with expected parameters.
+            expect(getUserStub).to.have.been.calledOnce.and.calledWith(uid);
+          });
+      });
+
+      it('verifySessionCookie() should reject revoked session cookies', () => {
+        const uid = userRecord.uid;
+        // One second before validSince.
+        const oneSecBeforeValidSince = Math.floor(validSince.getTime() / 1000 - 1);
+        const getUserStub = sinon.stub(testConfig.Auth.prototype, 'getUser')
+          .resolves(userRecord);
+        stubs.push(getUserStub);
+
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          subject: uid,
+          issuer: 'https://session.firebase.google.com/' + mocks.projectId,
+        }, {
+          iat: oneSecBeforeValidSince,
+          auth_time: oneSecBeforeValidSince, // eslint-disable-line @typescript-eslint/camelcase
+        });
+
+        // verifyIdToken should force checking revocation in emulator mode,
+        // even if checkRevoked=false.
+        return mockAuth.verifySessionCookie(unsignedToken, false)
+          .then(() => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            // Confirm expected error returned.
+            expect(error).to.have.property('code', 'auth/session-cookie-revoked');
+            // Confirm underlying API called with expected parameters.
+            expect(getUserStub).to.have.been.calledOnce.and.calledWith(uid);
+          });
       });
 
       it('verifyIdToken() rejects an unsigned token if auth emulator is unreachable', async () => {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -3269,8 +3269,8 @@ AUTH_CONFIGS.forEach((testConfig) => {
           auth_time: oneSecBeforeValidSince, // eslint-disable-line @typescript-eslint/camelcase
         });
 
-        // verifyIdToken should force checking revocation in emulator mode,
-        // even if checkRevoked=false.
+        // verifySessionCookie should force checking revocation in emulator
+        // mode, even if checkRevoked=false.
         return mockAuth.verifySessionCookie(unsignedToken, false)
           .then(() => {
             throw new Error('Unexpected success');

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -3214,41 +3214,6 @@ AUTH_CONFIGS.forEach((testConfig) => {
         // Make sure this doesn't throw
         jwt.verify(token, '', { algorithms: ['none'] });
       });
-
-      it('verifyIdToken() rejects an unsigned token when only the env var is set', async () => {
-        const unsignedToken = mocks.generateIdToken({
-          algorithm: 'none'
-        });
-
-        await expect(mockAuth.verifyIdToken(unsignedToken))
-          .to.be.rejectedWith('Firebase ID token has incorrect algorithm. Expected "RS256"');
-      });
-
-      it('verifyIdToken() accepts an unsigned token when private method is called and env var is set', async () => {
-        (mockAuth as any).setJwtVerificationEnabled(false);
-
-        let claims = {};
-        if (testConfig.Auth === TenantAwareAuth) {
-          claims = {
-            firebase: {
-              tenant: TENANT_ID
-            }
-          }
-        }
-
-        const unsignedToken = mocks.generateIdToken({
-          algorithm: 'none'
-        }, claims);
-
-        const decoded = await mockAuth.verifyIdToken(unsignedToken);
-        expect(decoded).to.be.ok;
-      });
-
-      it('private method throws when env var is unset', async () => {
-        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
-        await expect(() => (mockAuth as any).setJwtVerificationEnabled(false))
-          .to.throw('This method is only available when connected to the Authentication emulator.')
-      });
     });
   });
 });

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -544,32 +544,27 @@ describe('FirebaseTokenVerifier', () => {
         });
     });
 
-    it('should decode an unsigned token when auth emulator host env var is set', async () => {
+    it('should decode an unsigned token if isEmulator=true', async () => {
       clock = sinon.useFakeTimers(1000);
 
-      try {
-        process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+      const emulatorVerifier = createTokenVerifier(app);
+      const mockIdToken = mocks.generateIdToken({
+        algorithm: 'none',
+        header: {}
+      });
 
-        const emulatorVerifier = createTokenVerifier(app);
-        const mockIdToken = mocks.generateIdToken({
-          algorithm: 'none',
-          header: {}
-        });
-
-        const decoded = await emulatorVerifier.verifyJWT(mockIdToken);
-        expect(decoded).to.deep.equal({
-          one: 'uno',
-          two: 'dos',
-          iat: 1,
-          exp: ONE_HOUR_IN_SECONDS + 1,
-          aud: mocks.projectId,
-          iss: 'https://securetoken.google.com/' + mocks.projectId,
-          sub: mocks.uid,
-          uid: mocks.uid,
-        });
-      } finally {
-        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
-      }
+      const isEmulator = true;
+      const decoded = await emulatorVerifier.verifyJWT(mockIdToken, isEmulator);
+      expect(decoded).to.deep.equal({
+        one: 'uno',
+        two: 'dos',
+        iat: 1,
+        exp: ONE_HOUR_IN_SECONDS + 1,
+        aud: mocks.projectId,
+        iss: 'https://securetoken.google.com/' + mocks.projectId,
+        sub: mocks.uid,
+        uid: mocks.uid,
+      });
     });
 
     it('should not decode a signed token when the algorithm is set to none (emulator)', async () => {


### PR DESCRIPTION
### Discussion

This PR implements http://go/firebase-auth-emulator-admin-sdk (Google internal design doc). Token verification now works everywhere, not just in functions emulator.

### Testing

Ran `node ~/w/firebase-tools/lib/bin/firebase.js emulators:exec --project fake-project-id --only auth 'npx mocha test/integration/auth.spec.ts --slow 5000 --timeout 20000 --require ts-node/register'` manually and all tests passed locally (once unrelated pending fixes in the Auth Emulator such as https://github.com/firebase/firebase-tools/pull/3091 and https://github.com/firebase/firebase-tools/pull/3088 are applied).

### API Changes

(secret API removed; no public API changes)
