### PR TITLE
fix: Updated integration tests to use the modular API surface

### DIFF
--- a/test/integration/app.spec.ts
+++ b/test/integration/app.spec.ts
@@ -30,7 +30,7 @@ describe('admin', () => {
   it('does not load RTDB by default', () => {
     const firebaseRtdb = require.cache[require.resolve('@firebase/database')];
     expect(firebaseRtdb).to.be.undefined;
-    const rtdbInternal = require.cache[require.resolve('../../lib/database/database-internal')];
+    const rtdbInternal = require.cache[require.resolve('../../lib/database/database')];
     expect(rtdbInternal).to.be.undefined;
   });
 

--- a/test/integration/app.spec.ts
+++ b/test/integration/app.spec.ts
@@ -15,6 +15,8 @@
  */
 
 import * as admin from '../../lib/index';
+import { App, deleteApp, getApp, initializeApp } from '../../lib/app/index';
+import { getAuth } from '../../lib/auth/index';
 import { expect } from 'chai';
 import {
   defaultApp, nullApp, nonNullApp, databaseUrl, projectId, storageBucket,
@@ -27,30 +29,56 @@ describe('admin', () => {
     expect(storageBucket).to.be.not.empty;
   });
 
-  it('does not load RTDB by default', () => {
-    const firebaseRtdb = require.cache[require.resolve('@firebase/database')];
-    expect(firebaseRtdb).to.be.undefined;
-    const rtdbInternal = require.cache[require.resolve('../../lib/database/database')];
-    expect(rtdbInternal).to.be.undefined;
-  });
+  describe('Dependency lazy loading', () => {
+    const tempCache: {[key: string]: any} = {};
+    const dependencies = ['@firebase/database', '@google-cloud/firestore'];
+    let lazyLoadingApp: App;
 
-  it('loads RTDB when calling admin.database', () => {
-    const rtdbNamespace = admin.database;
-    expect(rtdbNamespace).to.not.be.null;
-    const firebaseRtdb = require.cache[require.resolve('@firebase/database')];
-    expect(firebaseRtdb).to.not.be.undefined;
-  });
+    before(() => {
+      // Unload dependencies if already loaded. Some of the other test files have imports
+      // to firebase-admin/database and firebase-admin/firestore, which cause the corresponding
+      // dependencies to get loaded before the tests are executed.
+      dependencies.forEach((name) => {
+        const resolvedName = require.resolve(name);
+        tempCache[name] = require.cache[resolvedName];
+        delete require.cache[resolvedName];
+      });
 
-  it('does not load Firestore by default', () => {
-    const gcloud = require.cache[require.resolve('@google-cloud/firestore')];
-    expect(gcloud).to.be.undefined;
-  });
+      // Initialize the SDK
+      lazyLoadingApp = initializeApp(defaultApp.options, 'lazyLoadingApp');
+    });
 
-  it('loads Firestore when calling admin.firestore', () => {
-    const firestoreNamespace = admin.firestore;
-    expect(firestoreNamespace).to.not.be.null;
-    const gcloud = require.cache[require.resolve('@google-cloud/firestore')];
-    expect(gcloud).to.not.be.undefined;
+    it('does not load RTDB by default', () => {
+      const firebaseRtdb = require.cache[require.resolve('@firebase/database')];
+      expect(firebaseRtdb).to.be.undefined;
+    });
+
+    it('loads RTDB when calling admin.database', () => {
+      const rtdbNamespace = admin.database;
+      expect(rtdbNamespace).to.not.be.null;
+      const firebaseRtdb = require.cache[require.resolve('@firebase/database')];
+      expect(firebaseRtdb).to.not.be.undefined;
+    });
+
+    it('does not load Firestore by default', () => {
+      const gcloud = require.cache[require.resolve('@google-cloud/firestore')];
+      expect(gcloud).to.be.undefined;
+    });
+
+    it('loads Firestore when calling admin.firestore', () => {
+      const firestoreNamespace = admin.firestore;
+      expect(firestoreNamespace).to.not.be.null;
+      const gcloud = require.cache[require.resolve('@google-cloud/firestore')];
+      expect(gcloud).to.not.be.undefined;
+    });
+
+    after(() => {
+      dependencies.forEach((name) => {
+        const resolvedName = require.resolve(name);
+        require.cache[resolvedName] = tempCache[name];
+      });
+      return deleteApp(lazyLoadingApp);
+    })
   });
 });
 
@@ -96,5 +124,44 @@ describe('admin.app', () => {
     expect(admin.database(app).app).to.deep.equal(app);
     expect(admin.messaging(app).app).to.deep.equal(app);
     expect(admin.storage(app).app).to.deep.equal(app);
+  });
+});
+
+describe('getApp', () => {
+  it('getApp() returns the default App', () => {
+    const app = getApp();
+    expect(app).to.deep.equal(defaultApp);
+    expect(app.name).to.equal('[DEFAULT]');
+    expect(app.options.databaseURL).to.equal(databaseUrl);
+    expect(app.options.databaseAuthVariableOverride).to.be.undefined;
+    expect(app.options.storageBucket).to.equal(storageBucket);
+  });
+
+  it('getApp("null") returns the App named "null"', () => {
+    const app = getApp('null');
+    expect(app).to.deep.equal(nullApp);
+    expect(app.name).to.equal('null');
+    expect(app.options.databaseURL).to.equal(databaseUrl);
+    expect(app.options.databaseAuthVariableOverride).to.be.null;
+    expect(app.options.storageBucket).to.equal(storageBucket);
+  });
+
+  it('getApp("nonNull") returns the App named "nonNull"', () => {
+    const app = getApp('nonNull');
+    expect(app).to.deep.equal(nonNullApp);
+    expect(app.name).to.equal('nonNull');
+    expect(app.options.databaseURL).to.equal(databaseUrl);
+    expect((app.options.databaseAuthVariableOverride as any).uid).to.be.ok;
+    expect(app.options.storageBucket).to.equal(storageBucket);
+  });
+
+  it('namespace services are attached to the default App', () => {
+    const app = getApp();
+    expect(getAuth(app).app).to.deep.equal(app);
+  });
+
+  it('namespace services are attached to the named App', () => {
+    const app = getApp('null');
+    expect(getAuth(app).app).to.deep.equal(app);
   });
 });

--- a/test/integration/database.spec.ts
+++ b/test/integration/database.spec.ts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { defaultApp, nullApp, nonNullApp, cmdArgs, databaseUrl } from './setup';
+import * as admin from '../../lib/index';
+import {
+  Database, DataSnapshot, EventType, Reference, ServerValue, getDatabase, getDatabaseWithUrl,
+} from '../../lib/database/index';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const chalk = require('chalk');
@@ -46,12 +49,18 @@ describe('admin.database', () => {
         '.write': 'auth != null',
       },
     };
-    return admin.database().setRules(defaultRules);
+    return getDatabase().setRules(defaultRules);
+  });
+
+  it('getDatabase() returns a database client', () => {
+    const db: Database = getDatabase();
+    expect(db).to.not.be.undefined;
   });
 
   it('admin.database() returns a database client', () => {
-    const db = admin.database();
-    expect(db).to.be.instanceOf((admin.database as any).Database);
+    const db: admin.database.Database = admin.database();
+    expect(db).to.not.be.undefined;
+    expect(db).to.equal(getDatabase());
   });
 
   it('admin.database.ServerValue type is defined', () => {
@@ -60,37 +69,36 @@ describe('admin.database', () => {
   });
 
   it('default App is not blocked by security rules', () => {
-    return defaultApp.database().ref('blocked').set(admin.database.ServerValue.TIMESTAMP)
+    return getDatabase(defaultApp).ref('blocked').set(ServerValue.TIMESTAMP)
       .should.eventually.be.fulfilled;
   });
 
   it('App with null auth overrides is blocked by security rules', () => {
-    return nullApp.database().ref('blocked').set(admin.database.ServerValue.TIMESTAMP)
+    return getDatabase(nullApp).ref('blocked').set(ServerValue.TIMESTAMP)
       .should.eventually.be.rejectedWith('PERMISSION_DENIED: Permission denied');
   });
 
   it('App with non-null auth override is not blocked by security rules', () => {
-    return nonNullApp.database().ref('blocked').set(admin.database.ServerValue.TIMESTAMP)
+    return getDatabase(nonNullApp).ref('blocked').set(ServerValue.TIMESTAMP)
       .should.eventually.be.fulfilled;
   });
 
-  describe('admin.database().ref()', () => {
-    let ref: admin.database.Reference;
+  describe('Reference', () => {
+    let ref: Reference;
 
     before(() => {
-      ref = admin.database().ref(path);
+      ref = getDatabase().ref(path);
     });
 
     it('ref() can be called with ref', () => {
-      const copy = admin.database().ref(ref);
-      expect(copy).to.be.instanceof((admin.database as any).Reference);
+      const copy: Reference = getDatabase().ref(ref);
       expect(copy.key).to.equal(ref.key);
     });
 
     it('set() completes successfully', () => {
       return ref.set({
         success: true,
-        timestamp: admin.database.ServerValue.TIMESTAMP,
+        timestamp: ServerValue.TIMESTAMP,
       }).should.eventually.be.fulfilled;
     });
 
@@ -115,24 +123,29 @@ describe('admin.database', () => {
     });
   });
 
-  describe('app.database(url).ref()', () => {
+  describe('getDatabaseWithUrl()', () => {
 
-    let refWithUrl: admin.database.Reference;
+    let refWithUrl: Reference;
 
     before(() => {
-      const app = admin.app();
-      refWithUrl = app.database(databaseUrl).ref(path);
+      refWithUrl = getDatabaseWithUrl(databaseUrl).ref(path);
+    });
+
+    it('getDatabaseWithUrl(url) returns a Database client for URL', () => {
+      const db: Database = getDatabaseWithUrl(databaseUrl);
+      expect(db).to.not.be.undefined;
     });
 
     it('app.database(url) returns a Database client for URL', () => {
-      const db = admin.app().database(databaseUrl);
-      expect(db).to.be.instanceOf((admin.database as any).Database);
+      const db: Database = admin.app().database(databaseUrl);
+      expect(db).to.not.be.undefined;
+      expect(db).to.equal(getDatabaseWithUrl(databaseUrl));
     });
 
     it('set() completes successfully', () => {
       return refWithUrl.set({
         success: true,
-        timestamp: admin.database.ServerValue.TIMESTAMP,
+        timestamp: ServerValue.TIMESTAMP,
       }).should.eventually.be.fulfilled;
     });
 
@@ -157,14 +170,14 @@ describe('admin.database', () => {
     });
   });
 
-  it('admin.database().getRules() returns currently defined rules as a string', () => {
-    return admin.database().getRules().then((result) => {
+  it('getDatabase().getRules() returns currently defined rules as a string', () => {
+    return getDatabase().getRules().then((result) => {
       return expect(result).to.be.not.empty;
     });
   });
 
-  it('admin.database().getRulesJSON() returns currently defined rules as an object', () => {
-    return admin.database().getRulesJSON().then((result) => {
+  it('getDatabase().getRulesJSON() returns currently defined rules as an object', () => {
+    return getDatabase().getRulesJSON().then((result) => {
       return expect(result).to.be.not.undefined;
     });
   });
@@ -174,8 +187,8 @@ describe('admin.database', () => {
 // will trigger a TS compilation failure if the RTDB typings were not loaded
 // correctly. (Marked as export to avoid compilation warning.)
 export function addValueEventListener(
-  db: admin.database.Database,
-  callback: (s: admin.database.DataSnapshot | null) => any): void {
-  const eventType: admin.database.EventType = 'value';
+  db: Database,
+  callback: (s: DataSnapshot | null) => any): void {
+  const eventType: EventType = 'value';
   db.ref().on(eventType, callback);
 }

--- a/test/integration/firestore.spec.ts
+++ b/test/integration/firestore.spec.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { clone } from 'lodash';
+import * as admin from '../../lib/index';
+import {
+  DocumentReference, DocumentSnapshot, FieldValue, Firestore, FirestoreDataConverter,
+  QueryDocumentSnapshot, Timestamp, getFirestore, setLogFunction,
+} from '../../lib/firestore/index';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -31,21 +35,27 @@ const mountainView = {
 
 describe('admin.firestore', () => {
 
-  let reference: admin.firestore.DocumentReference;
+  let reference: DocumentReference;
 
   before(() => {
-    const db = admin.firestore();
+    const db = getFirestore();
     reference = db.collection('cities').doc();
   });
 
+  it('getFirestore() returns a Firestore client', () => {
+    const firestore: Firestore = getFirestore();
+    expect(firestore).to.not.be.undefined;
+  });
+
   it('admin.firestore() returns a Firestore client', () => {
-    const firestore = admin.firestore();
-    expect(firestore).to.be.instanceOf(admin.firestore.Firestore);
+    const firestore: admin.firestore.Firestore = admin.firestore();
+    expect(firestore).to.not.be.undefined;
+    expect(firestore).to.equal(getFirestore());
   });
 
   it('app.firestore() returns a Firestore client', () => {
-    const firestore = admin.app().firestore();
-    expect(firestore).to.be.instanceOf(admin.firestore.Firestore);
+    const firestore: admin.firestore.Firestore = admin.app().firestore();
+    expect(firestore).to.not.be.undefined;
   });
 
   it('supports basic data access', () => {
@@ -66,9 +76,9 @@ describe('admin.firestore', () => {
       });
   });
 
-  it('admin.firestore.FieldValue.serverTimestamp() provides a server-side timestamp', () => {
+  it('FieldValue.serverTimestamp() provides a server-side timestamp', () => {
     const expected: any = clone(mountainView);
-    expected.timestamp = admin.firestore.FieldValue.serverTimestamp();
+    expected.timestamp = FieldValue.serverTimestamp();
     return reference.set(expected)
       .then(() => {
         return reference.get();
@@ -77,7 +87,7 @@ describe('admin.firestore', () => {
         const data = snapshot.data();
         expect(data).to.exist;
         expect(data!.timestamp).is.not.null;
-        expect(data!.timestamp).to.be.instanceOf(admin.firestore.Timestamp);
+        expect(data!.timestamp).to.be.instanceOf(Timestamp);
         return reference.delete();
       })
       .should.eventually.be.fulfilled;
@@ -118,20 +128,20 @@ describe('admin.firestore', () => {
   });
 
   it('supports operations with custom type converters', () => {
-    const converter: admin.firestore.FirestoreDataConverter<City> = {
+    const converter: FirestoreDataConverter<City> = {
       toFirestore: (city: City) => {
         return {
           name: city.localId,
           population: city.people,
         };
       },
-      fromFirestore: (snap: admin.firestore.QueryDocumentSnapshot) => {
+      fromFirestore: (snap: QueryDocumentSnapshot) => {
         return new City(snap.data().name, snap.data().population);
       }
     };
 
     const expected: City = new City('Sunnyvale', 153185);
-    const refWithConverter: admin.firestore.DocumentReference<City> = admin.firestore()
+    const refWithConverter: DocumentReference<City> = getFirestore()
       .collection('cities')
       .doc()
       .withConverter(converter);
@@ -139,15 +149,15 @@ describe('admin.firestore', () => {
       .then(() => {
         return refWithConverter.get();
       })
-      .then((snapshot: admin.firestore.DocumentSnapshot<City>) => {
+      .then((snapshot: DocumentSnapshot<City>) => {
         expect(snapshot.data()).to.be.instanceOf(City);
         return refWithConverter.delete();
       });
   });
 
   it('supports saving references in documents', () => {
-    const source = admin.firestore().collection('cities').doc();
-    const target = admin.firestore().collection('cities').doc();
+    const source = getFirestore().collection('cities').doc();
+    const target = getFirestore().collection('cities').doc();
     return source.set(mountainView)
       .then(() => {
         return target.set({ name: 'Palo Alto', sisterCity: source });
@@ -167,10 +177,10 @@ describe('admin.firestore', () => {
       .should.eventually.be.fulfilled;
   });
 
-  it('admin.firestore.setLogFunction() enables logging for the Firestore module', () => {
+  it('setLogFunction() enables logging for the Firestore module', () => {
     const logs: string[] = [];
-    const source = admin.firestore().collection('cities').doc();
-    admin.firestore.setLogFunction((log) => {
+    const source = getFirestore().collection('cities').doc();
+    setLogFunction((log) => {
       logs.push(log);
     });
     return source.set({ name: 'San Francisco' })

--- a/test/integration/instance-id.spec.ts
+++ b/test/integration/instance-id.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { getInstanceId } from '../../lib/instance-id/index';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -24,7 +24,7 @@ chai.use(chaiAsPromised);
 describe('admin.instanceId', () => {
   it('deleteInstanceId() fails when called with fictive-ID0 instance ID', () => {
     // instance ids have to conform to /[cdef][A-Za-z0-9_-]{9}[AEIMQUYcgkosw048]/
-    return admin.instanceId().deleteInstanceId('fictive-ID0')
+    return getInstanceId().deleteInstanceId('fictive-ID0')
       .should.eventually.be
       .rejectedWith('Instance ID "fictive-ID0": Failed to find the instance ID.');
   });

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { Message, MulticastMessage, getMessaging } from '../../lib/messaging/index';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -38,7 +38,7 @@ const condition = '"test0" in topics || ("test1" in topics && "test2" in topics)
 
 const invalidTopic = 'topic-$%#^';
 
-const message: admin.messaging.Message = {
+const message: Message = {
   data: {
     foo: 'bar',
   },
@@ -102,15 +102,15 @@ const options = {
 
 describe('admin.messaging', () => {
   it('send(message, dryRun) returns a message ID', () => {
-    return admin.messaging().send(message, true)
+    return getMessaging().send(message, true)
       .then((name) => {
         expect(name).matches(/^projects\/.*\/messages\/.*$/);
       });
   });
 
   it('sendAll()', () => {
-    const messages: admin.messaging.Message[] = [message, message, message];
-    return admin.messaging().sendAll(messages, true)
+    const messages: Message[] = [message, message, message];
+    return getMessaging().sendAll(messages, true)
       .then((response) => {
         expect(response.responses.length).to.equal(messages.length);
         expect(response.successCount).to.equal(messages.length);
@@ -123,11 +123,11 @@ describe('admin.messaging', () => {
   });
 
   it('sendAll(500)', () => {
-    const messages: admin.messaging.Message[] = [];
+    const messages: Message[] = [];
     for (let i = 0; i < 500; i++) {
       messages.push({ topic: `foo-bar-${i % 10}` });
     }
-    return admin.messaging().sendAll(messages, true)
+    return getMessaging().sendAll(messages, true)
       .then((response) => {
         expect(response.responses.length).to.equal(messages.length);
         expect(response.successCount).to.equal(messages.length);
@@ -140,12 +140,12 @@ describe('admin.messaging', () => {
   });
 
   it('sendMulticast()', () => {
-    const multicastMessage: admin.messaging.MulticastMessage = {
+    const multicastMessage: MulticastMessage = {
       data: message.data,
       android: message.android,
       tokens: ['not-a-token', 'also-not-a-token'],
     };
-    return admin.messaging().sendMulticast(multicastMessage, true)
+    return getMessaging().sendMulticast(multicastMessage, true)
       .then((response) => {
         expect(response.responses.length).to.equal(2);
         expect(response.successCount).to.equal(0);
@@ -159,86 +159,86 @@ describe('admin.messaging', () => {
   });
 
   it('sendToDevice(token) returns a response with multicast ID', () => {
-    return admin.messaging().sendToDevice(registrationToken, payload, options)
+    return getMessaging().sendToDevice(registrationToken, payload, options)
       .then((response) => {
         expect(typeof response.multicastId).to.equal('number');
       });
   });
 
   it('sendToDevice(token-list) returns a response with multicat ID', () => {
-    return admin.messaging().sendToDevice(registrationTokens, payload, options)
+    return getMessaging().sendToDevice(registrationTokens, payload, options)
       .then((response) => {
         expect(typeof response.multicastId).to.equal('number');
       });
   });
 
   it('sendToDeviceGroup() returns a response with success count', () => {
-    return admin.messaging().sendToDeviceGroup(notificationKey, payload, options)
+    return getMessaging().sendToDeviceGroup(notificationKey, payload, options)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');
       });
   });
 
   it('sendToTopic() returns a response with message ID', () => {
-    return admin.messaging().sendToTopic(topic, payload, options)
+    return getMessaging().sendToTopic(topic, payload, options)
       .then((response) => {
         expect(typeof response.messageId).to.equal('number');
       });
   });
 
   it('sendToCondition() returns a response with message ID', () => {
-    return admin.messaging().sendToCondition(condition, payload, options)
+    return getMessaging().sendToCondition(condition, payload, options)
       .then((response) => {
         expect(typeof response.messageId).to.equal('number');
       });
   });
 
   it('sendToDevice(token) fails when called with invalid payload', () =>  {
-    return admin.messaging().sendToDevice(registrationToken, invalidPayload, options)
+    return getMessaging().sendToDevice(registrationToken, invalidPayload, options)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-payload');
   });
 
   it('sendToDevice(token-list) fails when called with invalid payload', () =>  {
-    return admin.messaging().sendToDevice(registrationTokens, invalidPayload, options)
+    return getMessaging().sendToDevice(registrationTokens, invalidPayload, options)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-payload');
   });
 
   it('sendToDeviceGroup() fails when called with invalid payload', () =>  {
-    return admin.messaging().sendToDeviceGroup(notificationKey, invalidPayload, options)
+    return getMessaging().sendToDeviceGroup(notificationKey, invalidPayload, options)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-payload');
   });
 
   it('sendToTopic() fails when called with invalid payload', () =>  {
-    return admin.messaging().sendToTopic(topic, invalidPayload, options)
+    return getMessaging().sendToTopic(topic, invalidPayload, options)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-payload');
   });
 
   it('sendToCondition() fails when called with invalid payload', () =>  {
-    return admin.messaging().sendToCondition(condition, invalidPayload, options)
+    return getMessaging().sendToCondition(condition, invalidPayload, options)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-payload');
   });
 
   it('subscribeToTopic() returns a response with success count', () => {
-    return admin.messaging().subscribeToTopic(registrationToken, topic)
+    return getMessaging().subscribeToTopic(registrationToken, topic)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');
       });
   });
 
   it('unsubscribeFromTopic() returns a response with success count', () => {
-    return admin.messaging().unsubscribeFromTopic(registrationToken, topic)
+    return getMessaging().unsubscribeFromTopic(registrationToken, topic)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');
       });
   });
 
   it('subscribeToTopic() fails when called with invalid topic', () => {
-    return admin.messaging().subscribeToTopic(registrationToken, invalidTopic)
+    return getMessaging().subscribeToTopic(registrationToken, invalidTopic)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-argument');
   });
 
   it('unsubscribeFromTopic() fails when called with invalid topic', () => {
-    return admin.messaging().unsubscribeFromTopic(registrationToken, invalidTopic)
+    return getMessaging().unsubscribeFromTopic(registrationToken, invalidTopic)
       .should.eventually.be.rejected.and.have.property('code', 'messaging/invalid-argument');
   });
 });

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { deepCopy } from '../../src/utils/deep-copy';
+import { RemoteConfigCondition, RemoteConfigTemplate, getRemoteConfig, } from '../../lib/remote-config/index';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -57,7 +57,7 @@ const VALID_PARAMETER_GROUPS = {
   },
 };
 
-const VALID_CONDITIONS: admin.remoteConfig.RemoteConfigCondition[] = [
+const VALID_CONDITIONS: RemoteConfigCondition[] = [
   {
     name: 'ios',
     expression: 'device.os == \'ios\'',
@@ -74,12 +74,12 @@ const VALID_VERSION = {
   description: `template description ${Date.now()}`,
 }
 
-let currentTemplate: admin.remoteConfig.RemoteConfigTemplate;
+let currentTemplate: RemoteConfigTemplate;
 
 describe('admin.remoteConfig', () => {
   before(async () => {
     // obtain the most recent template (etag) to perform operations
-    currentTemplate = await admin.remoteConfig().getTemplate();
+    currentTemplate = await getRemoteConfig().getTemplate();
   });
 
   it('verify that the etag is read-only', () => {
@@ -95,7 +95,7 @@ describe('admin.remoteConfig', () => {
       currentTemplate.parameters = VALID_PARAMETERS;
       currentTemplate.parameterGroups = VALID_PARAMETER_GROUPS;
       currentTemplate.version = VALID_VERSION;
-      return admin.remoteConfig().validateTemplate(currentTemplate)
+      return getRemoteConfig().validateTemplate(currentTemplate)
         .then((template) => {
           expect(template.etag).matches(/^etag-[0-9]*-[0-9]*$/);
           expect(template.conditions.length).to.equal(2);
@@ -113,7 +113,7 @@ describe('admin.remoteConfig', () => {
       currentTemplate.parameters = VALID_PARAMETERS;
       currentTemplate.parameterGroups = VALID_PARAMETER_GROUPS;
       currentTemplate.version = VALID_VERSION;
-      return admin.remoteConfig().validateTemplate(currentTemplate)
+      return getRemoteConfig().validateTemplate(currentTemplate)
         .should.eventually.be.rejected.and.have.property('code', 'remote-config/invalid-argument');
     });
   });
@@ -125,7 +125,7 @@ describe('admin.remoteConfig', () => {
       currentTemplate.parameters = VALID_PARAMETERS;
       currentTemplate.parameterGroups = VALID_PARAMETER_GROUPS;
       currentTemplate.version = VALID_VERSION;
-      return admin.remoteConfig().publishTemplate(currentTemplate)
+      return getRemoteConfig().publishTemplate(currentTemplate)
         .then((template) => {
           expect(template.etag).matches(/^etag-[0-9]*-[0-9]*$/);
           expect(template.conditions.length).to.equal(2);
@@ -143,14 +143,14 @@ describe('admin.remoteConfig', () => {
       currentTemplate.parameters = VALID_PARAMETERS;
       currentTemplate.parameterGroups = VALID_PARAMETER_GROUPS;
       currentTemplate.version = VALID_VERSION;
-      return admin.remoteConfig().publishTemplate(currentTemplate)
+      return getRemoteConfig().publishTemplate(currentTemplate)
         .should.eventually.be.rejected.and.have.property('code', 'remote-config/invalid-argument');
     });
   });
 
   describe('getTemplate', () => {
     it('should return the most recently published template', () => {
-      return admin.remoteConfig().getTemplate()
+      return getRemoteConfig().getTemplate()
         .then((template) => {
           expect(template.etag).matches(/^etag-[0-9]*-[0-9]*$/);
           expect(template.conditions.length).to.equal(2);
@@ -171,23 +171,23 @@ describe('admin.remoteConfig', () => {
   describe('getTemplateAtVersion', () => {
     before(async () => {
       // obtain the current active template
-      let activeTemplate = await admin.remoteConfig().getTemplate();
+      let activeTemplate = await getRemoteConfig().getTemplate();
 
       // publish a new template to create a new version number
       activeTemplate.version = { description: versionOneDescription };
-      activeTemplate = await admin.remoteConfig().publishTemplate(activeTemplate)
+      activeTemplate = await getRemoteConfig().publishTemplate(activeTemplate)
       expect(activeTemplate.version).to.be.not.undefined;
       versionOneNumber = activeTemplate.version!.versionNumber!;
 
       // publish another template to create a second version number
       activeTemplate.version = { description: versionTwoDescription };
-      activeTemplate = await admin.remoteConfig().publishTemplate(activeTemplate)
+      activeTemplate = await getRemoteConfig().publishTemplate(activeTemplate)
       expect(activeTemplate.version).to.be.not.undefined;
       versionTwoNumber = activeTemplate.version!.versionNumber!;
     });
 
     it('should return the requested template version v1', () => {
-      return admin.remoteConfig().getTemplateAtVersion(versionOneNumber)
+      return getRemoteConfig().getTemplateAtVersion(versionOneNumber)
         .then((template) => {
           expect(template.etag).matches(/^etag-[0-9]*-[0-9]*$/);
           expect(template.version).to.be.not.undefined;
@@ -199,7 +199,7 @@ describe('admin.remoteConfig', () => {
 
   describe('listVersions', () => {
     it('should return the most recently published 2 versions', () => {
-      return admin.remoteConfig().listVersions({
+      return getRemoteConfig().listVersions({
         pageSize: 2,
       })
         .then((response) => {
@@ -215,7 +215,7 @@ describe('admin.remoteConfig', () => {
 
   describe('rollback', () => {
     it('verify the most recent template version before rollback to the one prior', () => {
-      return admin.remoteConfig().getTemplate()
+      return getRemoteConfig().getTemplate()
         .then((template) => {
           expect(template.version).to.be.not.undefined;
           expect(template.version!.versionNumber).equals(versionTwoNumber);
@@ -223,7 +223,7 @@ describe('admin.remoteConfig', () => {
     });
 
     it('should rollback to the requested version', () => {
-      return admin.remoteConfig().rollback(versionOneNumber)
+      return getRemoteConfig().rollback(versionOneNumber)
         .then((template) => {
           expect(template.version).to.be.not.undefined;
           expect(template.version!.updateType).equals('ROLLBACK');
@@ -238,14 +238,14 @@ describe('admin.remoteConfig', () => {
 
     INVALID_STRINGS.forEach((invalidJson) => {
       it(`should throw if the json string is ${JSON.stringify(invalidJson)}`, () => {
-        expect(() => admin.remoteConfig().createTemplateFromJSON(invalidJson))
+        expect(() => getRemoteConfig().createTemplateFromJSON(invalidJson))
           .to.throw('JSON string must be a valid non-empty string');
       });
     });
 
     INVALID_JSON_STRINGS.forEach((invalidJson) => {
       it(`should throw if the json string is ${JSON.stringify(invalidJson)}`, () => {
-        expect(() => admin.remoteConfig().createTemplateFromJSON(invalidJson))
+        expect(() => getRemoteConfig().createTemplateFromJSON(invalidJson))
           .to.throw(/Failed to parse the JSON string/);
       });
     });
@@ -263,14 +263,14 @@ describe('admin.remoteConfig', () => {
       invalidEtagTemplate.etag = invalidEtag;
       const jsonString = JSON.stringify(invalidEtagTemplate);
       it(`should throw if the ETag is ${JSON.stringify(invalidEtag)}`, () => {
-        expect(() => admin.remoteConfig().createTemplateFromJSON(jsonString))
+        expect(() => getRemoteConfig().createTemplateFromJSON(jsonString))
           .to.throw(`Invalid Remote Config template: ${jsonString}`);
       });
     });
 
     it('should succeed when a valid json string is provided', () => {
       const jsonString = JSON.stringify(sourceTemplate);
-      const newTemplate = admin.remoteConfig().createTemplateFromJSON(jsonString);
+      const newTemplate = getRemoteConfig().createTemplateFromJSON(jsonString);
       expect(newTemplate.etag).to.equal(sourceTemplate.etag);
       expect(() => {
         (currentTemplate as any).etag = 'new-etag';

--- a/test/integration/security-rules.spec.ts
+++ b/test/integration/security-rules.spec.ts
@@ -15,8 +15,7 @@
  */
 
 import * as chai from 'chai';
-
-import * as admin from '../../lib/index';
+import { Ruleset, RulesetMetadata, getSecurityRules } from '../../lib/security-rules/index';
 
 const expect = chai.expect;
 
@@ -47,27 +46,27 @@ describe('admin.securityRules', () => {
 
   const rulesetsToDelete: string[] = [];
 
-  function scheduleForDelete(ruleset: admin.securityRules.Ruleset): void {
+  function scheduleForDelete(ruleset: Ruleset): void {
     rulesetsToDelete.push(ruleset.name);
   }
 
-  function unscheduleForDelete(ruleset: admin.securityRules.Ruleset): void {
+  function unscheduleForDelete(ruleset: Ruleset): void {
     rulesetsToDelete.splice(rulesetsToDelete.indexOf(ruleset.name), 1);
   }
 
   function deleteTempRulesets(): Promise<void[]> {
     const promises: Array<Promise<void>> = [];
     rulesetsToDelete.forEach((rs) => {
-      promises.push(admin.securityRules().deleteRuleset(rs));
+      promises.push(getSecurityRules().deleteRuleset(rs));
     });
     rulesetsToDelete.splice(0, rulesetsToDelete.length); // Clear out the array.
     return Promise.all(promises);
   }
 
-  function createTemporaryRuleset(): Promise<admin.securityRules.Ruleset> {
+  function createTemporaryRuleset(): Promise<Ruleset> {
     const name = 'firestore.rules';
-    const rulesFile = admin.securityRules().createRulesFileFromSource(name, SAMPLE_FIRESTORE_RULES);
-    return admin.securityRules().createRuleset(rulesFile)
+    const rulesFile = getSecurityRules().createRulesFileFromSource(name, SAMPLE_FIRESTORE_RULES);
+    return getSecurityRules().createRuleset(rulesFile)
       .then((ruleset) => {
         scheduleForDelete(ruleset);
         return ruleset;
@@ -80,14 +79,14 @@ describe('admin.securityRules', () => {
 
   describe('createRulesFileFromSource()', () => {
     it('creates a RulesFile from the source string', () => {
-      const rulesFile = admin.securityRules().createRulesFileFromSource(
+      const rulesFile = getSecurityRules().createRulesFileFromSource(
         RULES_FILE_NAME, SAMPLE_FIRESTORE_RULES);
       expect(rulesFile.name).to.equal(RULES_FILE_NAME);
       expect(rulesFile.content).to.equal(SAMPLE_FIRESTORE_RULES);
     });
 
     it('creates a RulesFile from the source Buffer', () => {
-      const rulesFile = admin.securityRules().createRulesFileFromSource(
+      const rulesFile = getSecurityRules().createRulesFileFromSource(
         'firestore.rules', Buffer.from(SAMPLE_FIRESTORE_RULES, 'utf-8'));
       expect(rulesFile.name).to.equal(RULES_FILE_NAME);
       expect(rulesFile.content).to.equal(SAMPLE_FIRESTORE_RULES);
@@ -96,9 +95,9 @@ describe('admin.securityRules', () => {
 
   describe('createRuleset()', () => {
     it('creates a new Ruleset from a given RulesFile', () => {
-      const rulesFile = admin.securityRules().createRulesFileFromSource(
+      const rulesFile = getSecurityRules().createRulesFileFromSource(
         RULES_FILE_NAME, SAMPLE_FIRESTORE_RULES);
-      return admin.securityRules().createRuleset(rulesFile)
+      return getSecurityRules().createRuleset(rulesFile)
         .then((ruleset) => {
           scheduleForDelete(ruleset);
           verifyFirestoreRuleset(ruleset);
@@ -106,9 +105,9 @@ describe('admin.securityRules', () => {
     });
 
     it('rejects with invalid-argument when the source is invalid', () => {
-      const rulesFile = admin.securityRules().createRulesFileFromSource(
+      const rulesFile = getSecurityRules().createRulesFileFromSource(
         RULES_FILE_NAME, 'invalid syntax');
-      return admin.securityRules().createRuleset(rulesFile)
+      return getSecurityRules().createRuleset(rulesFile)
         .should.eventually.be.rejected.and.have.property('code', 'security-rules/invalid-argument');
     });
   });
@@ -116,19 +115,19 @@ describe('admin.securityRules', () => {
   describe('getRuleset()', () => {
     it('rejects with not-found when the Ruleset does not exist', () => {
       const nonExistingName = '00000000-1111-2222-3333-444444444444';
-      return admin.securityRules().getRuleset(nonExistingName)
+      return getSecurityRules().getRuleset(nonExistingName)
         .should.eventually.be.rejected.and.have.property('code', 'security-rules/not-found');
     });
 
     it('rejects with invalid-argument when the Ruleset name is invalid', () => {
-      return admin.securityRules().getRuleset('invalid uuid')
+      return getSecurityRules().getRuleset('invalid uuid')
         .should.eventually.be.rejected.and.have.property('code', 'security-rules/invalid-argument');
     });
 
     it('resolves with existing Ruleset', () => {
       return createTemporaryRuleset()
         .then((expectedRuleset) =>
-          admin.securityRules().getRuleset(expectedRuleset.name)
+          getSecurityRules().getRuleset(expectedRuleset.name)
             .then((actualRuleset) => {
               expect(actualRuleset).to.deep.equal(expectedRuleset);
             }),
@@ -137,15 +136,15 @@ describe('admin.securityRules', () => {
   });
 
   describe('Cloud Firestore', () => {
-    let oldRuleset: admin.securityRules.Ruleset | null = null;
-    let newRuleset: admin.securityRules.Ruleset | null = null;
+    let oldRuleset: Ruleset | null = null;
+    let newRuleset: Ruleset | null = null;
 
     function revertFirestoreRulesetIfModified(): Promise<void> {
       if (!newRuleset || !oldRuleset) {
         return Promise.resolve();
       }
 
-      return admin.securityRules().releaseFirestoreRuleset(oldRuleset);
+      return getSecurityRules().releaseFirestoreRuleset(oldRuleset);
     }
 
     afterEach(() => {
@@ -153,7 +152,7 @@ describe('admin.securityRules', () => {
     });
 
     it('getFirestoreRuleset() returns the Ruleset currently in effect', () => {
-      return admin.securityRules().getFirestoreRuleset()
+      return getSecurityRules().getFirestoreRuleset()
         .then((ruleset) => {
           expect(ruleset.name).to.match(RULESET_NAME_PATTERN);
           const createTime = new Date(ruleset.createTime);
@@ -164,10 +163,10 @@ describe('admin.securityRules', () => {
     });
 
     it('releaseFirestoreRulesetFromSource() applies the specified Ruleset to Firestore', () => {
-      return admin.securityRules().getFirestoreRuleset()
+      return getSecurityRules().getFirestoreRuleset()
         .then((ruleset) => {
           oldRuleset = ruleset;
-          return admin.securityRules().releaseFirestoreRulesetFromSource(SAMPLE_FIRESTORE_RULES);
+          return getSecurityRules().releaseFirestoreRulesetFromSource(SAMPLE_FIRESTORE_RULES);
         })
         .then((ruleset) => {
           scheduleForDelete(ruleset);
@@ -175,7 +174,7 @@ describe('admin.securityRules', () => {
 
           expect(ruleset.name).to.not.equal(oldRuleset!.name);
           verifyFirestoreRuleset(ruleset);
-          return admin.securityRules().getFirestoreRuleset();
+          return getSecurityRules().getFirestoreRuleset();
         })
         .then((ruleset) => {
           expect(ruleset.name).to.equal(newRuleset!.name);
@@ -185,15 +184,15 @@ describe('admin.securityRules', () => {
   });
 
   describe('Cloud Storage', () => {
-    let oldRuleset: admin.securityRules.Ruleset | null = null;
-    let newRuleset: admin.securityRules.Ruleset | null = null;
+    let oldRuleset: Ruleset | null = null;
+    let newRuleset: Ruleset | null = null;
 
     function revertStorageRulesetIfModified(): Promise<void> {
       if (!newRuleset || !oldRuleset) {
         return Promise.resolve();
       }
 
-      return admin.securityRules().releaseStorageRuleset(oldRuleset);
+      return getSecurityRules().releaseStorageRuleset(oldRuleset);
     }
 
     afterEach(() => {
@@ -201,7 +200,7 @@ describe('admin.securityRules', () => {
     });
 
     it('getStorageRuleset() returns the currently applied Storage rules', () => {
-      return admin.securityRules().getStorageRuleset()
+      return getSecurityRules().getStorageRuleset()
         .then((ruleset) => {
           expect(ruleset.name).to.match(RULESET_NAME_PATTERN);
           const createTime = new Date(ruleset.createTime);
@@ -212,10 +211,10 @@ describe('admin.securityRules', () => {
     });
 
     it('releaseStorageRulesetFromSource() applies the specified Ruleset to Storage', () => {
-      return admin.securityRules().getStorageRuleset()
+      return getSecurityRules().getStorageRuleset()
         .then((ruleset) => {
           oldRuleset = ruleset;
-          return admin.securityRules().releaseStorageRulesetFromSource(SAMPLE_STORAGE_RULES);
+          return getSecurityRules().releaseStorageRulesetFromSource(SAMPLE_STORAGE_RULES);
         })
         .then((ruleset) => {
           scheduleForDelete(ruleset);
@@ -225,7 +224,7 @@ describe('admin.securityRules', () => {
           expect(ruleset.name).to.match(RULESET_NAME_PATTERN);
           const createTime = new Date(ruleset.createTime);
           expect(ruleset.createTime).equals(createTime.toUTCString());
-          return admin.securityRules().getStorageRuleset();
+          return getSecurityRules().getStorageRuleset();
         })
         .then((ruleset) => {
           expect(ruleset.name).to.equal(newRuleset!.name);
@@ -235,12 +234,10 @@ describe('admin.securityRules', () => {
 
   describe('listRulesetMetadata()', () => {
     it('lists all available Rulesets in pages', () => {
-      type RulesetMetadata = admin.securityRules.RulesetMetadata;
-
       function listAllRulesets(
         pageToken?: string, results: RulesetMetadata[] = []): Promise<RulesetMetadata[]> {
 
-        return admin.securityRules().listRulesetMetadata(100, pageToken)
+        return getSecurityRules().listRulesetMetadata(100, pageToken)
           .then((page) => {
             results.push(...page.rulesets);
             if (page.nextPageToken) {
@@ -262,7 +259,7 @@ describe('admin.securityRules', () => {
     });
 
     it('lists the specified number of Rulesets', () => {
-      return admin.securityRules().listRulesetMetadata(2)
+      return getSecurityRules().listRulesetMetadata(2)
         .then((page) => {
           expect(page.rulesets.length).to.be.at.most(2);
           expect(page.rulesets.length).to.be.at.least(1);
@@ -273,20 +270,20 @@ describe('admin.securityRules', () => {
   describe('deleteRuleset()', () => {
     it('rejects with not-found when the Ruleset does not exist', () => {
       const nonExistingName = '00000000-1111-2222-3333-444444444444';
-      return admin.securityRules().deleteRuleset(nonExistingName)
+      return getSecurityRules().deleteRuleset(nonExistingName)
         .should.eventually.be.rejected.and.have.property('code', 'security-rules/not-found');
     });
 
     it('rejects with invalid-argument when the Ruleset name is invalid', () => {
-      return admin.securityRules().deleteRuleset('invalid uuid')
+      return getSecurityRules().deleteRuleset('invalid uuid')
         .should.eventually.be.rejected.and.have.property('code', 'security-rules/invalid-argument');
     });
 
     it('deletes existing Ruleset', () => {
       return createTemporaryRuleset().then((ruleset) => {
-        return admin.securityRules().deleteRuleset(ruleset.name)
+        return getSecurityRules().deleteRuleset(ruleset.name)
           .then(() => {
-            return admin.securityRules().getRuleset(ruleset.name)
+            return getSecurityRules().getRuleset(ruleset.name)
               .should.eventually.be.rejected.and.have.property('code', 'security-rules/not-found');
           })
           .then(() => {
@@ -296,7 +293,7 @@ describe('admin.securityRules', () => {
     });
   });
 
-  function verifyFirestoreRuleset(ruleset: admin.securityRules.Ruleset): void {
+  function verifyFirestoreRuleset(ruleset: Ruleset): void {
     expect(ruleset.name).to.match(RULESET_NAME_PATTERN);
     const createTime = new Date(ruleset.createTime);
     expect(ruleset.createTime).equals(createTime.toUTCString());

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import fs = require('fs');
 import minimist = require('minimist');
 import path = require('path');
 import { random } from 'lodash';
-import { GoogleOAuthAccessToken } from '../../src/credential/index';
+import {
+  App, Credential, GoogleOAuthAccessToken, cert, deleteApp, initializeApp,
+} from '../../lib/app/index'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const chalk = require('chalk');
@@ -29,10 +30,10 @@ export let storageBucket: string;
 export let projectId: string;
 export let apiKey: string;
 
-export let defaultApp: admin.app.App;
-export let nullApp: admin.app.App;
-export let nonNullApp: admin.app.App;
-export let noServiceAccountApp: admin.app.App;
+export let defaultApp: App;
+export let nullApp: App;
+export let nonNullApp: App;
+export let noServiceAccountApp: App;
 
 export let cmdArgs: any;
 
@@ -66,21 +67,21 @@ before(() => {
   databaseUrl = 'https://' + projectId + '.firebaseio.com';
   storageBucket = projectId + '.appspot.com';
 
-  defaultApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+  defaultApp = initializeApp({
+    credential: cert(serviceAccount),
     databaseURL: databaseUrl,
     storageBucket,
   });
 
-  nullApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+  nullApp = initializeApp({
+    credential: cert(serviceAccount),
     databaseURL: databaseUrl,
     databaseAuthVariableOverride: null,
     storageBucket,
   }, 'null');
 
-  nonNullApp = admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+  nonNullApp = initializeApp({
+    credential: cert(serviceAccount),
     databaseURL: databaseUrl,
     databaseAuthVariableOverride: {
       uid: generateRandomString(20),
@@ -88,8 +89,8 @@ before(() => {
     storageBucket,
   }, 'nonNull');
 
-  noServiceAccountApp = admin.initializeApp({
-    credential: new CertificatelessCredential(admin.credential.cert(serviceAccount)),
+  noServiceAccountApp = initializeApp({
+    credential: new CertificatelessCredential(cert(serviceAccount)),
     serviceAccountId: serviceAccount.client_email,
     projectId,
   }, 'noServiceAccount');
@@ -99,17 +100,17 @@ before(() => {
 
 after(() => {
   return Promise.all([
-    defaultApp.delete(),
-    nullApp.delete(),
-    nonNullApp.delete(),
-    noServiceAccountApp.delete(),
+    deleteApp(defaultApp),
+    deleteApp(nullApp),
+    deleteApp(nonNullApp),
+    deleteApp(noServiceAccountApp),
   ]);
 });
 
-class CertificatelessCredential implements admin.credential.Credential {
-  private readonly delegate: admin.credential.Credential;
+class CertificatelessCredential implements Credential {
+  private readonly delegate: Credential;
 
-  constructor(delegate: admin.credential.Credential) {
+  constructor(delegate: Credential) {
     this.delegate = delegate;
   }
 

--- a/test/integration/storage.spec.ts
+++ b/test/integration/storage.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as admin from '../../lib/index';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { Bucket, File } from '@google-cloud/storage';
 
 import { projectId } from './setup';
+import { getStorage } from '../../lib/storage/index';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -28,19 +28,19 @@ const expect = chai.expect;
 
 describe('admin.storage', () => {
   it('bucket() returns a handle to the default bucket', () => {
-    const bucket: Bucket = admin.storage().bucket();
+    const bucket: Bucket = getStorage().bucket();
     return verifyBucket(bucket, 'storage().bucket()')
       .should.eventually.be.fulfilled;
   });
 
   it('bucket(string) returns a handle to the specified bucket', () => {
-    const bucket: Bucket = admin.storage().bucket(projectId + '.appspot.com');
+    const bucket: Bucket = getStorage().bucket(projectId + '.appspot.com');
     return verifyBucket(bucket, 'storage().bucket(string)')
       .should.eventually.be.fulfilled;
   });
 
   it('bucket(non-existing) returns a handle which can be queried for existence', () => {
-    const bucket: Bucket = admin.storage().bucket('non.existing');
+    const bucket: Bucket = getStorage().bucket('non.existing');
     return bucket.exists()
       .then((data) => {
         expect(data[0]).to.be.false;


### PR DESCRIPTION
I've updated the existing integration test suite to use the new modular API surface whenever possible. Most of the changes required were pretty straightforward. For example:

1. Changing invocations like `admin.auth()` into `getAuth()`.
2. Changing type annotations like `admin.auth.UserRecord` into `UserRecord`.

However, this change broke some of the existing lazy loading tests. The updated `database.spec.ts` and `firestore.spec.ts` imports `firebase-admin/database` and `firebase-admin/firestore`, which in turn loads the corresponding 3rd party dependencies. The old lazy loading tests relied on this not happening. I've implemented a somewhat hacky solution to get around this issue. But we should probably find a better way to test lazy loading in the future.