### PR TITLE
chore: Clean up nightly workflow trigger tests

### DIFF
--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -88,12 +88,6 @@ describe('admin.remoteConfig', () => {
     }).to.throw('Cannot set property etag of #<RemoteConfigTemplateImpl> which has only a getter');
   });
 
-  // A failing integration test to trigger the send email action.
-  // Remove this once the testing is complete.
-  it('A failing integration test to trigger nightly email notifications', () => {
-    expect('a').to.be.equal('b');
-  });
-
   describe('validateTemplate', () => {
     it('should succeed with a vaild template', () => {
       // set parameters, groups, and conditions


### PR DESCRIPTION
- Remove the failing integration test that was added to trigger the send email workflow in nightly builds.
- The test was added in #1210 
- Nightly workflow tests were completed at:
- https://github.com/firebase/firebase-admin-node/actions/runs/709407686
- https://github.com/firebase/firebase-admin-node/actions/runs/709427014