### PR TITLE
chore: Fix bug in send-email action code

### DIFF
--- a/.github/actions/send-email/dist/index.js
+++ b/.github/actions/send-email/dist/index.js
@@ -276,7 +276,14 @@ function sendEmail(config) {
   });
 
   return mg.messages
-    .create(domain, config)
+    .create(config.domain, {
+      from: config.from,
+      to: config.to,
+      cc: config.cc,
+      subject: config.subject,
+      text: config.text,
+      html: config.html,
+    })
     .then((resp) => {
       core.setOutput('response', resp.message);
       return;

--- a/.github/actions/send-email/index.js
+++ b/.github/actions/send-email/index.js
@@ -56,7 +56,14 @@ function sendEmail(config) {
   });
 
   return mg.messages
-    .create(domain, config)
+    .create(config.domain, {
+      from: config.from,
+      to: config.to,
+      cc: config.cc,
+      subject: config.subject,
+      text: config.text,
+      html: config.html,
+    })
     .then((resp) => {
       core.setOutput('response', resp.message);
       return;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,11 @@ name: Nightly Builds
 
 on:
   # Runs every day at 06:00 AM (PT) and 08:00 PM (PT) / 04:00 AM (UTC) and 02:00 PM (UTC)
+  # or on 'firebase_build' repository dispatch event.
   schedule:
     - cron: "0 4,14 * * *"
+  repository_dispatch:
+    types: [firebase_build]
 
 jobs:
   nightly:
@@ -75,11 +78,11 @@ jobs:
         domain: ${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}
         from: 'GitHub <admin-github@${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}>'
         to: ${{ secrets.FIREBASE_ADMIN_GITHUB_EMAIL }}
-        subject: '[${{github.repository}}] Nightly build failed!'
+        subject: 'Nightly build ${{github.run_id}} of ${{github.repository}} failed!'
         html: >
-          <b>Nightly workflow failed on: ${{github.repository}}</b>
+          <b>Nightly workflow ${{github.run_id}} failed on: ${{github.repository}}</b>
           <br /><br />Navigate to the 
-          <a href="https://github.com/firebase/firebase-admin-node/actions">failed workflow</a>.
+          <a href="https://github.com/firebase/firebase-admin-node/actions/runs/${{github.run_id}}">failed workflow</a>.
       continue-on-error: true
 
     - name: Send email on cancelled
@@ -90,9 +93,9 @@ jobs:
         domain: ${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}
         from: 'GitHub <admin-github@${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}>'
         to: ${{ secrets.FIREBASE_ADMIN_GITHUB_EMAIL }}
-        subject: '[${{github.repository}}] Nightly build got cancelled!'
+        subject: 'Nightly build ${{github.run_id}} of ${{github.repository}} cancelled!'
         html: >
-          <b>Nightly workflow cancelled on: ${{github.repository}}</b>
+          <b>Nightly workflow ${{github.run_id}} cancelled on: ${{github.repository}}</b>
           <br /><br />Navigate to the 
-          <a href="https://github.com/firebase/firebase-admin-node/actions">cancelled workflow</a>.
+          <a href="https://github.com/firebase/firebase-admin-node/actions/runs/${{github.run_id}}">cancelled workflow</a>.
       continue-on-error: true


### PR DESCRIPTION
- The script was failing because the `domain` was undefined in the script (it should be `config.domain`).
- This PR fixes the above issue and instead of passing the whole config object this includes only the necessary parameters in the message.