### PR TITLE
feat(rtdb): Support emulator mode for rules management operations

### DIFF
--- a/src/database/database-internal.ts
+++ b/src/database/database-internal.ts
@@ -123,12 +123,15 @@ class DatabaseRulesClient {
   private readonly httpClient: AuthorizedHttpClient;
 
   constructor(app: FirebaseApp, dbUrl: string) {
+    let parsedUrl = new URL(dbUrl);
     const emulatorHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
     if (emulatorHost) {
-      dbUrl = `http://${emulatorHost}`;
+      const hostname = parsedUrl.hostname;
+      const dotIndex = hostname.indexOf('.');
+      const namespace = hostname.substring(0, dotIndex).toLowerCase();
+      parsedUrl = new URL(`http://${emulatorHost}?ns=${namespace}`);
     }
 
-    const parsedUrl = new URL(dbUrl);
     parsedUrl.pathname = path.join(parsedUrl.pathname, RULES_URL_PATH);
     this.dbUrl = parsedUrl.toString();
     this.httpClient = new AuthorizedHttpClient(app);

--- a/src/database/database-internal.ts
+++ b/src/database/database-internal.ts
@@ -63,7 +63,7 @@ export class DatabaseService {
   /**
    * Returns the app associated with this DatabaseService instance.
    *
-   * @return  The app associated with this DatabaseService instance.
+   * @return The app associated with this DatabaseService instance.
    */
   get app(): FirebaseApp {
     return this.appInternal;

--- a/src/database/database-internal.ts
+++ b/src/database/database-internal.ts
@@ -63,7 +63,7 @@ export class DatabaseService {
   /**
    * Returns the app associated with this DatabaseService instance.
    *
-   * @return {FirebaseApp} The app associated with this DatabaseService instance.
+   * @return  The app associated with this DatabaseService instance.
    */
   get app(): FirebaseApp {
     return this.appInternal;
@@ -123,6 +123,11 @@ class DatabaseRulesClient {
   private readonly httpClient: AuthorizedHttpClient;
 
   constructor(app: FirebaseApp, dbUrl: string) {
+    const emulatorHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+    if (emulatorHost) {
+      dbUrl = `http://${emulatorHost}`;
+    }
+
     const parsedUrl = new URL(dbUrl);
     parsedUrl.pathname = path.join(parsedUrl.pathname, RULES_URL_PATH);
     this.dbUrl = parsedUrl.toString();
@@ -133,7 +138,7 @@ class DatabaseRulesClient {
    * Gets the currently applied security rules as a string. The return value consists of
    * the rules source including comments.
    *
-   * @return {Promise<string>} A promise fulfilled with the rules as a raw string.
+   * @return A promise fulfilled with the rules as a raw string.
    */
   public getRules(): Promise<string> {
     const req: HttpRequestConfig = {

--- a/src/database/database-internal.ts
+++ b/src/database/database-internal.ts
@@ -126,9 +126,7 @@ class DatabaseRulesClient {
     let parsedUrl = new URL(dbUrl);
     const emulatorHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
     if (emulatorHost) {
-      const hostname = parsedUrl.hostname;
-      const dotIndex = hostname.indexOf('.');
-      const namespace = hostname.substring(0, dotIndex).toLowerCase();
+      const namespace = extractNamespace(parsedUrl);
       parsedUrl = new URL(`http://${emulatorHost}?ns=${namespace}`);
     }
 
@@ -240,4 +238,15 @@ class DatabaseRulesClient {
 
     return `${intro}: ${err.response.text}`;
   }
+}
+
+function extractNamespace(parsedUrl: URL): string {
+  const ns = parsedUrl.searchParams.get('ns');
+  if (ns) {
+    return ns;
+  }
+
+  const hostname = parsedUrl.hostname;
+  const dotIndex = hostname.indexOf('.');
+  return hostname.substring(0, dotIndex).toLowerCase();
 }

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -48,7 +48,7 @@ describe('Database', () => {
   describe('Constructor', () => {
     const invalidApps = [null, NaN, 0, 1, true, false, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];
     invalidApps.forEach((invalidApp) => {
-      it(`should throw given invalid app: ${ JSON.stringify(invalidApp) }`, () => {
+      it(`should throw given invalid app: ${JSON.stringify(invalidApp)}`, () => {
         expect(() => {
           const databaseAny: any = DatabaseService;
           return new databaseAny(invalidApp);
@@ -154,11 +154,8 @@ describe('Database', () => {
     }`;
     const rulesPath = '.settings/rules.json';
 
-    function callParamsForGet(
-      strict = false,
-      url = `https://databasename.firebaseio.com/${rulesPath}`,
-    ): HttpRequestConfig {
-
+    function callParamsForGet(options?: { strict?: boolean; url?: string }): HttpRequestConfig {
+      const url = options?.url || `https://databasename.firebaseio.com/${rulesPath}`;
       const params: HttpRequestConfig = {
         method: 'GET',
         url,
@@ -167,7 +164,7 @@ describe('Database', () => {
         },
       };
 
-      if (strict) {
+      if (options?.strict) {
         params.data = { format: 'strict' };
       }
 
@@ -215,7 +212,7 @@ describe('Database', () => {
         return db.getRules().then((result) => {
           expect(result).to.equal(rulesString);
           return expect(stub).to.have.been.calledOnce.and.calledWith(
-            callParamsForGet(false, `https://custom.firebaseio.com/${rulesPath}`));
+            callParamsForGet({ url: `https://custom.firebaseio.com/${rulesPath}` }));
         });
       });
 
@@ -225,7 +222,7 @@ describe('Database', () => {
         return db.getRules().then((result) => {
           expect(result).to.equal(rulesString);
           return expect(stub).to.have.been.calledOnce.and.calledWith(
-            callParamsForGet(false, `http://localhost:9000/${rulesPath}?ns=foo`));
+            callParamsForGet({ url: `http://localhost:9000/${rulesPath}?ns=foo` }));
         });
       });
 
@@ -259,7 +256,7 @@ describe('Database', () => {
         return db.getRulesJSON().then((result) => {
           expect(result).to.deep.equal(rules);
           return expect(stub).to.have.been.calledOnce.and.calledWith(
-            callParamsForGet(true));
+            callParamsForGet({ strict: true }));
         });
       });
 
@@ -269,7 +266,7 @@ describe('Database', () => {
         return db.getRulesJSON().then((result) => {
           expect(result).to.deep.equal(rules);
           return expect(stub).to.have.been.calledOnce.and.calledWith(
-            callParamsForGet(true, `https://custom.firebaseio.com/${rulesPath}`));
+            callParamsForGet({ strict: true, url: `https://custom.firebaseio.com/${rulesPath}` }));
         });
       });
 
@@ -279,7 +276,7 @@ describe('Database', () => {
         return db.getRulesJSON().then((result) => {
           expect(result).to.deep.equal(rules);
           return expect(stub).to.have.been.calledOnce.and.calledWith(
-            callParamsForGet(true, `http://localhost:9000/${rulesPath}?ns=foo`));
+            callParamsForGet({ strict: true, url: `http://localhost:9000/${rulesPath}?ns=foo` }));
         });
       });
 
@@ -407,6 +404,45 @@ describe('Database', () => {
           new Error('network error'));
         stubs.push(stub);
         return db.setRules(rules).should.eventually.be.rejectedWith('network error');
+      });
+    });
+
+    describe('emulator mode', () => {
+      before(() => {
+        process.env.FIREBASE_DATABASE_EMULATOR_HOST = 'localhost:9090';
+      });
+
+      after(() => {
+        delete process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+      });
+
+      it('getRules should connect to the emulator', () => {
+        const db: Database = database.getDatabase();
+        const stub = stubSuccessfulResponse(rules);
+        return db.getRules().then((result) => {
+          expect(result).to.equal(rulesString);
+          return expect(stub).to.have.been.calledOnce.and.calledWith(
+            callParamsForGet({ url: `http://localhost:9090/${rulesPath}` }));
+        });
+      });
+
+      it('getRulesJSON should connect to the emulator', () => {
+        const db: Database = database.getDatabase();
+        const stub = stubSuccessfulResponse(rules);
+        return db.getRulesJSON().then((result) => {
+          expect(result).to.equal(rules);
+          return expect(stub).to.have.been.calledOnce.and.calledWith(
+            callParamsForGet({ strict: true, url: `http://localhost:9090/${rulesPath}` }));
+        });
+      });
+
+      it('setRules should connect to the emulator', () => {
+        const db: Database = database.getDatabase();
+        const stub = stubSuccessfulResponse({});
+        return db.setRules(rulesString).then(() => {
+          return expect(stub).to.have.been.calledOnce.and.calledWith(
+            callParamsForPut(rulesString, `http://localhost:9090/${rulesPath}`));
+        });
       });
     });
   });


### PR DESCRIPTION
Connect to the emulator in `getRules()` and `setRules()` APIs when the emulator mode is enabled. Emulator mode can be enabled by setting the `FIREBASE_DATABASE_EMULATOR_HOST` env variable, or by setting an emulator URL directly in AppOptions. In the first case we pick up the namespace from the `databaseURL` App option.

Resolves #1149 

RELEASE NOTE: Rules management APIs now support the Firebase emulator suite. Methods like `getRules()` and `setRules()` will automatically connect to the local emulator, when the emulator mode is enabled.