### PR TITLE
chore: Experimental markdown docs

### DIFF
--- a/docgen/markdown/firebase-admin.app.app.md
+++ b/docgen/markdown/firebase-admin.app.app.md
@@ -1,0 +1,73 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}App interface{% endblock title %}
+{% block body %}
+A Firebase app holds the initialization information for a collection of services.
+
+Do not call this constructor directly. Instead, use  to create an app.
+
+<b>Signature:</b>
+
+```typescript
+export interface App 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [name](./firebase-admin.app.app.md#appname) | string | The (read-only) name for this app.<!-- -->The default app's name is <code>&quot;[DEFAULT]&quot;</code>. |
+|  [options](./firebase-admin.app.app.md#appoptions) | [AppOptions](./firebase-admin.app.appoptions.md#appoptions_interface) | The (read-only) configuration options for this app. These are the original parameters given in . |
+
+## App.name
+
+The (read-only) name for this app.
+
+The default app's name is `"[DEFAULT]"`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+name: string;
+```
+
+### Example 1
+
+
+```javascript
+// The default app's name is "[DEFAULT]"
+initializeApp(defaultAppConfig);
+console.log(admin.app().name);  // "[DEFAULT]"
+
+```
+
+### Example 2
+
+
+```javascript
+// A named app's name is what you provide to initializeApp()
+const otherApp = initializeApp(otherAppConfig, "other");
+console.log(otherApp.name);  // "other"
+
+```
+
+## App.options
+
+The (read-only) configuration options for this app. These are the original parameters given in .
+
+<b>Signature:</b>
+
+```typescript
+options: AppOptions;
+```
+
+### Example
+
+
+```javascript
+const app = initializeApp(config);
+console.log(app.options.credential === config.credential);  // true
+console.log(app.options.databaseURL === config.databaseURL);  // true
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.appoptions.md
+++ b/docgen/markdown/firebase-admin.app.appoptions.md
@@ -1,0 +1,101 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AppOptions interface{% endblock title %}
+{% block body %}
+Available options to pass to \[`initializeApp()`<!-- -->\](admin\#.initializeApp).
+
+<b>Signature:</b>
+
+```typescript
+export interface AppOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [credential](./firebase-admin.app.appoptions.md#appoptionscredential) | [Credential](./firebase-admin.app.credential.md#credential_interface) | A  object used to authenticate the Admin SDK.<!-- -->See \[Initialize the SDK\](/docs/admin/setup\#initialize\_the\_sdk) for detailed documentation and code samples. |
+|  [databaseAuthVariableOverride](./firebase-admin.app.appoptions.md#appoptionsdatabaseauthvariableoverride) | object \| null | The object to use as the \[<code>auth</code>\](/docs/reference/security/database/\#auth) variable in your Realtime Database Rules when the Admin SDK reads from or writes to the Realtime Database. This allows you to downscope the Admin SDK from its default full read and write privileges.<!-- -->You can pass <code>null</code> to act as an unauthenticated client.<!-- -->See \[Authenticate with limited privileges\](/docs/database/admin/start\#authenticate-with-limited-privileges) for detailed documentation and code samples. |
+|  [databaseURL](./firebase-admin.app.appoptions.md#appoptionsdatabaseurl) | string | The URL of the Realtime Database from which to read and write data. |
+|  [httpAgent](./firebase-admin.app.appoptions.md#appoptionshttpagent) | Agent | An \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when making outgoing HTTP calls. This Agent instance is used by all services that make REST calls (e.g. <code>auth</code>, <code>messaging</code>, <code>projectManagement</code>).<!-- -->Realtime Database and Firestore use other means of communicating with the backend servers, so they do not use this HTTP Agent. <code>Credential</code> instances also do not use this HTTP Agent, but instead support specifying an HTTP Agent in the corresponding factory methods. |
+|  [projectId](./firebase-admin.app.appoptions.md#appoptionsprojectid) | string | The ID of the Google Cloud project associated with the App. |
+|  [serviceAccountId](./firebase-admin.app.appoptions.md#appoptionsserviceaccountid) | string | The ID of the service account to be used for signing custom tokens. This can be found in the <code>client_email</code> field of a service account JSON file. |
+|  [storageBucket](./firebase-admin.app.appoptions.md#appoptionsstoragebucket) | string | The name of the Google Cloud Storage bucket used for storing application data. Use only the bucket name without any prefixes or additions (do \*not\* prefix the name with "gs://"). |
+
+## AppOptions.credential
+
+A  object used to authenticate the Admin SDK.
+
+See \[Initialize the SDK\](/docs/admin/setup\#initialize\_the\_sdk) for detailed documentation and code samples.
+
+<b>Signature:</b>
+
+```typescript
+credential?: Credential;
+```
+
+## AppOptions.databaseAuthVariableOverride
+
+The object to use as the \[`auth`<!-- -->\](/docs/reference/security/database/\#auth) variable in your Realtime Database Rules when the Admin SDK reads from or writes to the Realtime Database. This allows you to downscope the Admin SDK from its default full read and write privileges.
+
+You can pass `null` to act as an unauthenticated client.
+
+See \[Authenticate with limited privileges\](/docs/database/admin/start\#authenticate-with-limited-privileges) for detailed documentation and code samples.
+
+<b>Signature:</b>
+
+```typescript
+databaseAuthVariableOverride?: object | null;
+```
+
+## AppOptions.databaseURL
+
+The URL of the Realtime Database from which to read and write data.
+
+<b>Signature:</b>
+
+```typescript
+databaseURL?: string;
+```
+
+## AppOptions.httpAgent
+
+An \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when making outgoing HTTP calls. This Agent instance is used by all services that make REST calls (e.g. `auth`<!-- -->, `messaging`<!-- -->, `projectManagement`<!-- -->).
+
+Realtime Database and Firestore use other means of communicating with the backend servers, so they do not use this HTTP Agent. `Credential` instances also do not use this HTTP Agent, but instead support specifying an HTTP Agent in the corresponding factory methods.
+
+<b>Signature:</b>
+
+```typescript
+httpAgent?: Agent;
+```
+
+## AppOptions.projectId
+
+The ID of the Google Cloud project associated with the App.
+
+<b>Signature:</b>
+
+```typescript
+projectId?: string;
+```
+
+## AppOptions.serviceAccountId
+
+The ID of the service account to be used for signing custom tokens. This can be found in the `client_email` field of a service account JSON file.
+
+<b>Signature:</b>
+
+```typescript
+serviceAccountId?: string;
+```
+
+## AppOptions.storageBucket
+
+The name of the Google Cloud Storage bucket used for storing application data. Use only the bucket name without any prefixes or additions (do \*not\* prefix the name with "gs://").
+
+<b>Signature:</b>
+
+```typescript
+storageBucket?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.credential.md
+++ b/docgen/markdown/firebase-admin.app.credential.md
@@ -1,0 +1,37 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Credential interface{% endblock title %}
+{% block body %}
+Interface that provides Google OAuth2 access tokens used to authenticate with Firebase services.
+
+In most cases, you will not need to implement this yourself and can instead use the default implementations provided by .
+
+<b>Signature:</b>
+
+```typescript
+export interface Credential 
+```
+
+## Methods
+
+|  Method | Description |
+|  --- | --- |
+|  [getAccessToken()](./firebase-admin.app.credential.md#credentialgetaccesstoken) | Returns a Google OAuth2 access token object used to authenticate with Firebase services.<!-- -->This object contains the following properties: \* <code>access_token</code> (<code>string</code>): The actual Google OAuth2 access token. \* <code>expires_in</code> (<code>number</code>): The number of seconds from when the token was issued that it expires. A Google OAuth2 access token object. |
+
+## Credential.getAccessToken()
+
+Returns a Google OAuth2 access token object used to authenticate with Firebase services.
+
+This object contains the following properties: \* `access_token` (`string`<!-- -->): The actual Google OAuth2 access token. \* `expires_in` (`number`<!-- -->): The number of seconds from when the token was issued that it expires.
+
+ A Google OAuth2 access token object.
+
+<b>Signature:</b>
+
+```typescript
+getAccessToken(): Promise<GoogleOAuthAccessToken>;
+```
+<b>Returns:</b>
+
+Promise&lt;[GoogleOAuthAccessToken](./firebase-admin.app.googleoauthaccesstoken.md#googleoauthaccesstoken_interface)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.firebasearrayindexerror.md
+++ b/docgen/markdown/firebase-admin.app.firebasearrayindexerror.md
@@ -1,0 +1,62 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}FirebaseArrayIndexError interface{% endblock title %}
+{% block body %}
+Composite type which includes both a `FirebaseError` object and an index which can be used to get the errored item.
+
+<b>Signature:</b>
+
+```typescript
+export interface FirebaseArrayIndexError 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [error](./firebase-admin.app.firebasearrayindexerror.md#firebasearrayindexerrorerror) | [FirebaseError](./firebase-admin.app.firebaseerror.md#firebaseerror_interface) | The error object. |
+|  [index](./firebase-admin.app.firebasearrayindexerror.md#firebasearrayindexerrorindex) | number | The index of the errored item within the original array passed as part of the called API method. |
+
+## FirebaseArrayIndexError.error
+
+The error object.
+
+<b>Signature:</b>
+
+```typescript
+error: FirebaseError;
+```
+
+## FirebaseArrayIndexError.index
+
+The index of the errored item within the original array passed as part of the called API method.
+
+<b>Signature:</b>
+
+```typescript
+index: number;
+```
+
+### Example
+
+
+```javascript
+var registrationTokens = [token1, token2, token3];
+admin.messaging().subscribeToTopic(registrationTokens, 'topic-name')
+  .then(function(response) {
+    if (response.failureCount > 0) {
+      console.log("Following devices unsucessfully subscribed to topic:");
+      response.errors.forEach(function(error) {
+        var invalidToken = registrationTokens[error.index];
+        console.log(invalidToken, error.error);
+      });
+    } else {
+      console.log("All devices successfully subscribed to topic:", response);
+    }
+  })
+  .catch(function(error) {
+    console.log("Error subscribing to topic:", error);
+  });
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.firebaseerror.md
+++ b/docgen/markdown/firebase-admin.app.firebaseerror.md
@@ -1,0 +1,75 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}FirebaseError interface{% endblock title %}
+{% block body %}
+`FirebaseError` is a subclass of the standard JavaScript `Error` object. In addition to a message string and stack trace, it contains a string code.
+
+<b>Signature:</b>
+
+```typescript
+export interface FirebaseError 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [code](./firebase-admin.app.firebaseerror.md#firebaseerrorcode) | string | Error codes are strings using the following format: <code>&quot;service/string-code&quot;</code>. Some examples include <code>&quot;auth/invalid-uid&quot;</code> and <code>&quot;messaging/invalid-recipient&quot;</code>.<!-- -->While the message for a given error can change, the code will remain the same between backward-compatible versions of the Firebase SDK. |
+|  [message](./firebase-admin.app.firebaseerror.md#firebaseerrormessage) | string | An explanatory message for the error that just occurred.<!-- -->This message is designed to be helpful to you, the developer. Because it generally does not convey meaningful information to end users, this message should not be displayed in your application. |
+|  [stack](./firebase-admin.app.firebaseerror.md#firebaseerrorstack) | string | A string value containing the execution backtrace when the error originally occurred.<!-- -->This information can be useful to you and can be sent to  to help explain the cause of an error. |
+
+## Methods
+
+|  Method | Description |
+|  --- | --- |
+|  [toJSON()](./firebase-admin.app.firebaseerror.md#firebaseerrortojson) |  A JSON-serializable representation of this object. |
+
+## FirebaseError.code
+
+Error codes are strings using the following format: `"service/string-code"`<!-- -->. Some examples include `"auth/invalid-uid"` and `"messaging/invalid-recipient"`<!-- -->.
+
+While the message for a given error can change, the code will remain the same between backward-compatible versions of the Firebase SDK.
+
+<b>Signature:</b>
+
+```typescript
+code: string;
+```
+
+## FirebaseError.message
+
+An explanatory message for the error that just occurred.
+
+This message is designed to be helpful to you, the developer. Because it generally does not convey meaningful information to end users, this message should not be displayed in your application.
+
+<b>Signature:</b>
+
+```typescript
+message: string;
+```
+
+## FirebaseError.stack
+
+A string value containing the execution backtrace when the error originally occurred.
+
+This information can be useful to you and can be sent to  to help explain the cause of an error.
+
+<b>Signature:</b>
+
+```typescript
+stack?: string;
+```
+
+## FirebaseError.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.googleoauthaccesstoken.md
+++ b/docgen/markdown/firebase-admin.app.googleoauthaccesstoken.md
@@ -1,0 +1,34 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}GoogleOAuthAccessToken interface{% endblock title %}
+{% block body %}
+Interface for Google OAuth 2.0 access tokens.
+
+<b>Signature:</b>
+
+```typescript
+export interface GoogleOAuthAccessToken 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [access\_token](./firebase-admin.app.googleoauthaccesstoken.md#googleoauthaccesstokenaccess_token) | string |  |
+|  [expires\_in](./firebase-admin.app.googleoauthaccesstoken.md#googleoauthaccesstokenexpires_in) | number |  |
+
+## GoogleOAuthAccessToken.access\_token
+
+<b>Signature:</b>
+
+```typescript
+access_token: string;
+```
+
+## GoogleOAuthAccessToken.expires\_in
+
+<b>Signature:</b>
+
+```typescript
+expires_in: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.md
+++ b/docgen/markdown/firebase-admin.app.md
@@ -1,0 +1,247 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.app package{% endblock title %}
+{% block body %}
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [applicationDefault(httpAgent)](./firebase-admin.app.md#applicationdefault) | Returns a credential created from the  that grants admin access to Firebase services. This credential can be used in the call to .<!-- -->Google Application Default Credentials are available on any Google infrastructure, such as Google App Engine and Google Compute Engine.<!-- -->See  for more details. |
+|  [cert(serviceAccountPathOrObject, httpAgent)](./firebase-admin.app.md#cert) | Returns a credential created from the provided service account that grants admin access to Firebase services. This credential can be used in the call to .<!-- -->See  for more details. |
+|  [deleteApp(app)](./firebase-admin.app.md#deleteapp) | Renders this given <code>App</code> unusable and frees the resources of all associated services (though it does \*not\* clean up any backend resources). When running the SDK locally, this method must be called to ensure graceful termination of the process. |
+|  [getApp(name)](./firebase-admin.app.md#getapp) |  |
+|  [getApps()](./firebase-admin.app.md#getapps) |  |
+|  [initializeApp(options, name)](./firebase-admin.app.md#initializeapp) |  |
+|  [refreshToken(refreshTokenPathOrObject, httpAgent)](./firebase-admin.app.md#refreshtoken) | Returns a credential created from the provided refresh token that grants admin access to Firebase services. This credential can be used in the call to .<!-- -->See  for more details. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [App](./firebase-admin.app.app.md#app_interface) | A Firebase app holds the initialization information for a collection of services.<!-- -->Do not call this constructor directly. Instead, use  to create an app. |
+|  [AppOptions](./firebase-admin.app.appoptions.md#appoptions_interface) | Available options to pass to \[<code>initializeApp()</code>\](admin\#.initializeApp). |
+|  [Credential](./firebase-admin.app.credential.md#credential_interface) | Interface that provides Google OAuth2 access tokens used to authenticate with Firebase services.<!-- -->In most cases, you will not need to implement this yourself and can instead use the default implementations provided by . |
+|  [FirebaseArrayIndexError](./firebase-admin.app.firebasearrayindexerror.md#firebasearrayindexerror_interface) | Composite type which includes both a <code>FirebaseError</code> object and an index which can be used to get the errored item. |
+|  [FirebaseError](./firebase-admin.app.firebaseerror.md#firebaseerror_interface) | <code>FirebaseError</code> is a subclass of the standard JavaScript <code>Error</code> object. In addition to a message string and stack trace, it contains a string code. |
+|  [GoogleOAuthAccessToken](./firebase-admin.app.googleoauthaccesstoken.md#googleoauthaccesstoken_interface) | Interface for Google OAuth 2.0 access tokens. |
+|  [ServiceAccount](./firebase-admin.app.serviceaccount.md#serviceaccount_interface) |  |
+
+## Variables
+
+|  Variable | Description |
+|  --- | --- |
+|  [SDK\_VERSION](./firebase-admin.app.md#sdk_version) |  |
+
+## applicationDefault()
+
+Returns a credential created from the  that grants admin access to Firebase services. This credential can be used in the call to .
+
+Google Application Default Credentials are available on any Google infrastructure, such as Google App Engine and Google Compute Engine.
+
+See  for more details.
+
+<b>Signature:</b>
+
+```typescript
+export declare function applicationDefault(httpAgent?: Agent): Credential;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  httpAgent | Agent | Optional \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when retrieving access tokens from Google token servers. A credential authenticated via Google Application Default Credentials that can be used to initialize an app. |
+
+<b>Returns:</b>
+
+[Credential](./firebase-admin.app.credential.md#credential_interface)
+
+### Example
+
+
+```javascript
+initializeApp({
+  credential: applicationDefault(),
+  databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+});
+
+```
+
+## cert()
+
+Returns a credential created from the provided service account that grants admin access to Firebase services. This credential can be used in the call to .
+
+See  for more details.
+
+<b>Signature:</b>
+
+```typescript
+export declare function cert(serviceAccountPathOrObject: string | ServiceAccount, httpAgent?: Agent): Credential;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  serviceAccountPathOrObject | string \| [ServiceAccount](./firebase-admin.app.serviceaccount.md#serviceaccount_interface) | The path to a service account key JSON file or an object representing a service account key. |
+|  httpAgent | Agent | Optional \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when retrieving access tokens from Google token servers. A credential authenticated via the provided service account that can be used to initialize an app. |
+
+<b>Returns:</b>
+
+[Credential](./firebase-admin.app.credential.md#credential_interface)
+
+### Example 1
+
+
+```javascript
+// Providing a path to a service account key JSON file
+const serviceAccount = require("path/to/serviceAccountKey.json");
+initializeApp({
+  credential: cert(serviceAccount),
+  databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+});
+
+```
+
+### Example 2
+
+
+```javascript
+// Providing a service account object inline
+initializeApp({
+  credential: cert({
+    projectId: "<PROJECT_ID>",
+    clientEmail: "foo@<PROJECT_ID>.iam.gserviceaccount.com",
+    privateKey: "-----BEGIN PRIVATE KEY-----<KEY>-----END PRIVATE KEY-----\n"
+  }),
+  databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+});
+
+```
+
+## deleteApp()
+
+Renders this given `App` unusable and frees the resources of all associated services (though it does \*not\* clean up any backend resources). When running the SDK locally, this method must be called to ensure graceful termination of the process.
+
+<b>Signature:</b>
+
+```typescript
+export declare function deleteApp(app: App): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.app.md#app_interface) |  |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+### Example
+
+
+```javascript
+deleteApp(app)
+  .then(function() {
+    console.log("App deleted successfully");
+  })
+  .catch(function(error) {
+    console.log("Error deleting app:", error);
+  });
+
+```
+
+## getApp()
+
+<b>Signature:</b>
+
+```typescript
+export declare function getApp(name?: string): App;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string |  |
+
+<b>Returns:</b>
+
+[App](./firebase-admin.app.app.md#app_interface)
+
+## getApps()
+
+<b>Signature:</b>
+
+```typescript
+export declare function getApps(): App[];
+```
+<b>Returns:</b>
+
+[App](./firebase-admin.app.app.md#app_interface)<!-- -->\[\]
+
+## initializeApp()
+
+<b>Signature:</b>
+
+```typescript
+export declare function initializeApp(options?: AppOptions, name?: string): App;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  options | [AppOptions](./firebase-admin.app.appoptions.md#appoptions_interface) |  |
+|  name | string |  |
+
+<b>Returns:</b>
+
+[App](./firebase-admin.app.app.md#app_interface)
+
+## refreshToken()
+
+Returns a credential created from the provided refresh token that grants admin access to Firebase services. This credential can be used in the call to .
+
+See  for more details.
+
+<b>Signature:</b>
+
+```typescript
+export declare function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  refreshTokenPathOrObject | string \| object | The path to a Google OAuth2 refresh token JSON file or an object representing a Google OAuth2 refresh token. |
+|  httpAgent | Agent | Optional \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when retrieving access tokens from Google token servers. A credential authenticated via the provided service account that can be used to initialize an app. |
+
+<b>Returns:</b>
+
+[Credential](./firebase-admin.app.credential.md#credential_interface)
+
+### Example
+
+
+```javascript
+// Providing a path to a refresh token JSON file
+const refreshToken = require("path/to/refreshToken.json");
+initializeApp({
+  credential: refreshToken(refreshToken),
+  databaseURL: "https://<DATABASE_NAME>.firebaseio.com"
+});
+
+```
+
+## SDK\_VERSION
+
+<b>Signature:</b>
+
+```typescript
+SDK_VERSION: string
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.app.serviceaccount.md
+++ b/docgen/markdown/firebase-admin.app.serviceaccount.md
@@ -1,0 +1,41 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ServiceAccount interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface ServiceAccount 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [clientEmail](./firebase-admin.app.serviceaccount.md#serviceaccountclientemail) | string |  |
+|  [privateKey](./firebase-admin.app.serviceaccount.md#serviceaccountprivatekey) | string |  |
+|  [projectId](./firebase-admin.app.serviceaccount.md#serviceaccountprojectid) | string |  |
+
+## ServiceAccount.clientEmail
+
+<b>Signature:</b>
+
+```typescript
+clientEmail?: string;
+```
+
+## ServiceAccount.privateKey
+
+<b>Signature:</b>
+
+```typescript
+privateKey?: string;
+```
+
+## ServiceAccount.projectId
+
+<b>Signature:</b>
+
+```typescript
+projectId?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.appoptions.md
+++ b/docgen/markdown/firebase-admin.appoptions.md
@@ -1,0 +1,101 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AppOptions interface{% endblock title %}
+{% block body %}
+Available options to pass to \[`initializeApp()`<!-- -->\](admin\#.initializeApp).
+
+<b>Signature:</b>
+
+```typescript
+export interface AppOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [credential](./firebase-admin.appoptions.md#appoptionscredential) | Credential | A  object used to authenticate the Admin SDK.<!-- -->See \[Initialize the SDK\](/docs/admin/setup\#initialize\_the\_sdk) for detailed documentation and code samples. |
+|  [databaseAuthVariableOverride](./firebase-admin.appoptions.md#appoptionsdatabaseauthvariableoverride) | object \| null | The object to use as the \[<code>auth</code>\](/docs/reference/security/database/\#auth) variable in your Realtime Database Rules when the Admin SDK reads from or writes to the Realtime Database. This allows you to downscope the Admin SDK from its default full read and write privileges.<!-- -->You can pass <code>null</code> to act as an unauthenticated client.<!-- -->See \[Authenticate with limited privileges\](/docs/database/admin/start\#authenticate-with-limited-privileges) for detailed documentation and code samples. |
+|  [databaseURL](./firebase-admin.appoptions.md#appoptionsdatabaseurl) | string | The URL of the Realtime Database from which to read and write data. |
+|  [httpAgent](./firebase-admin.appoptions.md#appoptionshttpagent) | Agent | An \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when making outgoing HTTP calls. This Agent instance is used by all services that make REST calls (e.g. <code>auth</code>, <code>messaging</code>, <code>projectManagement</code>).<!-- -->Realtime Database and Firestore use other means of communicating with the backend servers, so they do not use this HTTP Agent. <code>Credential</code> instances also do not use this HTTP Agent, but instead support specifying an HTTP Agent in the corresponding factory methods. |
+|  [projectId](./firebase-admin.appoptions.md#appoptionsprojectid) | string | The ID of the Google Cloud project associated with the App. |
+|  [serviceAccountId](./firebase-admin.appoptions.md#appoptionsserviceaccountid) | string | The ID of the service account to be used for signing custom tokens. This can be found in the <code>client_email</code> field of a service account JSON file. |
+|  [storageBucket](./firebase-admin.appoptions.md#appoptionsstoragebucket) | string | The name of the Google Cloud Storage bucket used for storing application data. Use only the bucket name without any prefixes or additions (do \*not\* prefix the name with "gs://"). |
+
+## AppOptions.credential
+
+A  object used to authenticate the Admin SDK.
+
+See \[Initialize the SDK\](/docs/admin/setup\#initialize\_the\_sdk) for detailed documentation and code samples.
+
+<b>Signature:</b>
+
+```typescript
+credential?: Credential;
+```
+
+## AppOptions.databaseAuthVariableOverride
+
+The object to use as the \[`auth`<!-- -->\](/docs/reference/security/database/\#auth) variable in your Realtime Database Rules when the Admin SDK reads from or writes to the Realtime Database. This allows you to downscope the Admin SDK from its default full read and write privileges.
+
+You can pass `null` to act as an unauthenticated client.
+
+See \[Authenticate with limited privileges\](/docs/database/admin/start\#authenticate-with-limited-privileges) for detailed documentation and code samples.
+
+<b>Signature:</b>
+
+```typescript
+databaseAuthVariableOverride?: object | null;
+```
+
+## AppOptions.databaseURL
+
+The URL of the Realtime Database from which to read and write data.
+
+<b>Signature:</b>
+
+```typescript
+databaseURL?: string;
+```
+
+## AppOptions.httpAgent
+
+An \[HTTP Agent\](https://nodejs.org/api/http.html\#http\_class\_http\_agent) to be used when making outgoing HTTP calls. This Agent instance is used by all services that make REST calls (e.g. `auth`<!-- -->, `messaging`<!-- -->, `projectManagement`<!-- -->).
+
+Realtime Database and Firestore use other means of communicating with the backend servers, so they do not use this HTTP Agent. `Credential` instances also do not use this HTTP Agent, but instead support specifying an HTTP Agent in the corresponding factory methods.
+
+<b>Signature:</b>
+
+```typescript
+httpAgent?: Agent;
+```
+
+## AppOptions.projectId
+
+The ID of the Google Cloud project associated with the App.
+
+<b>Signature:</b>
+
+```typescript
+projectId?: string;
+```
+
+## AppOptions.serviceAccountId
+
+The ID of the service account to be used for signing custom tokens. This can be found in the `client_email` field of a service account JSON file.
+
+<b>Signature:</b>
+
+```typescript
+serviceAccountId?: string;
+```
+
+## AppOptions.storageBucket
+
+The name of the Google Cloud Storage bucket used for storing application data. Use only the bucket name without any prefixes or additions (do \*not\* prefix the name with "gs://").
+
+<b>Signature:</b>
+
+```typescript
+storageBucket?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.actioncodesettings.md
+++ b/docgen/markdown/firebase-admin.auth.actioncodesettings.md
@@ -1,0 +1,77 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ActionCodeSettings interface{% endblock title %}
+{% block body %}
+This is the interface that defines the required continue/state URL with optional Android and iOS bundle identifiers.
+
+<b>Signature:</b>
+
+```typescript
+export interface ActionCodeSettings 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [android](./firebase-admin.auth.actioncodesettings.md#actioncodesettingsandroid) | { packageName: string; installApp?: boolean; minimumVersion?: string; } | Defines the Android package name. This will try to open the link in an android app if it is installed. If <code>installApp</code> is passed, it specifies whether to install the Android app if the device supports it and the app is not already installed. If this field is provided without a <code>packageName</code>, an error is thrown explaining that the <code>packageName</code> must be provided in conjunction with this field. If <code>minimumVersion</code> is specified, and an older version of the app is installed, the user is taken to the Play Store to upgrade the app. |
+|  [dynamicLinkDomain](./firebase-admin.auth.actioncodesettings.md#actioncodesettingsdynamiclinkdomain) | string | Defines the dynamic link domain to use for the current link if it is to be opened using Firebase Dynamic Links, as multiple dynamic link domains can be configured per project. This field provides the ability to explicitly choose configured per project. This fields provides the ability explicitly choose one. If none is provided, the oldest domain is used by default. |
+|  [handleCodeInApp](./firebase-admin.auth.actioncodesettings.md#actioncodesettingshandlecodeinapp) | boolean | Whether to open the link via a mobile app or a browser. The default is false. When set to true, the action code link is sent as a Universal Link or Android App Link and is opened by the app if installed. In the false case, the code is sent to the web widget first and then redirects to the app if installed. |
+|  [iOS](./firebase-admin.auth.actioncodesettings.md#actioncodesettingsios) | { bundleId: string; } | Defines the iOS bundle ID. This will try to open the link in an iOS app if it is installed. |
+|  [url](./firebase-admin.auth.actioncodesettings.md#actioncodesettingsurl) | string | Defines the link continue/state URL, which has different meanings in different contexts: <ul> <li>When the link is handled in the web action widgets, this is the deep link in the <code>continueUrl</code> query parameter.</li> <li>When the link is handled in the app directly, this is the <code>continueUrl</code> query parameter in the deep link of the Dynamic Link.</li> </ul> |
+
+## ActionCodeSettings.android
+
+Defines the Android package name. This will try to open the link in an android app if it is installed. If `installApp` is passed, it specifies whether to install the Android app if the device supports it and the app is not already installed. If this field is provided without a `packageName`<!-- -->, an error is thrown explaining that the `packageName` must be provided in conjunction with this field. If `minimumVersion` is specified, and an older version of the app is installed, the user is taken to the Play Store to upgrade the app.
+
+<b>Signature:</b>
+
+```typescript
+android?: {
+        packageName: string;
+        installApp?: boolean;
+        minimumVersion?: string;
+    };
+```
+
+## ActionCodeSettings.dynamicLinkDomain
+
+Defines the dynamic link domain to use for the current link if it is to be opened using Firebase Dynamic Links, as multiple dynamic link domains can be configured per project. This field provides the ability to explicitly choose configured per project. This fields provides the ability explicitly choose one. If none is provided, the oldest domain is used by default.
+
+<b>Signature:</b>
+
+```typescript
+dynamicLinkDomain?: string;
+```
+
+## ActionCodeSettings.handleCodeInApp
+
+Whether to open the link via a mobile app or a browser. The default is false. When set to true, the action code link is sent as a Universal Link or Android App Link and is opened by the app if installed. In the false case, the code is sent to the web widget first and then redirects to the app if installed.
+
+<b>Signature:</b>
+
+```typescript
+handleCodeInApp?: boolean;
+```
+
+## ActionCodeSettings.iOS
+
+Defines the iOS bundle ID. This will try to open the link in an iOS app if it is installed.
+
+<b>Signature:</b>
+
+```typescript
+iOS?: {
+        bundleId: string;
+    };
+```
+
+## ActionCodeSettings.url
+
+Defines the link continue/state URL, which has different meanings in different contexts: <ul> <li>When the link is handled in the web action widgets, this is the deep link in the `continueUrl` query parameter.</li> <li>When the link is handled in the app directly, this is the `continueUrl` query parameter in the deep link of the Dynamic Link.</li> </ul>
+
+<b>Signature:</b>
+
+```typescript
+url: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.auth.md
+++ b/docgen/markdown/firebase-admin.auth.auth.md
@@ -1,0 +1,50 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Auth class{% endblock title %}
+{% block body %}
+Auth service bound to the provided app. An Auth instance can have multiple tenants.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Auth extends BaseAuth 
+```
+<b>Extends:</b> [BaseAuth](./firebase-admin.auth.baseauth.md#baseauth_class)
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.auth.auth.md#authapp) |  | App | Returns the app associated with this Auth instance. The app associated with this Auth instance. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [tenantManager()](./firebase-admin.auth.auth.md#authtenantmanager) |  |  The tenant manager instance associated with the current project. |
+
+## Auth.app
+
+Returns the app associated with this Auth instance.
+
+ The app associated with this Auth instance.
+
+<b>Signature:</b>
+
+```typescript
+get app(): App;
+```
+
+## Auth.tenantManager()
+
+ The tenant manager instance associated with the current project.
+
+<b>Signature:</b>
+
+```typescript
+tenantManager(): TenantManager;
+```
+<b>Returns:</b>
+
+[TenantManager](./firebase-admin.auth.tenantmanager.md#tenantmanager_class)
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.authproviderconfig.md
+++ b/docgen/markdown/firebase-admin.auth.authproviderconfig.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AuthProviderConfig interface{% endblock title %}
+{% block body %}
+The base Auth provider configuration interface.
+
+<b>Signature:</b>
+
+```typescript
+export interface AuthProviderConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.auth.authproviderconfig.md#authproviderconfigdisplayname) | string | The user-friendly display name to the current configuration. This name is also used as the provider label in the Cloud Console. |
+|  [enabled](./firebase-admin.auth.authproviderconfig.md#authproviderconfigenabled) | boolean | Whether the provider configuration is enabled or disabled. A user cannot sign in using a disabled provider. |
+|  [providerId](./firebase-admin.auth.authproviderconfig.md#authproviderconfigproviderid) | string | The provider ID defined by the developer. For a SAML provider, this is always prefixed by <code>saml.</code>. For an OIDC provider, this is always prefixed by <code>oidc.</code>. |
+
+## AuthProviderConfig.displayName
+
+The user-friendly display name to the current configuration. This name is also used as the provider label in the Cloud Console.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## AuthProviderConfig.enabled
+
+Whether the provider configuration is enabled or disabled. A user cannot sign in using a disabled provider.
+
+<b>Signature:</b>
+
+```typescript
+enabled: boolean;
+```
+
+## AuthProviderConfig.providerId
+
+The provider ID defined by the developer. For a SAML provider, this is always prefixed by `saml.`<!-- -->. For an OIDC provider, this is always prefixed by `oidc.`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+providerId: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.authproviderconfigfilter.md
+++ b/docgen/markdown/firebase-admin.auth.authproviderconfigfilter.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AuthProviderConfigFilter interface{% endblock title %}
+{% block body %}
+The filter interface used for listing provider configurations. This is used when specifying how to list configured identity providers via .
+
+<b>Signature:</b>
+
+```typescript
+export interface AuthProviderConfigFilter 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [maxResults](./firebase-admin.auth.authproviderconfigfilter.md#authproviderconfigfiltermaxresults) | number | The maximum number of results to return per page. The default and maximum is 100. |
+|  [pageToken](./firebase-admin.auth.authproviderconfigfilter.md#authproviderconfigfilterpagetoken) | string | The next page token. When not specified, the lookup starts from the beginning of the list. |
+|  [type](./firebase-admin.auth.authproviderconfigfilter.md#authproviderconfigfiltertype) | 'saml' \| 'oidc' | The Auth provider configuration filter. This can be either <code>saml</code> or <code>oidc</code>. The former is used to look up SAML providers only, while the latter is used for OIDC providers. |
+
+## AuthProviderConfigFilter.maxResults
+
+The maximum number of results to return per page. The default and maximum is 100.
+
+<b>Signature:</b>
+
+```typescript
+maxResults?: number;
+```
+
+## AuthProviderConfigFilter.pageToken
+
+The next page token. When not specified, the lookup starts from the beginning of the list.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+
+## AuthProviderConfigFilter.type
+
+The Auth provider configuration filter. This can be either `saml` or `oidc`<!-- -->. The former is used to look up SAML providers only, while the latter is used for OIDC providers.
+
+<b>Signature:</b>
+
+```typescript
+type: 'saml' | 'oidc';
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.baseauth.md
+++ b/docgen/markdown/firebase-admin.auth.baseauth.md
@@ -1,0 +1,669 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}BaseAuth class{% endblock title %}
+{% block body %}
+Common parent interface for both `Auth` and `TenantAwareAuth` APIs.
+
+<b>Signature:</b>
+
+```typescript
+export declare abstract class BaseAuth 
+```
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [createCustomToken(uid, developerClaims)](./firebase-admin.auth.baseauth.md#baseauthcreatecustomtoken) |  | Creates a new Firebase custom token (JWT) that can be sent back to a client device to use to sign in with the client SDKs' <code>signInWithCustomToken()</code> methods. (Tenant-aware instances will also embed the tenant ID in the token.)<!-- -->See \[Create Custom Tokens\](/docs/auth/admin/create-custom-tokens) for code samples and detailed documentation. |
+|  [createProviderConfig(config)](./firebase-admin.auth.baseauth.md#baseauthcreateproviderconfig) |  | Returns a promise that resolves with the newly created <code>AuthProviderConfig</code> when the new provider configuration is created.<!-- -->SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform). |
+|  [createSessionCookie(idToken, sessionCookieOptions)](./firebase-admin.auth.baseauth.md#baseauthcreatesessioncookie) |  | Creates a new Firebase session cookie with the specified options. The created JWT string can be set as a server-side session cookie with a custom cookie policy, and be used for session management. The session cookie JWT will have the same payload claims as the provided ID token.<!-- -->See \[Manage Session Cookies\](/docs/auth/admin/manage-cookies) for code samples and detailed documentation. |
+|  [createUser(properties)](./firebase-admin.auth.baseauth.md#baseauthcreateuser) |  | Creates a new user.<!-- -->See \[Create a user\](/docs/auth/admin/manage-users\#create\_a\_user) for code samples and detailed documentation. |
+|  [deleteProviderConfig(providerId)](./firebase-admin.auth.baseauth.md#baseauthdeleteproviderconfig) |  | Deletes the provider configuration corresponding to the provider ID passed. If the specified ID does not exist, an <code>auth/configuration-not-found</code> error is thrown.<!-- -->SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform). |
+|  [deleteUser(uid)](./firebase-admin.auth.baseauth.md#baseauthdeleteuser) |  | Deletes an existing user.<!-- -->See \[Delete a user\](/docs/auth/admin/manage-users\#delete\_a\_user) for code samples and detailed documentation. |
+|  [deleteUsers(uids)](./firebase-admin.auth.baseauth.md#baseauthdeleteusers) |  | Deletes the users specified by the given uids.<!-- -->Deleting a non-existing user won't generate an error (i.e. this method is idempotent.) Non-existing users are considered to be successfully deleted, and are therefore counted in the <code>DeleteUsersResult.successCount</code> value.<!-- -->Only a maximum of 1000 identifiers may be supplied. If more than 1000 identifiers are supplied, this method throws a FirebaseAuthError.<!-- -->This API is currently rate limited at the server to 1 QPS. If you exceed this, you may get a quota exceeded error. Therefore, if you want to delete more than 1000 users, you may need to add a delay to ensure you don't go over this limit. |
+|  [generateEmailVerificationLink(email, actionCodeSettings)](./firebase-admin.auth.baseauth.md#baseauthgenerateemailverificationlink) |  | Generates the out of band email action link to verify the user's ownership of the specified email. The  object provided as an argument to this method defines whether the link is to be handled by a mobile app or browser along with additional state information to be passed in the deep link, etc. |
+|  [generatePasswordResetLink(email, actionCodeSettings)](./firebase-admin.auth.baseauth.md#baseauthgeneratepasswordresetlink) |  | Generates the out of band email action link to reset a user's password. The link is generated for the user with the specified email address. The optional  object defines whether the link is to be handled by a mobile app or browser and the additional state information to be passed in the deep link, etc. |
+|  [generateSignInWithEmailLink(email, actionCodeSettings)](./firebase-admin.auth.baseauth.md#baseauthgeneratesigninwithemaillink) |  | Generates the out of band email action link to verify the user's ownership of the specified email. The  object provided as an argument to this method defines whether the link is to be handled by a mobile app or browser along with additional state information to be passed in the deep link, etc. |
+|  [getProviderConfig(providerId)](./firebase-admin.auth.baseauth.md#baseauthgetproviderconfig) |  | Looks up an Auth provider configuration by the provided ID. Returns a promise that resolves with the provider configuration corresponding to the provider ID specified. If the specified ID does not exist, an <code>auth/configuration-not-found</code> error is thrown.<!-- -->SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform). |
+|  [getUser(uid)](./firebase-admin.auth.baseauth.md#baseauthgetuser) |  | Gets the user data for the user corresponding to a given <code>uid</code>.<!-- -->See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation. |
+|  [getUserByEmail(email)](./firebase-admin.auth.baseauth.md#baseauthgetuserbyemail) |  | Gets the user data for the user corresponding to a given email.<!-- -->See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation. |
+|  [getUserByPhoneNumber(phoneNumber)](./firebase-admin.auth.baseauth.md#baseauthgetuserbyphonenumber) |  | Gets the user data for the user corresponding to a given phone number. The phone number has to conform to the E.164 specification.<!-- -->See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation. |
+|  [getUsers(identifiers)](./firebase-admin.auth.baseauth.md#baseauthgetusers) |  | Gets the user data corresponding to the specified identifiers.<!-- -->There are no ordering guarantees; in particular, the nth entry in the result list is not guaranteed to correspond to the nth entry in the input parameters list.<!-- -->Only a maximum of 100 identifiers may be supplied. If more than 100 identifiers are supplied, this method throws a FirebaseAuthError. |
+|  [importUsers(users, options)](./firebase-admin.auth.baseauth.md#baseauthimportusers) |  | Imports the provided list of users into Firebase Auth. A maximum of 1000 users are allowed to be imported one at a time. When importing users with passwords,  are required to be specified. This operation is optimized for bulk imports and will ignore checks on <code>uid</code>, <code>email</code> and other identifier uniqueness which could result in duplications. |
+|  [listProviderConfigs(options)](./firebase-admin.auth.baseauth.md#baseauthlistproviderconfigs) |  | Returns the list of existing provider configurations matching the filter provided. At most, 100 provider configs can be listed at a time.<!-- -->SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform). |
+|  [listUsers(maxResults, pageToken)](./firebase-admin.auth.baseauth.md#baseauthlistusers) |  | Retrieves a list of users (single batch only) with a size of <code>maxResults</code> starting from the offset as specified by <code>pageToken</code>. This is used to retrieve all the users of a specified project in batches.<!-- -->See \[List all users\](/docs/auth/admin/manage-users\#list\_all\_users) for code samples and detailed documentation. |
+|  [revokeRefreshTokens(uid)](./firebase-admin.auth.baseauth.md#baseauthrevokerefreshtokens) |  | Revokes all refresh tokens for an existing user.<!-- -->This API will update the user's  to the current UTC. It is important that the server on which this is called has its clock set correctly and synchronized.<!-- -->While this will revoke all sessions for a specified user and disable any new ID tokens for existing sessions from getting minted, existing ID tokens may remain active until their natural expiration (one hour). To verify that ID tokens are revoked, use  where <code>checkRevoked</code> is set to true. |
+|  [setCustomUserClaims(uid, customUserClaims)](./firebase-admin.auth.baseauth.md#baseauthsetcustomuserclaims) |  | Sets additional developer claims on an existing user identified by the provided <code>uid</code>, typically used to define user roles and levels of access. These claims should propagate to all devices where the user is already signed in (after token expiration or when token refresh is forced) and the next time the user signs in. If a reserved OIDC claim name is used (sub, iat, iss, etc), an error is thrown. They are set on the authenticated user's ID token JWT.<!-- -->See \[Defining user roles and access levels\](/docs/auth/admin/custom-claims) for code samples and detailed documentation. |
+|  [updateProviderConfig(providerId, updatedConfig)](./firebase-admin.auth.baseauth.md#baseauthupdateproviderconfig) |  | Returns a promise that resolves with the updated <code>AuthProviderConfig</code> corresponding to the provider ID specified. If the specified ID does not exist, an <code>auth/configuration-not-found</code> error is thrown.<!-- -->SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform). |
+|  [updateUser(uid, properties)](./firebase-admin.auth.baseauth.md#baseauthupdateuser) |  | Updates an existing user.<!-- -->See \[Update a user\](/docs/auth/admin/manage-users\#update\_a\_user) for code samples and detailed documentation. |
+|  [verifyIdToken(idToken, checkRevoked)](./firebase-admin.auth.baseauth.md#baseauthverifyidtoken) |  | Verifies a Firebase ID token (JWT). If the token is valid, the promise is fulfilled with the token's decoded claims; otherwise, the promise is rejected. An optional flag can be passed to additionally check whether the ID token was revoked.<!-- -->See \[Verify ID Tokens\](/docs/auth/admin/verify-id-tokens) for code samples and detailed documentation. |
+|  [verifySessionCookie(sessionCookie, checkRevoked)](./firebase-admin.auth.baseauth.md#baseauthverifysessioncookie) |  | Verifies a Firebase session cookie. Returns a Promise with the cookie claims. Rejects the promise if the cookie could not be verified. If <code>checkRevoked</code> is set to true, verifies if the session corresponding to the session cookie was revoked. If the corresponding user's session was revoked, an <code>auth/session-cookie-revoked</code> error is thrown. If not specified the check is not performed.<!-- -->See \[Verify Session Cookies\](/docs/auth/admin/manage-cookies\#verify\_session\_cookie\_and\_check\_permissions) for code samples and detailed documentation |
+
+## BaseAuth.createCustomToken()
+
+Creates a new Firebase custom token (JWT) that can be sent back to a client device to use to sign in with the client SDKs' `signInWithCustomToken()` methods. (Tenant-aware instances will also embed the tenant ID in the token.)
+
+See \[Create Custom Tokens\](/docs/auth/admin/create-custom-tokens) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+createCustomToken(uid: string, developerClaims?: object): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> to use as the custom token's subject. |
+|  developerClaims | object | Optional additional claims to include in the custom token's payload. A promise fulfilled with a custom token for the provided <code>uid</code> and payload. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## BaseAuth.createProviderConfig()
+
+Returns a promise that resolves with the newly created `AuthProviderConfig` when the new provider configuration is created.
+
+SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform).
+
+<b>Signature:</b>
+
+```typescript
+createProviderConfig(config: AuthProviderConfig): Promise<AuthProviderConfig>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  config | [AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface) | The provider configuration to create.  A promise that resolves with the created provider configuration. |
+
+<b>Returns:</b>
+
+Promise&lt;[AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)<!-- -->&gt;
+
+## BaseAuth.createSessionCookie()
+
+Creates a new Firebase session cookie with the specified options. The created JWT string can be set as a server-side session cookie with a custom cookie policy, and be used for session management. The session cookie JWT will have the same payload claims as the provided ID token.
+
+See \[Manage Session Cookies\](/docs/auth/admin/manage-cookies) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+createSessionCookie(idToken: string, sessionCookieOptions: SessionCookieOptions): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  idToken | string | The Firebase ID token to exchange for a session cookie. |
+|  sessionCookieOptions | [SessionCookieOptions](./firebase-admin.auth.sessioncookieoptions.md#sessioncookieoptions_interface) | The session cookie options which includes custom session duration. A promise that resolves on success with the created session cookie. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## BaseAuth.createUser()
+
+Creates a new user.
+
+See \[Create a user\](/docs/auth/admin/manage-users\#create\_a\_user) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+createUser(properties: CreateRequest): Promise<UserRecord>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  properties | [CreateRequest](./firebase-admin.auth.createrequest.md#createrequest_interface) | The properties to set on the new user record to be created. A promise fulfilled with the user data corresponding to the newly created user. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->&gt;
+
+## BaseAuth.deleteProviderConfig()
+
+Deletes the provider configuration corresponding to the provider ID passed. If the specified ID does not exist, an `auth/configuration-not-found` error is thrown.
+
+SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform).
+
+<b>Signature:</b>
+
+```typescript
+deleteProviderConfig(providerId: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  providerId | string | The provider ID corresponding to the provider config to delete.  A promise that resolves on completion. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## BaseAuth.deleteUser()
+
+Deletes an existing user.
+
+See \[Delete a user\](/docs/auth/admin/manage-users\#delete\_a\_user) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+deleteUser(uid: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> corresponding to the user to delete. An empty promise fulfilled once the user has been deleted. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## BaseAuth.deleteUsers()
+
+Deletes the users specified by the given uids.
+
+Deleting a non-existing user won't generate an error (i.e. this method is idempotent.) Non-existing users are considered to be successfully deleted, and are therefore counted in the `DeleteUsersResult.successCount` value.
+
+Only a maximum of 1000 identifiers may be supplied. If more than 1000 identifiers are supplied, this method throws a FirebaseAuthError.
+
+This API is currently rate limited at the server to 1 QPS. If you exceed this, you may get a quota exceeded error. Therefore, if you want to delete more than 1000 users, you may need to add a delay to ensure you don't go over this limit.
+
+<b>Signature:</b>
+
+```typescript
+deleteUsers(uids: string[]): Promise<DeleteUsersResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uids | string\[\] | The <code>uids</code> corresponding to the users to delete. A Promise that resolves to the total number of successful/failed deletions, as well as the array of errors that corresponds to the failed deletions. |
+
+<b>Returns:</b>
+
+Promise&lt;[DeleteUsersResult](./firebase-admin.auth.deleteusersresult.md#deleteusersresult_interface)<!-- -->&gt;
+
+## BaseAuth.generateEmailVerificationLink()
+
+Generates the out of band email action link to verify the user's ownership of the specified email. The  object provided as an argument to this method defines whether the link is to be handled by a mobile app or browser along with additional state information to be passed in the deep link, etc.
+
+<b>Signature:</b>
+
+```typescript
+generateEmailVerificationLink(email: string, actionCodeSettings?: ActionCodeSettings): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  email | string | The email account to verify. |
+|  actionCodeSettings | [ActionCodeSettings](./firebase-admin.auth.actioncodesettings.md#actioncodesettings_interface) | The action code settings. If specified, the state/continue URL is set as the "continueUrl" parameter in the email verification link. The default email verification landing page will use this to display a link to go back to the app if it is installed. If the actionCodeSettings is not specified, no URL is appended to the action URL. The state URL provided must belong to a domain that is whitelisted by the developer in the console. Otherwise an error is thrown. Mobile app redirects are only applicable if the developer configures and accepts the Firebase Dynamic Links terms of service. The Android package name and iOS bundle ID are respected only if they are configured in the same Firebase Auth project.  A promise that resolves with the generated link. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+### Example
+
+
+```javascript
+var actionCodeSettings = {
+  url: 'https://www.example.com/cart?email=user@example.com&cartId=123',
+  iOS: {
+    bundleId: 'com.example.ios'
+  },
+  android: {
+    packageName: 'com.example.android',
+    installApp: true,
+    minimumVersion: '12'
+  },
+  handleCodeInApp: true,
+  dynamicLinkDomain: 'custom.page.link'
+};
+admin.auth()
+    .generateEmailVerificationLink('user@example.com', actionCodeSettings)
+    .then(function(link) {
+      // The link was successfully generated.
+    })
+    .catch(function(error) {
+      // Some error occurred, you can inspect the code: error.code
+    });
+
+```
+
+## BaseAuth.generatePasswordResetLink()
+
+Generates the out of band email action link to reset a user's password. The link is generated for the user with the specified email address. The optional  object defines whether the link is to be handled by a mobile app or browser and the additional state information to be passed in the deep link, etc.
+
+<b>Signature:</b>
+
+```typescript
+generatePasswordResetLink(email: string, actionCodeSettings?: ActionCodeSettings): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  email | string | The email address of the user whose password is to be reset. |
+|  actionCodeSettings | [ActionCodeSettings](./firebase-admin.auth.actioncodesettings.md#actioncodesettings_interface) | The action code settings. If specified, the state/continue URL is set as the "continueUrl" parameter in the password reset link. The default password reset landing page will use this to display a link to go back to the app if it is installed. If the actionCodeSettings is not specified, no URL is appended to the action URL. The state URL provided must belong to a domain that is whitelisted by the developer in the console. Otherwise an error is thrown. Mobile app redirects are only applicable if the developer configures and accepts the Firebase Dynamic Links terms of service. The Android package name and iOS bundle ID are respected only if they are configured in the same Firebase Auth project.  A promise that resolves with the generated link. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+### Example
+
+
+```javascript
+var actionCodeSettings = {
+  url: 'https://www.example.com/?email=user@example.com',
+  iOS: {
+    bundleId: 'com.example.ios'
+  },
+  android: {
+    packageName: 'com.example.android',
+    installApp: true,
+    minimumVersion: '12'
+  },
+  handleCodeInApp: true,
+  dynamicLinkDomain: 'custom.page.link'
+};
+admin.auth()
+    .generatePasswordResetLink('user@example.com', actionCodeSettings)
+    .then(function(link) {
+      // The link was successfully generated.
+    })
+    .catch(function(error) {
+      // Some error occurred, you can inspect the code: error.code
+    });
+
+```
+
+## BaseAuth.generateSignInWithEmailLink()
+
+Generates the out of band email action link to verify the user's ownership of the specified email. The  object provided as an argument to this method defines whether the link is to be handled by a mobile app or browser along with additional state information to be passed in the deep link, etc.
+
+<b>Signature:</b>
+
+```typescript
+generateSignInWithEmailLink(email: string, actionCodeSettings: ActionCodeSettings): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  email | string | The email account to verify. |
+|  actionCodeSettings | [ActionCodeSettings](./firebase-admin.auth.actioncodesettings.md#actioncodesettings_interface) | The action code settings. If specified, the state/continue URL is set as the "continueUrl" parameter in the email verification link. The default email verification landing page will use this to display a link to go back to the app if it is installed. If the actionCodeSettings is not specified, no URL is appended to the action URL. The state URL provided must belong to a domain that is whitelisted by the developer in the console. Otherwise an error is thrown. Mobile app redirects are only applicable if the developer configures and accepts the Firebase Dynamic Links terms of service. The Android package name and iOS bundle ID are respected only if they are configured in the same Firebase Auth project.  A promise that resolves with the generated link. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+### Example
+
+
+```javascript
+var actionCodeSettings = {
+  url: 'https://www.example.com/cart?email=user@example.com&cartId=123',
+  iOS: {
+    bundleId: 'com.example.ios'
+  },
+  android: {
+    packageName: 'com.example.android',
+    installApp: true,
+    minimumVersion: '12'
+  },
+  handleCodeInApp: true,
+  dynamicLinkDomain: 'custom.page.link'
+};
+admin.auth()
+    .generateEmailVerificationLink('user@example.com', actionCodeSettings)
+    .then(function(link) {
+      // The link was successfully generated.
+    })
+    .catch(function(error) {
+      // Some error occurred, you can inspect the code: error.code
+    });
+
+```
+
+## BaseAuth.getProviderConfig()
+
+Looks up an Auth provider configuration by the provided ID. Returns a promise that resolves with the provider configuration corresponding to the provider ID specified. If the specified ID does not exist, an `auth/configuration-not-found` error is thrown.
+
+SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform).
+
+<b>Signature:</b>
+
+```typescript
+getProviderConfig(providerId: string): Promise<AuthProviderConfig>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  providerId | string | The provider ID corresponding to the provider config to return.  A promise that resolves with the configuration corresponding to the provided ID. |
+
+<b>Returns:</b>
+
+Promise&lt;[AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)<!-- -->&gt;
+
+## BaseAuth.getUser()
+
+Gets the user data for the user corresponding to a given `uid`<!-- -->.
+
+See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+getUser(uid: string): Promise<UserRecord>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> corresponding to the user whose data to fetch. A promise fulfilled with the user data corresponding to the provided <code>uid</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->&gt;
+
+## BaseAuth.getUserByEmail()
+
+Gets the user data for the user corresponding to a given email.
+
+See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+getUserByEmail(email: string): Promise<UserRecord>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  email | string | The email corresponding to the user whose data to fetch. A promise fulfilled with the user data corresponding to the provided email. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->&gt;
+
+## BaseAuth.getUserByPhoneNumber()
+
+Gets the user data for the user corresponding to a given phone number. The phone number has to conform to the E.164 specification.
+
+See \[Retrieve user data\](/docs/auth/admin/manage-users\#retrieve\_user\_data) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+getUserByPhoneNumber(phoneNumber: string): Promise<UserRecord>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  phoneNumber | string | The phone number corresponding to the user whose data to fetch. A promise fulfilled with the user data corresponding to the provided phone number. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->&gt;
+
+## BaseAuth.getUsers()
+
+Gets the user data corresponding to the specified identifiers.
+
+There are no ordering guarantees; in particular, the nth entry in the result list is not guaranteed to correspond to the nth entry in the input parameters list.
+
+Only a maximum of 100 identifiers may be supplied. If more than 100 identifiers are supplied, this method throws a FirebaseAuthError.
+
+<b>Signature:</b>
+
+```typescript
+getUsers(identifiers: UserIdentifier[]): Promise<GetUsersResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  identifiers | [UserIdentifier](./firebase-admin.auth.md#useridentifier)<!-- -->\[\] | The identifiers used to indicate which user records should be returned. Must have &lt;<!-- -->= 100 entries.  {<!-- -->Promise<GetUsersResult>} A promise that resolves to the corresponding user records. |
+
+<b>Returns:</b>
+
+Promise&lt;[GetUsersResult](./firebase-admin.auth.getusersresult.md#getusersresult_interface)<!-- -->&gt;
+
+## Exceptions
+
+FirebaseAuthError If any of the identifiers are invalid or if more than 100 identifiers are specified.
+
+## BaseAuth.importUsers()
+
+Imports the provided list of users into Firebase Auth. A maximum of 1000 users are allowed to be imported one at a time. When importing users with passwords,  are required to be specified. This operation is optimized for bulk imports and will ignore checks on `uid`<!-- -->, `email` and other identifier uniqueness which could result in duplications.
+
+<b>Signature:</b>
+
+```typescript
+importUsers(users: UserImportRecord[], options?: UserImportOptions): Promise<UserImportResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  users | [UserImportRecord](./firebase-admin.auth.userimportrecord.md#userimportrecord_interface)<!-- -->\[\] | The list of user records to import to Firebase Auth. |
+|  options | [UserImportOptions](./firebase-admin.auth.userimportoptions.md#userimportoptions_interface) | The user import options, required when the users provided include password credentials.  A promise that resolves when the operation completes with the result of the import. This includes the number of successful imports, the number of failed imports and their corresponding errors. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserImportResult](./firebase-admin.auth.userimportresult.md#userimportresult_interface)<!-- -->&gt;
+
+## BaseAuth.listProviderConfigs()
+
+Returns the list of existing provider configurations matching the filter provided. At most, 100 provider configs can be listed at a time.
+
+SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform).
+
+<b>Signature:</b>
+
+```typescript
+listProviderConfigs(options: AuthProviderConfigFilter): Promise<ListProviderConfigResults>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  options | [AuthProviderConfigFilter](./firebase-admin.auth.authproviderconfigfilter.md#authproviderconfigfilter_interface) | The provider config filter to apply.  A promise that resolves with the list of provider configs meeting the filter requirements. |
+
+<b>Returns:</b>
+
+Promise&lt;[ListProviderConfigResults](./firebase-admin.auth.listproviderconfigresults.md#listproviderconfigresults_interface)<!-- -->&gt;
+
+## BaseAuth.listUsers()
+
+Retrieves a list of users (single batch only) with a size of `maxResults` starting from the offset as specified by `pageToken`<!-- -->. This is used to retrieve all the users of a specified project in batches.
+
+See \[List all users\](/docs/auth/admin/manage-users\#list\_all\_users) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+listUsers(maxResults?: number, pageToken?: string): Promise<ListUsersResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  maxResults | number | The page size, 1000 if undefined. This is also the maximum allowed limit. |
+|  pageToken | string | The next page token. If not specified, returns users starting without any offset.  A promise that resolves with the current batch of downloaded users and the next page token. |
+
+<b>Returns:</b>
+
+Promise&lt;[ListUsersResult](./firebase-admin.auth.listusersresult.md#listusersresult_interface)<!-- -->&gt;
+
+## BaseAuth.revokeRefreshTokens()
+
+Revokes all refresh tokens for an existing user.
+
+This API will update the user's  to the current UTC. It is important that the server on which this is called has its clock set correctly and synchronized.
+
+While this will revoke all sessions for a specified user and disable any new ID tokens for existing sessions from getting minted, existing ID tokens may remain active until their natural expiration (one hour). To verify that ID tokens are revoked, use  where `checkRevoked` is set to true.
+
+<b>Signature:</b>
+
+```typescript
+revokeRefreshTokens(uid: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> corresponding to the user whose refresh tokens are to be revoked. An empty promise fulfilled once the user's refresh tokens have been revoked. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## BaseAuth.setCustomUserClaims()
+
+Sets additional developer claims on an existing user identified by the provided `uid`<!-- -->, typically used to define user roles and levels of access. These claims should propagate to all devices where the user is already signed in (after token expiration or when token refresh is forced) and the next time the user signs in. If a reserved OIDC claim name is used (sub, iat, iss, etc), an error is thrown. They are set on the authenticated user's ID token JWT.
+
+See \[Defining user roles and access levels\](/docs/auth/admin/custom-claims) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> of the user to edit. |
+|  customUserClaims | object \| null | The developer claims to set. If null is passed, existing custom claims are deleted. Passing a custom claims payload larger than 1000 bytes will throw an error. Custom claims are added to the user's ID token which is transmitted on every authenticated request. For profile non-access related user attributes, use database or other separate storage systems.  A promise that resolves when the operation completes successfully. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## BaseAuth.updateProviderConfig()
+
+Returns a promise that resolves with the updated `AuthProviderConfig` corresponding to the provider ID specified. If the specified ID does not exist, an `auth/configuration-not-found` error is thrown.
+
+SAML and OIDC provider support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform).
+
+<b>Signature:</b>
+
+```typescript
+updateProviderConfig(providerId: string, updatedConfig: UpdateAuthProviderRequest): Promise<AuthProviderConfig>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  providerId | string | The provider ID corresponding to the provider config to update. |
+|  updatedConfig | [UpdateAuthProviderRequest](./firebase-admin.auth.md#updateauthproviderrequest) | The updated configuration.  A promise that resolves with the updated provider configuration. |
+
+<b>Returns:</b>
+
+Promise&lt;[AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)<!-- -->&gt;
+
+## BaseAuth.updateUser()
+
+Updates an existing user.
+
+See \[Update a user\](/docs/auth/admin/manage-users\#update\_a\_user) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  uid | string | The <code>uid</code> corresponding to the user to update. |
+|  properties | [UpdateRequest](./firebase-admin.auth.updaterequest.md#updaterequest_interface) | The properties to update on the provided user. A promise fulfilled with the updated user data. |
+
+<b>Returns:</b>
+
+Promise&lt;[UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->&gt;
+
+## BaseAuth.verifyIdToken()
+
+Verifies a Firebase ID token (JWT). If the token is valid, the promise is fulfilled with the token's decoded claims; otherwise, the promise is rejected. An optional flag can be passed to additionally check whether the ID token was revoked.
+
+See \[Verify ID Tokens\](/docs/auth/admin/verify-id-tokens) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  idToken | string | The ID token to verify. |
+|  checkRevoked | boolean | Whether to check if the ID token was revoked. This requires an extra request to the Firebase Auth backend to check the <code>tokensValidAfterTime</code> time for the corresponding user. When not specified, this additional check is not applied. A promise fulfilled with the token's decoded claims if the ID token is valid; otherwise, a rejected promise. |
+
+<b>Returns:</b>
+
+Promise&lt;[DecodedIdToken](./firebase-admin.auth.decodedidtoken.md#decodedidtoken_interface)<!-- -->&gt;
+
+## BaseAuth.verifySessionCookie()
+
+Verifies a Firebase session cookie. Returns a Promise with the cookie claims. Rejects the promise if the cookie could not be verified. If `checkRevoked` is set to true, verifies if the session corresponding to the session cookie was revoked. If the corresponding user's session was revoked, an `auth/session-cookie-revoked` error is thrown. If not specified the check is not performed.
+
+See \[Verify Session Cookies\](/docs/auth/admin/manage-cookies\#verify\_session\_cookie\_and\_check\_permissions) for code samples and detailed documentation
+
+<b>Signature:</b>
+
+```typescript
+verifySessionCookie(sessionCookie: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  sessionCookie | string | The session cookie to verify. |
+|  checkRevoked | boolean |  |
+
+<b>Returns:</b>
+
+Promise&lt;[DecodedIdToken](./firebase-admin.auth.decodedidtoken.md#decodedidtoken_interface)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.createmultifactorinforequest.md
+++ b/docgen/markdown/firebase-admin.auth.createmultifactorinforequest.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}CreateMultiFactorInfoRequest interface{% endblock title %}
+{% block body %}
+Interface representing base properties of a user enrolled second factor for a `CreateRequest`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export interface CreateMultiFactorInfoRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.auth.createmultifactorinforequest.md#createmultifactorinforequestdisplayname) | string | The optional display name for an enrolled second factor. |
+|  [factorId](./firebase-admin.auth.createmultifactorinforequest.md#createmultifactorinforequestfactorid) | string | The type identifier of the second factor. For SMS second factors, this is <code>phone</code>. |
+
+## CreateMultiFactorInfoRequest.displayName
+
+The optional display name for an enrolled second factor.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## CreateMultiFactorInfoRequest.factorId
+
+The type identifier of the second factor. For SMS second factors, this is `phone`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+factorId: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.createphonemultifactorinforequest.md
+++ b/docgen/markdown/firebase-admin.auth.createphonemultifactorinforequest.md
@@ -1,0 +1,28 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}CreatePhoneMultiFactorInfoRequest interface{% endblock title %}
+{% block body %}
+Interface representing a phone specific user enrolled second factor for a `CreateRequest`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export interface CreatePhoneMultiFactorInfoRequest extends CreateMultiFactorInfoRequest 
+```
+<b>Extends:</b> [CreateMultiFactorInfoRequest](./firebase-admin.auth.createmultifactorinforequest.md#createmultifactorinforequest_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [phoneNumber](./firebase-admin.auth.createphonemultifactorinforequest.md#createphonemultifactorinforequestphonenumber) | string | The phone number associated with a phone second factor. |
+
+## CreatePhoneMultiFactorInfoRequest.phoneNumber
+
+The phone number associated with a phone second factor.
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.createrequest.md
+++ b/docgen/markdown/firebase-admin.auth.createrequest.md
@@ -1,0 +1,39 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}CreateRequest interface{% endblock title %}
+{% block body %}
+Interface representing the properties to set on a new user record to be created.
+
+<b>Signature:</b>
+
+```typescript
+export interface CreateRequest extends UpdateRequest 
+```
+<b>Extends:</b> [UpdateRequest](./firebase-admin.auth.updaterequest.md#updaterequest_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [multiFactor](./firebase-admin.auth.createrequest.md#createrequestmultifactor) | [MultiFactorCreateSettings](./firebase-admin.auth.multifactorcreatesettings.md#multifactorcreatesettings_interface) | The user's multi-factor related properties. |
+|  [uid](./firebase-admin.auth.createrequest.md#createrequestuid) | string | The user's <code>uid</code>. |
+
+## CreateRequest.multiFactor
+
+The user's multi-factor related properties.
+
+<b>Signature:</b>
+
+```typescript
+multiFactor?: MultiFactorCreateSettings;
+```
+
+## CreateRequest.uid
+
+The user's `uid`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+uid?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.decodedidtoken.md
+++ b/docgen/markdown/firebase-admin.auth.decodedidtoken.md
@@ -1,0 +1,175 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}DecodedIdToken interface{% endblock title %}
+{% block body %}
+Interface representing a decoded Firebase ID token, returned from the  method.
+
+Firebase ID tokens are OpenID Connect spec-compliant JSON Web Tokens (JWTs). See the \[ID Token section of the OpenID Connect spec\](http://openid.net/specs/openid-connect-core-1\_0.html\#IDToken) for more information about the specific properties below.
+
+<b>Signature:</b>
+
+```typescript
+export interface DecodedIdToken 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [aud](./firebase-admin.auth.decodedidtoken.md#decodedidtokenaud) | string | The audience for which this token is intended.<!-- -->This value is a string equal to your Firebase project ID, the unique identifier for your Firebase project, which can be found in \[your project's settings\](https://console.firebase.google.com/project/\_/settings/general/android:com.random.android). |
+|  [auth\_time](./firebase-admin.auth.decodedidtoken.md#decodedidtokenauth_time) | number | Time, in seconds since the Unix epoch, when the end-user authentication occurred.<!-- -->This value is not set when this particular ID token was created, but when the user initially logged in to this session. In a single session, the Firebase SDKs will refresh a user's ID tokens every hour. Each ID token will have a different \[<code>iat</code>\](\#iat) value, but the same <code>auth_time</code> value. |
+|  [email\_verified](./firebase-admin.auth.decodedidtoken.md#decodedidtokenemail_verified) | boolean | Whether or not the email of the user to whom the ID token belongs is verified, provided the user has an email. |
+|  [email](./firebase-admin.auth.decodedidtoken.md#decodedidtokenemail) | string | The email of the user to whom the ID token belongs, if available. |
+|  [exp](./firebase-admin.auth.decodedidtoken.md#decodedidtokenexp) | number | The ID token's expiration time, in seconds since the Unix epoch. That is, the time at which this ID token expires and should no longer be considered valid.<!-- -->The Firebase SDKs transparently refresh ID tokens every hour, issuing a new ID token with up to a one hour expiration. |
+|  [firebase](./firebase-admin.auth.decodedidtoken.md#decodedidtokenfirebase) | { identities: { \[key: string\]: any; }; sign\_in\_provider: string; sign\_in\_second\_factor?: string; second\_factor\_identifier?: string; tenant?: string; \[key: string\]: any; } | Information about the sign in event, including which sign in provider was used and provider-specific identity details.<!-- -->This data is provided by the Firebase Authentication service and is a reserved claim in the ID token. |
+|  [iat](./firebase-admin.auth.decodedidtoken.md#decodedidtokeniat) | number | The ID token's issued-at time, in seconds since the Unix epoch. That is, the time at which this ID token was issued and should start to be considered valid.<!-- -->The Firebase SDKs transparently refresh ID tokens every hour, issuing a new ID token with a new issued-at time. If you want to get the time at which the user session corresponding to the ID token initially occurred, see the \[<code>auth_time</code>\](\#auth\_time) property. |
+|  [iss](./firebase-admin.auth.decodedidtoken.md#decodedidtokeniss) | string | The issuer identifier for the issuer of the response.<!-- -->This value is a URL with the format <code>https://securetoken.google.com/&lt;PROJECT_ID&gt;</code>, where <code>&lt;PROJECT_ID&gt;</code> is the same project ID specified in the \[<code>aud</code>\](\#aud) property. |
+|  [phone\_number](./firebase-admin.auth.decodedidtoken.md#decodedidtokenphone_number) | string | The phone number of the user to whom the ID token belongs, if available. |
+|  [picture](./firebase-admin.auth.decodedidtoken.md#decodedidtokenpicture) | string | The photo URL for the user to whom the ID token belongs, if available. |
+|  [sub](./firebase-admin.auth.decodedidtoken.md#decodedidtokensub) | string | The <code>uid</code> corresponding to the user who the ID token belonged to.<!-- -->As a convenience, this value is copied over to the \[<code>uid</code>\](\#uid) property. |
+|  [uid](./firebase-admin.auth.decodedidtoken.md#decodedidtokenuid) | string | The <code>uid</code> corresponding to the user who the ID token belonged to.<!-- -->This value is not actually in the JWT token claims itself. It is added as a convenience, and is set as the value of the \[<code>sub</code>\](\#sub) property. |
+
+## DecodedIdToken.aud
+
+The audience for which this token is intended.
+
+This value is a string equal to your Firebase project ID, the unique identifier for your Firebase project, which can be found in \[your project's settings\](https://console.firebase.google.com/project/\_/settings/general/android:com.random.android).
+
+<b>Signature:</b>
+
+```typescript
+aud: string;
+```
+
+## DecodedIdToken.auth\_time
+
+Time, in seconds since the Unix epoch, when the end-user authentication occurred.
+
+This value is not set when this particular ID token was created, but when the user initially logged in to this session. In a single session, the Firebase SDKs will refresh a user's ID tokens every hour. Each ID token will have a different \[`iat`<!-- -->\](\#iat) value, but the same `auth_time` value.
+
+<b>Signature:</b>
+
+```typescript
+auth_time: number;
+```
+
+## DecodedIdToken.email\_verified
+
+Whether or not the email of the user to whom the ID token belongs is verified, provided the user has an email.
+
+<b>Signature:</b>
+
+```typescript
+email_verified?: boolean;
+```
+
+## DecodedIdToken.email
+
+The email of the user to whom the ID token belongs, if available.
+
+<b>Signature:</b>
+
+```typescript
+email?: string;
+```
+
+## DecodedIdToken.exp
+
+The ID token's expiration time, in seconds since the Unix epoch. That is, the time at which this ID token expires and should no longer be considered valid.
+
+The Firebase SDKs transparently refresh ID tokens every hour, issuing a new ID token with up to a one hour expiration.
+
+<b>Signature:</b>
+
+```typescript
+exp: number;
+```
+
+## DecodedIdToken.firebase
+
+Information about the sign in event, including which sign in provider was used and provider-specific identity details.
+
+This data is provided by the Firebase Authentication service and is a reserved claim in the ID token.
+
+<b>Signature:</b>
+
+```typescript
+firebase: {
+        identities: {
+            [key: string]: any;
+        };
+        sign_in_provider: string;
+        sign_in_second_factor?: string;
+        second_factor_identifier?: string;
+        tenant?: string;
+        [key: string]: any;
+    };
+```
+
+## DecodedIdToken.iat
+
+The ID token's issued-at time, in seconds since the Unix epoch. That is, the time at which this ID token was issued and should start to be considered valid.
+
+The Firebase SDKs transparently refresh ID tokens every hour, issuing a new ID token with a new issued-at time. If you want to get the time at which the user session corresponding to the ID token initially occurred, see the \[`auth_time`<!-- -->\](\#auth\_time) property.
+
+<b>Signature:</b>
+
+```typescript
+iat: number;
+```
+
+## DecodedIdToken.iss
+
+The issuer identifier for the issuer of the response.
+
+This value is a URL with the format `https://securetoken.google.com/<PROJECT_ID>`<!-- -->, where `<PROJECT_ID>` is the same project ID specified in the \[`aud`<!-- -->\](\#aud) property.
+
+<b>Signature:</b>
+
+```typescript
+iss: string;
+```
+
+## DecodedIdToken.phone\_number
+
+The phone number of the user to whom the ID token belongs, if available.
+
+<b>Signature:</b>
+
+```typescript
+phone_number?: string;
+```
+
+## DecodedIdToken.picture
+
+The photo URL for the user to whom the ID token belongs, if available.
+
+<b>Signature:</b>
+
+```typescript
+picture?: string;
+```
+
+## DecodedIdToken.sub
+
+The `uid` corresponding to the user who the ID token belonged to.
+
+As a convenience, this value is copied over to the \[`uid`<!-- -->\](\#uid) property.
+
+<b>Signature:</b>
+
+```typescript
+sub: string;
+```
+
+## DecodedIdToken.uid
+
+The `uid` corresponding to the user who the ID token belonged to.
+
+This value is not actually in the JWT token claims itself. It is added as a convenience, and is set as the value of the \[`sub`<!-- -->\](\#sub) property.
+
+<b>Signature:</b>
+
+```typescript
+uid: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.deleteusersresult.md
+++ b/docgen/markdown/firebase-admin.auth.deleteusersresult.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}DeleteUsersResult interface{% endblock title %}
+{% block body %}
+Represents the result of the  API.
+
+<b>Signature:</b>
+
+```typescript
+export interface DeleteUsersResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [errors](./firebase-admin.auth.deleteusersresult.md#deleteusersresulterrors) | FirebaseArrayIndexError\[\] | A list of <code>FirebaseArrayIndexError</code> instances describing the errors that were encountered during the deletion. Length of this list is equal to the return value of \[<code>failureCount</code>\](\#failureCount). |
+|  [failureCount](./firebase-admin.auth.deleteusersresult.md#deleteusersresultfailurecount) | number | The number of user records that failed to be deleted (possibly zero). |
+|  [successCount](./firebase-admin.auth.deleteusersresult.md#deleteusersresultsuccesscount) | number | The number of users that were deleted successfully (possibly zero). Users that did not exist prior to calling <code>deleteUsers()</code> are considered to be successfully deleted. |
+
+## DeleteUsersResult.errors
+
+A list of `FirebaseArrayIndexError` instances describing the errors that were encountered during the deletion. Length of this list is equal to the return value of \[`failureCount`<!-- -->\](\#failureCount).
+
+<b>Signature:</b>
+
+```typescript
+errors: FirebaseArrayIndexError[];
+```
+
+## DeleteUsersResult.failureCount
+
+The number of user records that failed to be deleted (possibly zero).
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## DeleteUsersResult.successCount
+
+The number of users that were deleted successfully (possibly zero). Users that did not exist prior to calling `deleteUsers()` are considered to be successfully deleted.
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.emailidentifier.md
+++ b/docgen/markdown/firebase-admin.auth.emailidentifier.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}EmailIdentifier interface{% endblock title %}
+{% block body %}
+Used for looking up an account by email.
+
+See `auth.getUsers()`
+
+<b>Signature:</b>
+
+```typescript
+export interface EmailIdentifier 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [email](./firebase-admin.auth.emailidentifier.md#emailidentifieremail) | string |  |
+
+## EmailIdentifier.email
+
+<b>Signature:</b>
+
+```typescript
+email: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.emailsigninproviderconfig.md
+++ b/docgen/markdown/firebase-admin.auth.emailsigninproviderconfig.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}EmailSignInProviderConfig interface{% endblock title %}
+{% block body %}
+The email sign in provider configuration.
+
+<b>Signature:</b>
+
+```typescript
+export interface EmailSignInProviderConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [enabled](./firebase-admin.auth.emailsigninproviderconfig.md#emailsigninproviderconfigenabled) | boolean | Whether email provider is enabled. |
+|  [passwordRequired](./firebase-admin.auth.emailsigninproviderconfig.md#emailsigninproviderconfigpasswordrequired) | boolean | Whether password is required for email sign-in. When not required, email sign-in can be performed with password or via email link sign-in. |
+
+## EmailSignInProviderConfig.enabled
+
+Whether email provider is enabled.
+
+<b>Signature:</b>
+
+```typescript
+enabled: boolean;
+```
+
+## EmailSignInProviderConfig.passwordRequired
+
+Whether password is required for email sign-in. When not required, email sign-in can be performed with password or via email link sign-in.
+
+<b>Signature:</b>
+
+```typescript
+passwordRequired?: boolean;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.getusersresult.md
+++ b/docgen/markdown/firebase-admin.auth.getusersresult.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}GetUsersResult interface{% endblock title %}
+{% block body %}
+Represents the result of the  API.
+
+<b>Signature:</b>
+
+```typescript
+export interface GetUsersResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [notFound](./firebase-admin.auth.getusersresult.md#getusersresultnotfound) | [UserIdentifier](./firebase-admin.auth.md#useridentifier)<!-- -->\[\] | Set of identifiers that were requested, but not found. |
+|  [users](./firebase-admin.auth.getusersresult.md#getusersresultusers) | [UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->\[\] | Set of user records, corresponding to the set of users that were requested. Only users that were found are listed here. The result set is unordered. |
+
+## GetUsersResult.notFound
+
+Set of identifiers that were requested, but not found.
+
+<b>Signature:</b>
+
+```typescript
+notFound: UserIdentifier[];
+```
+
+## GetUsersResult.users
+
+Set of user records, corresponding to the set of users that were requested. Only users that were found are listed here. The result set is unordered.
+
+<b>Signature:</b>
+
+```typescript
+users: UserRecord[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.listproviderconfigresults.md
+++ b/docgen/markdown/firebase-admin.auth.listproviderconfigresults.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListProviderConfigResults interface{% endblock title %}
+{% block body %}
+The response interface for listing provider configs. This is only available when listing all identity providers' configurations via .
+
+<b>Signature:</b>
+
+```typescript
+export interface ListProviderConfigResults 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [pageToken](./firebase-admin.auth.listproviderconfigresults.md#listproviderconfigresultspagetoken) | string | The next page token, if available. |
+|  [providerConfigs](./firebase-admin.auth.listproviderconfigresults.md#listproviderconfigresultsproviderconfigs) | [AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)<!-- -->\[\] | The list of providers for the specified type in the current page. |
+
+## ListProviderConfigResults.pageToken
+
+The next page token, if available.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+
+## ListProviderConfigResults.providerConfigs
+
+The list of providers for the specified type in the current page.
+
+<b>Signature:</b>
+
+```typescript
+providerConfigs: AuthProviderConfig[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.listtenantsresult.md
+++ b/docgen/markdown/firebase-admin.auth.listtenantsresult.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListTenantsResult interface{% endblock title %}
+{% block body %}
+Interface representing the object returned from a  operation. Contains the list of tenants for the current batch and the next page token if available.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListTenantsResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [pageToken](./firebase-admin.auth.listtenantsresult.md#listtenantsresultpagetoken) | string | The next page token if available. This is needed for the next batch download. |
+|  [tenants](./firebase-admin.auth.listtenantsresult.md#listtenantsresulttenants) | [Tenant](./firebase-admin.auth.tenant.md#tenant_class)<!-- -->\[\] | The list of  objects for the downloaded batch. |
+
+## ListTenantsResult.pageToken
+
+The next page token if available. This is needed for the next batch download.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+
+## ListTenantsResult.tenants
+
+The list of  objects for the downloaded batch.
+
+<b>Signature:</b>
+
+```typescript
+tenants: Tenant[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.listusersresult.md
+++ b/docgen/markdown/firebase-admin.auth.listusersresult.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListUsersResult interface{% endblock title %}
+{% block body %}
+Interface representing the object returned from a  operation. Contains the list of users for the current batch and the next page token if available.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListUsersResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [pageToken](./firebase-admin.auth.listusersresult.md#listusersresultpagetoken) | string | The next page token if available. This is needed for the next batch download. |
+|  [users](./firebase-admin.auth.listusersresult.md#listusersresultusers) | [UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class)<!-- -->\[\] | The list of  objects for the current downloaded batch. |
+
+## ListUsersResult.pageToken
+
+The next page token if available. This is needed for the next batch download.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+
+## ListUsersResult.users
+
+The list of  objects for the current downloaded batch.
+
+<b>Signature:</b>
+
+```typescript
+users: UserRecord[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.md
+++ b/docgen/markdown/firebase-admin.auth.md
@@ -1,0 +1,172 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.auth package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [Auth](./firebase-admin.auth.auth.md#auth_class) | Auth service bound to the provided app. An Auth instance can have multiple tenants. |
+|  [BaseAuth](./firebase-admin.auth.baseauth.md#baseauth_class) | Common parent interface for both <code>Auth</code> and <code>TenantAwareAuth</code> APIs. |
+|  [MultiFactorInfo](./firebase-admin.auth.multifactorinfo.md#multifactorinfo_class) | Interface representing the common properties of a user enrolled second factor. |
+|  [MultiFactorSettings](./firebase-admin.auth.multifactorsettings.md#multifactorsettings_class) | The multi-factor related user settings. |
+|  [PhoneMultiFactorInfo](./firebase-admin.auth.phonemultifactorinfo.md#phonemultifactorinfo_class) | Interface representing a phone specific user enrolled second factor. |
+|  [Tenant](./firebase-admin.auth.tenant.md#tenant_class) | Represents a tenant configuration.<!-- -->Multi-tenancy support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform)<!-- -->Before multi-tenancy can be used on a Google Cloud Identity Platform project, tenants must be allowed on that project via the Cloud Console UI.<!-- -->A tenant configuration provides information such as the display name, tenant identifier and email authentication configuration. For OIDC/SAML provider configuration management, <code>TenantAwareAuth</code> instances should be used instead of a <code>Tenant</code> to retrieve the list of configured IdPs on a tenant. When configuring these providers, note that tenants will inherit whitelisted domains and authenticated redirect URIs of their parent project.<!-- -->All other settings of a tenant will also be inherited. These will need to be managed from the Cloud Console UI. |
+|  [TenantAwareAuth](./firebase-admin.auth.tenantawareauth.md#tenantawareauth_class) | Tenant-aware <code>Auth</code> interface used for managing users, configuring SAML/OIDC providers, generating email links for password reset, email verification, etc for specific tenants.<!-- -->Multi-tenancy support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform)<!-- -->Each tenant contains its own identity providers, settings and sets of users. Using <code>TenantAwareAuth</code>, users for a specific tenant and corresponding OIDC/SAML configurations can also be managed, ID tokens for users signed in to a specific tenant can be verified, and email action links can also be generated for users belonging to the tenant.<code>TenantAwareAuth</code> instances for a specific <code>tenantId</code> can be instantiated by calling <code>auth.tenantManager().authForTenant(tenantId)</code>. |
+|  [TenantManager](./firebase-admin.auth.tenantmanager.md#tenantmanager_class) | Defines the tenant manager used to help manage tenant related operations. This includes: <ul> <li>The ability to create, update, list, get and delete tenants for the underlying project.</li> <li>Getting a <code>TenantAwareAuth</code> instance for running Auth related operations (user management, provider configuration management, token verification, email link generation, etc) in the context of a specified tenant.</li> </ul> |
+|  [UserInfo](./firebase-admin.auth.userinfo.md#userinfo_class) | Represents a user's info from a third-party identity provider such as Google or Facebook. |
+|  [UserMetadata](./firebase-admin.auth.usermetadata.md#usermetadata_class) | Represents a user's metadata. |
+|  [UserRecord](./firebase-admin.auth.userrecord.md#userrecord_class) | Represents a user. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getAuth(app)](./firebase-admin.auth.md#getauth) | Gets the  service for the default app or a given app.<code>getAuth()</code> can be called with no arguments to access the default app's  service or as <code>getAuth(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [ActionCodeSettings](./firebase-admin.auth.actioncodesettings.md#actioncodesettings_interface) | This is the interface that defines the required continue/state URL with optional Android and iOS bundle identifiers. |
+|  [AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface) | The base Auth provider configuration interface. |
+|  [AuthProviderConfigFilter](./firebase-admin.auth.authproviderconfigfilter.md#authproviderconfigfilter_interface) | The filter interface used for listing provider configurations. This is used when specifying how to list configured identity providers via . |
+|  [CreateMultiFactorInfoRequest](./firebase-admin.auth.createmultifactorinforequest.md#createmultifactorinforequest_interface) | Interface representing base properties of a user enrolled second factor for a <code>CreateRequest</code>. |
+|  [CreatePhoneMultiFactorInfoRequest](./firebase-admin.auth.createphonemultifactorinforequest.md#createphonemultifactorinforequest_interface) | Interface representing a phone specific user enrolled second factor for a <code>CreateRequest</code>. |
+|  [CreateRequest](./firebase-admin.auth.createrequest.md#createrequest_interface) | Interface representing the properties to set on a new user record to be created. |
+|  [DecodedIdToken](./firebase-admin.auth.decodedidtoken.md#decodedidtoken_interface) | Interface representing a decoded Firebase ID token, returned from the  method.<!-- -->Firebase ID tokens are OpenID Connect spec-compliant JSON Web Tokens (JWTs). See the \[ID Token section of the OpenID Connect spec\](http://openid.net/specs/openid-connect-core-1\_0.html\#IDToken) for more information about the specific properties below. |
+|  [DeleteUsersResult](./firebase-admin.auth.deleteusersresult.md#deleteusersresult_interface) | Represents the result of the  API. |
+|  [EmailIdentifier](./firebase-admin.auth.emailidentifier.md#emailidentifier_interface) | Used for looking up an account by email.<!-- -->See <code>auth.getUsers()</code> |
+|  [EmailSignInProviderConfig](./firebase-admin.auth.emailsigninproviderconfig.md#emailsigninproviderconfig_interface) | The email sign in provider configuration. |
+|  [GetUsersResult](./firebase-admin.auth.getusersresult.md#getusersresult_interface) | Represents the result of the  API. |
+|  [ListProviderConfigResults](./firebase-admin.auth.listproviderconfigresults.md#listproviderconfigresults_interface) | The response interface for listing provider configs. This is only available when listing all identity providers' configurations via . |
+|  [ListTenantsResult](./firebase-admin.auth.listtenantsresult.md#listtenantsresult_interface) | Interface representing the object returned from a  operation. Contains the list of tenants for the current batch and the next page token if available. |
+|  [ListUsersResult](./firebase-admin.auth.listusersresult.md#listusersresult_interface) | Interface representing the object returned from a  operation. Contains the list of users for the current batch and the next page token if available. |
+|  [MultiFactorConfig](./firebase-admin.auth.multifactorconfig.md#multifactorconfig_interface) | Interface representing a multi-factor configuration. This can be used to define whether multi-factor authentication is enabled or disabled and the list of second factor challenges that are supported. |
+|  [MultiFactorCreateSettings](./firebase-admin.auth.multifactorcreatesettings.md#multifactorcreatesettings_interface) | The multi-factor related user settings for create operations. |
+|  [MultiFactorUpdateSettings](./firebase-admin.auth.multifactorupdatesettings.md#multifactorupdatesettings_interface) | The multi-factor related user settings for update operations. |
+|  [OIDCAuthProviderConfig](./firebase-admin.auth.oidcauthproviderconfig.md#oidcauthproviderconfig_interface) | The \[OIDC\](https://openid.net/specs/openid-connect-core-1\_0-final.html) Auth provider configuration interface. An OIDC provider can be created via . |
+|  [OIDCUpdateAuthProviderRequest](./firebase-admin.auth.oidcupdateauthproviderrequest.md#oidcupdateauthproviderrequest_interface) | The request interface for updating an OIDC Auth provider. This is used when updating an OIDC provider's configuration via . |
+|  [PhoneIdentifier](./firebase-admin.auth.phoneidentifier.md#phoneidentifier_interface) | Used for looking up an account by phone number.<!-- -->See <code>auth.getUsers()</code> |
+|  [ProviderIdentifier](./firebase-admin.auth.provideridentifier.md#provideridentifier_interface) | Used for looking up an account by federated provider.<!-- -->See <code>auth.getUsers()</code> |
+|  [SAMLAuthProviderConfig](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfig_interface) | The \[SAML\](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html) Auth provider configuration interface. A SAML provider can be created via . |
+|  [SAMLUpdateAuthProviderRequest](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequest_interface) | The request interface for updating a SAML Auth provider. This is used when updating a SAML provider's configuration via . |
+|  [SessionCookieOptions](./firebase-admin.auth.sessioncookieoptions.md#sessioncookieoptions_interface) | Interface representing the session cookie options needed for the  method. |
+|  [UidIdentifier](./firebase-admin.auth.uididentifier.md#uididentifier_interface) | Used for looking up an account by uid.<!-- -->See <code>auth.getUsers()</code> |
+|  [UpdateMultiFactorInfoRequest](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequest_interface) | Interface representing common properties of a user enrolled second factor for an <code>UpdateRequest</code>. |
+|  [UpdatePhoneMultiFactorInfoRequest](./firebase-admin.auth.updatephonemultifactorinforequest.md#updatephonemultifactorinforequest_interface) | Interface representing a phone specific user enrolled second factor for an <code>UpdateRequest</code>. |
+|  [UpdateRequest](./firebase-admin.auth.updaterequest.md#updaterequest_interface) | Interface representing the properties to update on the provided user. |
+|  [UpdateTenantRequest](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequest_interface) | Interface representing the properties to update on the provided tenant. |
+|  [UserImportOptions](./firebase-admin.auth.userimportoptions.md#userimportoptions_interface) | Interface representing the user import options needed for  method. This is used to provide the password hashing algorithm information. |
+|  [UserImportRecord](./firebase-admin.auth.userimportrecord.md#userimportrecord_interface) | Interface representing a user to import to Firebase Auth via the  method. |
+|  [UserImportResult](./firebase-admin.auth.userimportresult.md#userimportresult_interface) | Interface representing the response from the  method for batch importing users to Firebase Auth. |
+|  [UserMetadataRequest](./firebase-admin.auth.usermetadatarequest.md#usermetadatarequest_interface) | User metadata to include when importing a user. |
+|  [UserProviderRequest](./firebase-admin.auth.userproviderrequest.md#userproviderrequest_interface) | User provider data to include when importing a user. |
+
+## Type Aliases
+
+|  Type Alias | Description |
+|  --- | --- |
+|  [AuthFactorType](./firebase-admin.auth.md#authfactortype) | Identifies a second factor type. |
+|  [CreateTenantRequest](./firebase-admin.auth.md#createtenantrequest) | Interface representing the properties to set on a new tenant. |
+|  [HashAlgorithmType](./firebase-admin.auth.md#hashalgorithmtype) |  |
+|  [MultiFactorConfigState](./firebase-admin.auth.md#multifactorconfigstate) | Identifies a multi-factor configuration state. |
+|  [UpdateAuthProviderRequest](./firebase-admin.auth.md#updateauthproviderrequest) |  |
+|  [UserIdentifier](./firebase-admin.auth.md#useridentifier) | Identifies a user to be looked up. |
+
+## getAuth()
+
+Gets the  service for the default app or a given app.
+
+`getAuth()` can be called with no arguments to access the default app's  service or as `getAuth(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getAuth(app?: App): Auth;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App |  |
+
+<b>Returns:</b>
+
+[Auth](./firebase-admin.auth.auth.md#auth_class)
+
+### Example 1
+
+
+```javascript
+// Get the Auth service for the default app
+const defaultAuth = getAuth();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Auth service for a given app
+const otherAuth = getAuth(otherApp);
+
+```
+
+## AuthFactorType
+
+Identifies a second factor type.
+
+<b>Signature:</b>
+
+```typescript
+export declare type AuthFactorType = 'phone';
+```
+
+## CreateTenantRequest
+
+Interface representing the properties to set on a new tenant.
+
+<b>Signature:</b>
+
+```typescript
+export declare type CreateTenantRequest = UpdateTenantRequest;
+```
+
+## HashAlgorithmType
+
+<b>Signature:</b>
+
+```typescript
+export declare type HashAlgorithmType = 'SCRYPT' | 'STANDARD_SCRYPT' | 'HMAC_SHA512' | 'HMAC_SHA256' | 'HMAC_SHA1' | 'HMAC_MD5' | 'MD5' | 'PBKDF_SHA1' | 'BCRYPT' | 'PBKDF2_SHA256' | 'SHA512' | 'SHA256' | 'SHA1';
+```
+
+## MultiFactorConfigState
+
+Identifies a multi-factor configuration state.
+
+<b>Signature:</b>
+
+```typescript
+export declare type MultiFactorConfigState = 'ENABLED' | 'DISABLED';
+```
+
+## UpdateAuthProviderRequest
+
+<b>Signature:</b>
+
+```typescript
+export declare type UpdateAuthProviderRequest = SAMLUpdateAuthProviderRequest | OIDCUpdateAuthProviderRequest;
+```
+
+## UserIdentifier
+
+Identifies a user to be looked up.
+
+<b>Signature:</b>
+
+```typescript
+export declare type UserIdentifier = UidIdentifier | EmailIdentifier | PhoneIdentifier | ProviderIdentifier;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.multifactorconfig.md
+++ b/docgen/markdown/firebase-admin.auth.multifactorconfig.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MultiFactorConfig interface{% endblock title %}
+{% block body %}
+Interface representing a multi-factor configuration. This can be used to define whether multi-factor authentication is enabled or disabled and the list of second factor challenges that are supported.
+
+<b>Signature:</b>
+
+```typescript
+export interface MultiFactorConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [factorIds](./firebase-admin.auth.multifactorconfig.md#multifactorconfigfactorids) | [AuthFactorType](./firebase-admin.auth.md#authfactortype)<!-- -->\[\] | The list of identifiers for enabled second factors. Currently only ‘phone’ is supported. |
+|  [state](./firebase-admin.auth.multifactorconfig.md#multifactorconfigstate) | [MultiFactorConfigState](./firebase-admin.auth.md#multifactorconfigstate) | The multi-factor config state. |
+
+## MultiFactorConfig.factorIds
+
+The list of identifiers for enabled second factors. Currently only ‘phone’ is supported.
+
+<b>Signature:</b>
+
+```typescript
+factorIds?: AuthFactorType[];
+```
+
+## MultiFactorConfig.state
+
+The multi-factor config state.
+
+<b>Signature:</b>
+
+```typescript
+state: MultiFactorConfigState;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.multifactorcreatesettings.md
+++ b/docgen/markdown/firebase-admin.auth.multifactorcreatesettings.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MultiFactorCreateSettings interface{% endblock title %}
+{% block body %}
+The multi-factor related user settings for create operations.
+
+<b>Signature:</b>
+
+```typescript
+export interface MultiFactorCreateSettings 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [enrolledFactors](./firebase-admin.auth.multifactorcreatesettings.md#multifactorcreatesettingsenrolledfactors) | [CreateMultiFactorInfoRequest](./firebase-admin.auth.createmultifactorinforequest.md#createmultifactorinforequest_interface)<!-- -->\[\] | The created user's list of enrolled second factors. |
+
+## MultiFactorCreateSettings.enrolledFactors
+
+The created user's list of enrolled second factors.
+
+<b>Signature:</b>
+
+```typescript
+enrolledFactors: CreateMultiFactorInfoRequest[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.multifactorinfo.md
+++ b/docgen/markdown/firebase-admin.auth.multifactorinfo.md
@@ -1,0 +1,80 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MultiFactorInfo class{% endblock title %}
+{% block body %}
+Interface representing the common properties of a user enrolled second factor.
+
+<b>Signature:</b>
+
+```typescript
+export declare abstract class MultiFactorInfo 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [displayName](./firebase-admin.auth.multifactorinfo.md#multifactorinfodisplayname) |  | string | The optional display name of the enrolled second factor. |
+|  [enrollmentTime](./firebase-admin.auth.multifactorinfo.md#multifactorinfoenrollmenttime) |  | string | The optional date the second factor was enrolled, formatted as a UTC string. |
+|  [factorId](./firebase-admin.auth.multifactorinfo.md#multifactorinfofactorid) |  | string | The type identifier of the second factor. For SMS second factors, this is <code>phone</code>. |
+|  [uid](./firebase-admin.auth.multifactorinfo.md#multifactorinfouid) |  | string | The ID of the enrolled second factor. This ID is unique to the user. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.multifactorinfo.md#multifactorinfotojson) |  |  A JSON-serializable representation of this object. |
+
+## MultiFactorInfo.displayName
+
+The optional display name of the enrolled second factor.
+
+<b>Signature:</b>
+
+```typescript
+readonly displayName?: string;
+```
+
+## MultiFactorInfo.enrollmentTime
+
+The optional date the second factor was enrolled, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+readonly enrollmentTime?: string;
+```
+
+## MultiFactorInfo.factorId
+
+The type identifier of the second factor. For SMS second factors, this is `phone`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+readonly factorId: string;
+```
+
+## MultiFactorInfo.uid
+
+The ID of the enrolled second factor. This ID is unique to the user.
+
+<b>Signature:</b>
+
+```typescript
+readonly uid: string;
+```
+
+## MultiFactorInfo.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.multifactorsettings.md
+++ b/docgen/markdown/firebase-admin.auth.multifactorsettings.md
@@ -1,0 +1,47 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MultiFactorSettings class{% endblock title %}
+{% block body %}
+The multi-factor related user settings.
+
+<b>Signature:</b>
+
+```typescript
+export declare class MultiFactorSettings 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [enrolledFactors](./firebase-admin.auth.multifactorsettings.md#multifactorsettingsenrolledfactors) |  | [MultiFactorInfo](./firebase-admin.auth.multifactorinfo.md#multifactorinfo_class)<!-- -->\[\] | List of second factors enrolled with the current user. Currently only phone second factors are supported. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.multifactorsettings.md#multifactorsettingstojson) |  |  A JSON-serializable representation of this multi-factor object. |
+
+## MultiFactorSettings.enrolledFactors
+
+List of second factors enrolled with the current user. Currently only phone second factors are supported.
+
+<b>Signature:</b>
+
+```typescript
+enrolledFactors: MultiFactorInfo[];
+```
+
+## MultiFactorSettings.toJSON()
+
+ A JSON-serializable representation of this multi-factor object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): any;
+```
+<b>Returns:</b>
+
+any
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.multifactorupdatesettings.md
+++ b/docgen/markdown/firebase-admin.auth.multifactorupdatesettings.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MultiFactorUpdateSettings interface{% endblock title %}
+{% block body %}
+The multi-factor related user settings for update operations.
+
+<b>Signature:</b>
+
+```typescript
+export interface MultiFactorUpdateSettings 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [enrolledFactors](./firebase-admin.auth.multifactorupdatesettings.md#multifactorupdatesettingsenrolledfactors) | [UpdateMultiFactorInfoRequest](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequest_interface)<!-- -->\[\] \| null | The updated list of enrolled second factors. The provided list overwrites the user's existing list of second factors. When null is passed, all of the user's existing second factors are removed. |
+
+## MultiFactorUpdateSettings.enrolledFactors
+
+The updated list of enrolled second factors. The provided list overwrites the user's existing list of second factors. When null is passed, all of the user's existing second factors are removed.
+
+<b>Signature:</b>
+
+```typescript
+enrolledFactors: UpdateMultiFactorInfoRequest[] | null;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.oidcauthproviderconfig.md
+++ b/docgen/markdown/firebase-admin.auth.oidcauthproviderconfig.md
@@ -1,0 +1,39 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}OIDCAuthProviderConfig interface{% endblock title %}
+{% block body %}
+The \[OIDC\](https://openid.net/specs/openid-connect-core-1\_0-final.html) Auth provider configuration interface. An OIDC provider can be created via .
+
+<b>Signature:</b>
+
+```typescript
+export interface OIDCAuthProviderConfig extends AuthProviderConfig 
+```
+<b>Extends:</b> [AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [clientId](./firebase-admin.auth.oidcauthproviderconfig.md#oidcauthproviderconfigclientid) | string | This is the required client ID used to confirm the audience of an OIDC provider's \[ID token\](https://openid.net/specs/openid-connect-core-1\_0-final.html\#IDToken). |
+|  [issuer](./firebase-admin.auth.oidcauthproviderconfig.md#oidcauthproviderconfigissuer) | string | This is the required provider issuer used to match the provider issuer of the ID token and to determine the corresponding OIDC discovery document, eg. \[<code>/.well-known/openid-configuration</code>\](https://openid.net/specs/openid-connect-discovery-1\_0.html\#ProviderConfig). This is needed for the following: <ul> <li>To verify the provided issuer.</li> <li>Determine the authentication/authorization endpoint during the OAuth <code>id_token</code> authentication flow.</li> <li>To retrieve the public signing keys via <code>jwks_uri</code> to verify the OIDC provider's ID token's signature.</li> <li>To determine the claims\_supported to construct the user attributes to be returned in the additional user info response.</li> </ul> ID token validation will be performed as defined in the \[spec\](https://openid.net/specs/openid-connect-core-1\_0.html\#IDTokenValidation). |
+
+## OIDCAuthProviderConfig.clientId
+
+This is the required client ID used to confirm the audience of an OIDC provider's \[ID token\](https://openid.net/specs/openid-connect-core-1\_0-final.html\#IDToken).
+
+<b>Signature:</b>
+
+```typescript
+clientId: string;
+```
+
+## OIDCAuthProviderConfig.issuer
+
+This is the required provider issuer used to match the provider issuer of the ID token and to determine the corresponding OIDC discovery document, eg. \[`/.well-known/openid-configuration`<!-- -->\](https://openid.net/specs/openid-connect-discovery-1\_0.html\#ProviderConfig). This is needed for the following: <ul> <li>To verify the provided issuer.</li> <li>Determine the authentication/authorization endpoint during the OAuth `id_token` authentication flow.</li> <li>To retrieve the public signing keys via `jwks_uri` to verify the OIDC provider's ID token's signature.</li> <li>To determine the claims\_supported to construct the user attributes to be returned in the additional user info response.</li> </ul> ID token validation will be performed as defined in the \[spec\](https://openid.net/specs/openid-connect-core-1\_0.html\#IDTokenValidation).
+
+<b>Signature:</b>
+
+```typescript
+issuer: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.oidcupdateauthproviderrequest.md
+++ b/docgen/markdown/firebase-admin.auth.oidcupdateauthproviderrequest.md
@@ -1,0 +1,60 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}OIDCUpdateAuthProviderRequest interface{% endblock title %}
+{% block body %}
+The request interface for updating an OIDC Auth provider. This is used when updating an OIDC provider's configuration via .
+
+<b>Signature:</b>
+
+```typescript
+export interface OIDCUpdateAuthProviderRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [clientId](./firebase-admin.auth.oidcupdateauthproviderrequest.md#oidcupdateauthproviderrequestclientid) | string | The OIDC provider's updated client ID. If not provided, the existing configuration's value is not modified. |
+|  [displayName](./firebase-admin.auth.oidcupdateauthproviderrequest.md#oidcupdateauthproviderrequestdisplayname) | string | The OIDC provider's updated display name. If not provided, the existing configuration's value is not modified. |
+|  [enabled](./firebase-admin.auth.oidcupdateauthproviderrequest.md#oidcupdateauthproviderrequestenabled) | boolean | Whether the OIDC provider is enabled or not. If not provided, the existing configuration's setting is not modified. |
+|  [issuer](./firebase-admin.auth.oidcupdateauthproviderrequest.md#oidcupdateauthproviderrequestissuer) | string | The OIDC provider's updated issuer. If not provided, the existing configuration's value is not modified. |
+
+## OIDCUpdateAuthProviderRequest.clientId
+
+The OIDC provider's updated client ID. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+clientId?: string;
+```
+
+## OIDCUpdateAuthProviderRequest.displayName
+
+The OIDC provider's updated display name. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## OIDCUpdateAuthProviderRequest.enabled
+
+Whether the OIDC provider is enabled or not. If not provided, the existing configuration's setting is not modified.
+
+<b>Signature:</b>
+
+```typescript
+enabled?: boolean;
+```
+
+## OIDCUpdateAuthProviderRequest.issuer
+
+The OIDC provider's updated issuer. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+issuer?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.phoneidentifier.md
+++ b/docgen/markdown/firebase-admin.auth.phoneidentifier.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}PhoneIdentifier interface{% endblock title %}
+{% block body %}
+Used for looking up an account by phone number.
+
+See `auth.getUsers()`
+
+<b>Signature:</b>
+
+```typescript
+export interface PhoneIdentifier 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [phoneNumber](./firebase-admin.auth.phoneidentifier.md#phoneidentifierphonenumber) | string |  |
+
+## PhoneIdentifier.phoneNumber
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.phonemultifactorinfo.md
+++ b/docgen/markdown/firebase-admin.auth.phonemultifactorinfo.md
@@ -1,0 +1,48 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}PhoneMultiFactorInfo class{% endblock title %}
+{% block body %}
+Interface representing a phone specific user enrolled second factor.
+
+<b>Signature:</b>
+
+```typescript
+export declare class PhoneMultiFactorInfo extends MultiFactorInfo 
+```
+<b>Extends:</b> [MultiFactorInfo](./firebase-admin.auth.multifactorinfo.md#multifactorinfo_class)
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [phoneNumber](./firebase-admin.auth.phonemultifactorinfo.md#phonemultifactorinfophonenumber) |  | string | The phone number associated with a phone second factor. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.phonemultifactorinfo.md#phonemultifactorinfotojson) |  |  A JSON-serializable representation of this object. |
+
+## PhoneMultiFactorInfo.phoneNumber
+
+The phone number associated with a phone second factor.
+
+<b>Signature:</b>
+
+```typescript
+readonly phoneNumber: string;
+```
+
+## PhoneMultiFactorInfo.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.provideridentifier.md
+++ b/docgen/markdown/firebase-admin.auth.provideridentifier.md
@@ -1,0 +1,36 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ProviderIdentifier interface{% endblock title %}
+{% block body %}
+Used for looking up an account by federated provider.
+
+See `auth.getUsers()`
+
+<b>Signature:</b>
+
+```typescript
+export interface ProviderIdentifier 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [providerId](./firebase-admin.auth.provideridentifier.md#provideridentifierproviderid) | string |  |
+|  [providerUid](./firebase-admin.auth.provideridentifier.md#provideridentifierprovideruid) | string |  |
+
+## ProviderIdentifier.providerId
+
+<b>Signature:</b>
+
+```typescript
+providerId: string;
+```
+
+## ProviderIdentifier.providerUid
+
+<b>Signature:</b>
+
+```typescript
+providerUid: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.samlauthproviderconfig.md
+++ b/docgen/markdown/firebase-admin.auth.samlauthproviderconfig.md
@@ -1,0 +1,72 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}SAMLAuthProviderConfig interface{% endblock title %}
+{% block body %}
+The \[SAML\](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html) Auth provider configuration interface. A SAML provider can be created via .
+
+<b>Signature:</b>
+
+```typescript
+export interface SAMLAuthProviderConfig extends AuthProviderConfig 
+```
+<b>Extends:</b> [AuthProviderConfig](./firebase-admin.auth.authproviderconfig.md#authproviderconfig_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [callbackURL](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfigcallbackurl) | string | This is fixed and must always be the same as the OAuth redirect URL provisioned by Firebase Auth, <code>https://project-id.firebaseapp.com/__/auth/handler</code> unless a custom <code>authDomain</code> is used. The callback URL should also be provided to the SAML IdP during configuration. |
+|  [idpEntityId](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfigidpentityid) | string | The SAML IdP entity identifier. |
+|  [rpEntityId](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfigrpentityid) | string | The SAML relying party (service provider) entity ID. This is defined by the developer but needs to be provided to the SAML IdP. |
+|  [ssoURL](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfigssourl) | string | The SAML IdP SSO URL. This must be a valid URL. |
+|  [x509Certificates](./firebase-admin.auth.samlauthproviderconfig.md#samlauthproviderconfigx509certificates) | string\[\] | The list of SAML IdP X.509 certificates issued by CA for this provider. Multiple certificates are accepted to prevent outages during IdP key rotation (for example ADFS rotates every 10 days). When the Auth server receives a SAML response, it will match the SAML response with the certificate on record. Otherwise the response is rejected. Developers are expected to manage the certificate updates as keys are rotated. |
+
+## SAMLAuthProviderConfig.callbackURL
+
+This is fixed and must always be the same as the OAuth redirect URL provisioned by Firebase Auth, `https://project-id.firebaseapp.com/__/auth/handler` unless a custom `authDomain` is used. The callback URL should also be provided to the SAML IdP during configuration.
+
+<b>Signature:</b>
+
+```typescript
+callbackURL?: string;
+```
+
+## SAMLAuthProviderConfig.idpEntityId
+
+The SAML IdP entity identifier.
+
+<b>Signature:</b>
+
+```typescript
+idpEntityId: string;
+```
+
+## SAMLAuthProviderConfig.rpEntityId
+
+The SAML relying party (service provider) entity ID. This is defined by the developer but needs to be provided to the SAML IdP.
+
+<b>Signature:</b>
+
+```typescript
+rpEntityId: string;
+```
+
+## SAMLAuthProviderConfig.ssoURL
+
+The SAML IdP SSO URL. This must be a valid URL.
+
+<b>Signature:</b>
+
+```typescript
+ssoURL: string;
+```
+
+## SAMLAuthProviderConfig.x509Certificates
+
+The list of SAML IdP X.509 certificates issued by CA for this provider. Multiple certificates are accepted to prevent outages during IdP key rotation (for example ADFS rotates every 10 days). When the Auth server receives a SAML response, it will match the SAML response with the certificate on record. Otherwise the response is rejected. Developers are expected to manage the certificate updates as keys are rotated.
+
+<b>Signature:</b>
+
+```typescript
+x509Certificates: string[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.samlupdateauthproviderrequest.md
+++ b/docgen/markdown/firebase-admin.auth.samlupdateauthproviderrequest.md
@@ -1,0 +1,93 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}SAMLUpdateAuthProviderRequest interface{% endblock title %}
+{% block body %}
+The request interface for updating a SAML Auth provider. This is used when updating a SAML provider's configuration via .
+
+<b>Signature:</b>
+
+```typescript
+export interface SAMLUpdateAuthProviderRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [callbackURL](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestcallbackurl) | string | The SAML provider's callback URL. If not provided, the existing configuration's value is not modified. |
+|  [displayName](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestdisplayname) | string | The SAML provider's updated display name. If not provided, the existing configuration's value is not modified. |
+|  [enabled](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestenabled) | boolean | Whether the SAML provider is enabled or not. If not provided, the existing configuration's setting is not modified. |
+|  [idpEntityId](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestidpentityid) | string | The SAML provider's updated IdP entity ID. If not provided, the existing configuration's value is not modified. |
+|  [rpEntityId](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestrpentityid) | string | The SAML provider's updated RP entity ID. If not provided, the existing configuration's value is not modified. |
+|  [ssoURL](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestssourl) | string | The SAML provider's updated SSO URL. If not provided, the existing configuration's value is not modified. |
+|  [x509Certificates](./firebase-admin.auth.samlupdateauthproviderrequest.md#samlupdateauthproviderrequestx509certificates) | string\[\] | The SAML provider's updated list of X.509 certificated. If not provided, the existing configuration list is not modified. |
+
+## SAMLUpdateAuthProviderRequest.callbackURL
+
+The SAML provider's callback URL. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+callbackURL?: string;
+```
+
+## SAMLUpdateAuthProviderRequest.displayName
+
+The SAML provider's updated display name. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## SAMLUpdateAuthProviderRequest.enabled
+
+Whether the SAML provider is enabled or not. If not provided, the existing configuration's setting is not modified.
+
+<b>Signature:</b>
+
+```typescript
+enabled?: boolean;
+```
+
+## SAMLUpdateAuthProviderRequest.idpEntityId
+
+The SAML provider's updated IdP entity ID. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+idpEntityId?: string;
+```
+
+## SAMLUpdateAuthProviderRequest.rpEntityId
+
+The SAML provider's updated RP entity ID. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+rpEntityId?: string;
+```
+
+## SAMLUpdateAuthProviderRequest.ssoURL
+
+The SAML provider's updated SSO URL. If not provided, the existing configuration's value is not modified.
+
+<b>Signature:</b>
+
+```typescript
+ssoURL?: string;
+```
+
+## SAMLUpdateAuthProviderRequest.x509Certificates
+
+The SAML provider's updated list of X.509 certificated. If not provided, the existing configuration list is not modified.
+
+<b>Signature:</b>
+
+```typescript
+x509Certificates?: string[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.sessioncookieoptions.md
+++ b/docgen/markdown/firebase-admin.auth.sessioncookieoptions.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}SessionCookieOptions interface{% endblock title %}
+{% block body %}
+Interface representing the session cookie options needed for the  method.
+
+<b>Signature:</b>
+
+```typescript
+export interface SessionCookieOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [expiresIn](./firebase-admin.auth.sessioncookieoptions.md#sessioncookieoptionsexpiresin) | number | The session cookie custom expiration in milliseconds. The minimum allowed is 5 minutes and the maxium allowed is 2 weeks. |
+
+## SessionCookieOptions.expiresIn
+
+The session cookie custom expiration in milliseconds. The minimum allowed is 5 minutes and the maxium allowed is 2 weeks.
+
+<b>Signature:</b>
+
+```typescript
+expiresIn: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.tenant.md
+++ b/docgen/markdown/firebase-admin.auth.tenant.md
@@ -1,0 +1,101 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Tenant class{% endblock title %}
+{% block body %}
+Represents a tenant configuration.
+
+Multi-tenancy support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform)
+
+Before multi-tenancy can be used on a Google Cloud Identity Platform project, tenants must be allowed on that project via the Cloud Console UI.
+
+A tenant configuration provides information such as the display name, tenant identifier and email authentication configuration. For OIDC/SAML provider configuration management, `TenantAwareAuth` instances should be used instead of a `Tenant` to retrieve the list of configured IdPs on a tenant. When configuring these providers, note that tenants will inherit whitelisted domains and authenticated redirect URIs of their parent project.
+
+All other settings of a tenant will also be inherited. These will need to be managed from the Cloud Console UI.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Tenant 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [displayName](./firebase-admin.auth.tenant.md#tenantdisplayname) |  | string | The tenant display name. |
+|  [emailSignInConfig](./firebase-admin.auth.tenant.md#tenantemailsigninconfig) |  | [EmailSignInProviderConfig](./firebase-admin.auth.emailsigninproviderconfig.md#emailsigninproviderconfig_interface) \| undefined | The email sign in provider configuration. |
+|  [multiFactorConfig](./firebase-admin.auth.tenant.md#tenantmultifactorconfig) |  | [MultiFactorConfig](./firebase-admin.auth.multifactorconfig.md#multifactorconfig_interface) \| undefined | The multi-factor auth configuration on the current tenant. |
+|  [tenantId](./firebase-admin.auth.tenant.md#tenanttenantid) |  | string | The tenant identifier. |
+|  [testPhoneNumbers](./firebase-admin.auth.tenant.md#tenanttestphonenumbers) |  | { \[phoneNumber: string\]: string; } | The map containing the test phone number / code pairs for the tenant. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.tenant.md#tenanttojson) |  |  A JSON-serializable representation of this object. |
+
+## Tenant.displayName
+
+The tenant display name.
+
+<b>Signature:</b>
+
+```typescript
+readonly displayName?: string;
+```
+
+## Tenant.emailSignInConfig
+
+The email sign in provider configuration.
+
+<b>Signature:</b>
+
+```typescript
+get emailSignInConfig(): EmailSignInProviderConfig | undefined;
+```
+
+## Tenant.multiFactorConfig
+
+The multi-factor auth configuration on the current tenant.
+
+<b>Signature:</b>
+
+```typescript
+get multiFactorConfig(): MultiFactorConfig | undefined;
+```
+
+## Tenant.tenantId
+
+The tenant identifier.
+
+<b>Signature:</b>
+
+```typescript
+readonly tenantId: string;
+```
+
+## Tenant.testPhoneNumbers
+
+The map containing the test phone number / code pairs for the tenant.
+
+<b>Signature:</b>
+
+```typescript
+readonly testPhoneNumbers?: {
+        [phoneNumber: string]: string;
+    };
+```
+
+## Tenant.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.tenantawareauth.md
+++ b/docgen/markdown/firebase-admin.auth.tenantawareauth.md
@@ -1,0 +1,112 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}TenantAwareAuth class{% endblock title %}
+{% block body %}
+Tenant-aware `Auth` interface used for managing users, configuring SAML/OIDC providers, generating email links for password reset, email verification, etc for specific tenants.
+
+Multi-tenancy support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP, including pricing and features, see the \[GCIP documentation\](https://cloud.google.com/identity-platform)
+
+Each tenant contains its own identity providers, settings and sets of users. Using `TenantAwareAuth`<!-- -->, users for a specific tenant and corresponding OIDC/SAML configurations can also be managed, ID tokens for users signed in to a specific tenant can be verified, and email action links can also be generated for users belonging to the tenant.
+
+`TenantAwareAuth` instances for a specific `tenantId` can be instantiated by calling `auth.tenantManager().authForTenant(tenantId)`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export declare class TenantAwareAuth extends BaseAuth 
+```
+<b>Extends:</b> [BaseAuth](./firebase-admin.auth.baseauth.md#baseauth_class)
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [tenantId](./firebase-admin.auth.tenantawareauth.md#tenantawareauthtenantid) |  | string | The tenant identifier corresponding to this <code>TenantAwareAuth</code> instance. All calls to the user management APIs, OIDC/SAML provider management APIs, email link generation APIs, etc will only be applied within the scope of this tenant. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [createSessionCookie(idToken, sessionCookieOptions)](./firebase-admin.auth.tenantawareauth.md#tenantawareauthcreatesessioncookie) |  | Creates a new Firebase session cookie with the specified options. The created JWT string can be set as a server-side session cookie with a custom cookie policy, and be used for session management. The session cookie JWT will have the same payload claims as the provided ID token.<!-- -->See \[Manage Session Cookies\](/docs/auth/admin/manage-cookies) for code samples and detailed documentation. |
+|  [verifyIdToken(idToken, checkRevoked)](./firebase-admin.auth.tenantawareauth.md#tenantawareauthverifyidtoken) |  | Verifies a Firebase ID token (JWT). If the token is valid, the promise is fulfilled with the token's decoded claims; otherwise, the promise is rejected. An optional flag can be passed to additionally check whether the ID token was revoked.<!-- -->See \[Verify ID Tokens\](/docs/auth/admin/verify-id-tokens) for code samples and detailed documentation. |
+|  [verifySessionCookie(sessionCookie, checkRevoked)](./firebase-admin.auth.tenantawareauth.md#tenantawareauthverifysessioncookie) |  | Verifies a Firebase session cookie. Returns a Promise with the cookie claims. Rejects the promise if the cookie could not be verified. If <code>checkRevoked</code> is set to true, verifies if the session corresponding to the session cookie was revoked. If the corresponding user's session was revoked, an <code>auth/session-cookie-revoked</code> error is thrown. If not specified the check is not performed.<!-- -->See \[Verify Session Cookies\](/docs/auth/admin/manage-cookies\#verify\_session\_cookie\_and\_check\_permissions) for code samples and detailed documentation |
+
+## TenantAwareAuth.tenantId
+
+The tenant identifier corresponding to this `TenantAwareAuth` instance. All calls to the user management APIs, OIDC/SAML provider management APIs, email link generation APIs, etc will only be applied within the scope of this tenant.
+
+<b>Signature:</b>
+
+```typescript
+readonly tenantId: string;
+```
+
+## TenantAwareAuth.createSessionCookie()
+
+Creates a new Firebase session cookie with the specified options. The created JWT string can be set as a server-side session cookie with a custom cookie policy, and be used for session management. The session cookie JWT will have the same payload claims as the provided ID token.
+
+See \[Manage Session Cookies\](/docs/auth/admin/manage-cookies) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+createSessionCookie(idToken: string, sessionCookieOptions: SessionCookieOptions): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  idToken | string | The Firebase ID token to exchange for a session cookie. |
+|  sessionCookieOptions | [SessionCookieOptions](./firebase-admin.auth.sessioncookieoptions.md#sessioncookieoptions_interface) | The session cookie options which includes custom session duration. A promise that resolves on success with the created session cookie. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## TenantAwareAuth.verifyIdToken()
+
+Verifies a Firebase ID token (JWT). If the token is valid, the promise is fulfilled with the token's decoded claims; otherwise, the promise is rejected. An optional flag can be passed to additionally check whether the ID token was revoked.
+
+See \[Verify ID Tokens\](/docs/auth/admin/verify-id-tokens) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  idToken | string | The ID token to verify. |
+|  checkRevoked | boolean | Whether to check if the ID token was revoked. This requires an extra request to the Firebase Auth backend to check the <code>tokensValidAfterTime</code> time for the corresponding user. When not specified, this additional check is not applied. A promise fulfilled with the token's decoded claims if the ID token is valid; otherwise, a rejected promise. |
+
+<b>Returns:</b>
+
+Promise&lt;[DecodedIdToken](./firebase-admin.auth.decodedidtoken.md#decodedidtoken_interface)<!-- -->&gt;
+
+## TenantAwareAuth.verifySessionCookie()
+
+Verifies a Firebase session cookie. Returns a Promise with the cookie claims. Rejects the promise if the cookie could not be verified. If `checkRevoked` is set to true, verifies if the session corresponding to the session cookie was revoked. If the corresponding user's session was revoked, an `auth/session-cookie-revoked` error is thrown. If not specified the check is not performed.
+
+See \[Verify Session Cookies\](/docs/auth/admin/manage-cookies\#verify\_session\_cookie\_and\_check\_permissions) for code samples and detailed documentation
+
+<b>Signature:</b>
+
+```typescript
+verifySessionCookie(sessionCookie: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  sessionCookie | string | The session cookie to verify. |
+|  checkRevoked | boolean |  |
+
+<b>Returns:</b>
+
+Promise&lt;[DecodedIdToken](./firebase-admin.auth.decodedidtoken.md#decodedidtoken_interface)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.tenantmanager.md
+++ b/docgen/markdown/firebase-admin.auth.tenantmanager.md
@@ -1,0 +1,145 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}TenantManager class{% endblock title %}
+{% block body %}
+Defines the tenant manager used to help manage tenant related operations. This includes: <ul> <li>The ability to create, update, list, get and delete tenants for the underlying project.</li> <li>Getting a `TenantAwareAuth` instance for running Auth related operations (user management, provider configuration management, token verification, email link generation, etc) in the context of a specified tenant.</li> </ul>
+
+<b>Signature:</b>
+
+```typescript
+export declare class TenantManager 
+```
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [authForTenant(tenantId)](./firebase-admin.auth.tenantmanager.md#tenantmanagerauthfortenant) |  | Returns a <code>TenantAwareAuth</code> instance bound to the given tenant ID. |
+|  [createTenant(tenantOptions)](./firebase-admin.auth.tenantmanager.md#tenantmanagercreatetenant) |  | Creates a new tenant. When creating new tenants, tenants that use separate billing and quota will require their own project and must be defined as <code>full_service</code>. |
+|  [deleteTenant(tenantId)](./firebase-admin.auth.tenantmanager.md#tenantmanagerdeletetenant) |  | Deletes an existing tenant. |
+|  [getTenant(tenantId)](./firebase-admin.auth.tenantmanager.md#tenantmanagergettenant) |  | Gets the tenant configuration for the tenant corresponding to a given <code>tenantId</code>. |
+|  [listTenants(maxResults, pageToken)](./firebase-admin.auth.tenantmanager.md#tenantmanagerlisttenants) |  | Retrieves a list of tenants (single batch only) with a size of <code>maxResults</code> starting from the offset as specified by <code>pageToken</code>. This is used to retrieve all the tenants of a specified project in batches. |
+|  [updateTenant(tenantId, tenantOptions)](./firebase-admin.auth.tenantmanager.md#tenantmanagerupdatetenant) |  | Updates an existing tenant configuration. |
+
+## TenantManager.authForTenant()
+
+Returns a `TenantAwareAuth` instance bound to the given tenant ID.
+
+<b>Signature:</b>
+
+```typescript
+authForTenant(tenantId: string): TenantAwareAuth;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  tenantId | string | The tenant ID whose <code>TenantAwareAuth</code> instance is to be returned. The <code>TenantAwareAuth</code> instance corresponding to this tenant identifier. |
+
+<b>Returns:</b>
+
+[TenantAwareAuth](./firebase-admin.auth.tenantawareauth.md#tenantawareauth_class)
+
+## TenantManager.createTenant()
+
+Creates a new tenant. When creating new tenants, tenants that use separate billing and quota will require their own project and must be defined as `full_service`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+createTenant(tenantOptions: CreateTenantRequest): Promise<Tenant>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  tenantOptions | [CreateTenantRequest](./firebase-admin.auth.md#createtenantrequest) | The properties to set on the new tenant configuration to be created. A promise fulfilled with the tenant configuration corresponding to the newly created tenant. |
+
+<b>Returns:</b>
+
+Promise&lt;[Tenant](./firebase-admin.auth.tenant.md#tenant_class)<!-- -->&gt;
+
+## TenantManager.deleteTenant()
+
+Deletes an existing tenant.
+
+<b>Signature:</b>
+
+```typescript
+deleteTenant(tenantId: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  tenantId | string | The <code>tenantId</code> corresponding to the tenant to delete. An empty promise fulfilled once the tenant has been deleted. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## TenantManager.getTenant()
+
+Gets the tenant configuration for the tenant corresponding to a given `tenantId`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+getTenant(tenantId: string): Promise<Tenant>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  tenantId | string | The tenant identifier corresponding to the tenant whose data to fetch. A promise fulfilled with the tenant configuration to the provided <code>tenantId</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[Tenant](./firebase-admin.auth.tenant.md#tenant_class)<!-- -->&gt;
+
+## TenantManager.listTenants()
+
+Retrieves a list of tenants (single batch only) with a size of `maxResults` starting from the offset as specified by `pageToken`<!-- -->. This is used to retrieve all the tenants of a specified project in batches.
+
+<b>Signature:</b>
+
+```typescript
+listTenants(maxResults?: number, pageToken?: string): Promise<ListTenantsResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  maxResults | number | The page size, 1000 if undefined. This is also the maximum allowed limit. |
+|  pageToken | string | The next page token. If not specified, returns tenants starting without any offset. A promise that resolves with a batch of downloaded tenants and the next page token. |
+
+<b>Returns:</b>
+
+Promise&lt;[ListTenantsResult](./firebase-admin.auth.listtenantsresult.md#listtenantsresult_interface)<!-- -->&gt;
+
+## TenantManager.updateTenant()
+
+Updates an existing tenant configuration.
+
+<b>Signature:</b>
+
+```typescript
+updateTenant(tenantId: string, tenantOptions: UpdateTenantRequest): Promise<Tenant>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  tenantId | string | The <code>tenantId</code> corresponding to the tenant to delete. |
+|  tenantOptions | [UpdateTenantRequest](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequest_interface) | The properties to update on the provided tenant. A promise fulfilled with the update tenant data. |
+
+<b>Returns:</b>
+
+Promise&lt;[Tenant](./firebase-admin.auth.tenant.md#tenant_class)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.uididentifier.md
+++ b/docgen/markdown/firebase-admin.auth.uididentifier.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UidIdentifier interface{% endblock title %}
+{% block body %}
+Used for looking up an account by uid.
+
+See `auth.getUsers()`
+
+<b>Signature:</b>
+
+```typescript
+export interface UidIdentifier 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [uid](./firebase-admin.auth.uididentifier.md#uididentifieruid) | string |  |
+
+## UidIdentifier.uid
+
+<b>Signature:</b>
+
+```typescript
+uid: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.updatemultifactorinforequest.md
+++ b/docgen/markdown/firebase-admin.auth.updatemultifactorinforequest.md
@@ -1,0 +1,60 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UpdateMultiFactorInfoRequest interface{% endblock title %}
+{% block body %}
+Interface representing common properties of a user enrolled second factor for an `UpdateRequest`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export interface UpdateMultiFactorInfoRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequestdisplayname) | string | The optional display name for an enrolled second factor. |
+|  [enrollmentTime](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequestenrollmenttime) | string | The optional date the second factor was enrolled, formatted as a UTC string. |
+|  [factorId](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequestfactorid) | string | The type identifier of the second factor. For SMS second factors, this is <code>phone</code>. |
+|  [uid](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequestuid) | string | The ID of the enrolled second factor. This ID is unique to the user. When not provided, a new one is provisioned by the Auth server. |
+
+## UpdateMultiFactorInfoRequest.displayName
+
+The optional display name for an enrolled second factor.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## UpdateMultiFactorInfoRequest.enrollmentTime
+
+The optional date the second factor was enrolled, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+enrollmentTime?: string;
+```
+
+## UpdateMultiFactorInfoRequest.factorId
+
+The type identifier of the second factor. For SMS second factors, this is `phone`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+factorId: string;
+```
+
+## UpdateMultiFactorInfoRequest.uid
+
+The ID of the enrolled second factor. This ID is unique to the user. When not provided, a new one is provisioned by the Auth server.
+
+<b>Signature:</b>
+
+```typescript
+uid?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.updatephonemultifactorinforequest.md
+++ b/docgen/markdown/firebase-admin.auth.updatephonemultifactorinforequest.md
@@ -1,0 +1,28 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UpdatePhoneMultiFactorInfoRequest interface{% endblock title %}
+{% block body %}
+Interface representing a phone specific user enrolled second factor for an `UpdateRequest`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export interface UpdatePhoneMultiFactorInfoRequest extends UpdateMultiFactorInfoRequest 
+```
+<b>Extends:</b> [UpdateMultiFactorInfoRequest](./firebase-admin.auth.updatemultifactorinforequest.md#updatemultifactorinforequest_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [phoneNumber](./firebase-admin.auth.updatephonemultifactorinforequest.md#updatephonemultifactorinforequestphonenumber) | string | The phone number associated with a phone second factor. |
+
+## UpdatePhoneMultiFactorInfoRequest.phoneNumber
+
+The phone number associated with a phone second factor.
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.updaterequest.md
+++ b/docgen/markdown/firebase-admin.auth.updaterequest.md
@@ -1,0 +1,104 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UpdateRequest interface{% endblock title %}
+{% block body %}
+Interface representing the properties to update on the provided user.
+
+<b>Signature:</b>
+
+```typescript
+export interface UpdateRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [disabled](./firebase-admin.auth.updaterequest.md#updaterequestdisabled) | boolean | Whether or not the user is disabled: <code>true</code> for disabled; <code>false</code> for enabled. |
+|  [displayName](./firebase-admin.auth.updaterequest.md#updaterequestdisplayname) | string \| null | The user's display name. |
+|  [email](./firebase-admin.auth.updaterequest.md#updaterequestemail) | string | The user's primary email. |
+|  [emailVerified](./firebase-admin.auth.updaterequest.md#updaterequestemailverified) | boolean | Whether or not the user's primary email is verified. |
+|  [multiFactor](./firebase-admin.auth.updaterequest.md#updaterequestmultifactor) | [MultiFactorUpdateSettings](./firebase-admin.auth.multifactorupdatesettings.md#multifactorupdatesettings_interface) | The user's updated multi-factor related properties. |
+|  [password](./firebase-admin.auth.updaterequest.md#updaterequestpassword) | string | The user's unhashed password. |
+|  [phoneNumber](./firebase-admin.auth.updaterequest.md#updaterequestphonenumber) | string \| null | The user's primary phone number. |
+|  [photoURL](./firebase-admin.auth.updaterequest.md#updaterequestphotourl) | string \| null | The user's photo URL. |
+
+## UpdateRequest.disabled
+
+Whether or not the user is disabled: `true` for disabled; `false` for enabled.
+
+<b>Signature:</b>
+
+```typescript
+disabled?: boolean;
+```
+
+## UpdateRequest.displayName
+
+The user's display name.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string | null;
+```
+
+## UpdateRequest.email
+
+The user's primary email.
+
+<b>Signature:</b>
+
+```typescript
+email?: string;
+```
+
+## UpdateRequest.emailVerified
+
+Whether or not the user's primary email is verified.
+
+<b>Signature:</b>
+
+```typescript
+emailVerified?: boolean;
+```
+
+## UpdateRequest.multiFactor
+
+The user's updated multi-factor related properties.
+
+<b>Signature:</b>
+
+```typescript
+multiFactor?: MultiFactorUpdateSettings;
+```
+
+## UpdateRequest.password
+
+The user's unhashed password.
+
+<b>Signature:</b>
+
+```typescript
+password?: string;
+```
+
+## UpdateRequest.phoneNumber
+
+The user's primary phone number.
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber?: string | null;
+```
+
+## UpdateRequest.photoURL
+
+The user's photo URL.
+
+<b>Signature:</b>
+
+```typescript
+photoURL?: string | null;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.updatetenantrequest.md
+++ b/docgen/markdown/firebase-admin.auth.updatetenantrequest.md
@@ -1,0 +1,62 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UpdateTenantRequest interface{% endblock title %}
+{% block body %}
+Interface representing the properties to update on the provided tenant.
+
+<b>Signature:</b>
+
+```typescript
+export interface UpdateTenantRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequestdisplayname) | string | The tenant display name. |
+|  [emailSignInConfig](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequestemailsigninconfig) | [EmailSignInProviderConfig](./firebase-admin.auth.emailsigninproviderconfig.md#emailsigninproviderconfig_interface) | The email sign in configuration. |
+|  [multiFactorConfig](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequestmultifactorconfig) | [MultiFactorConfig](./firebase-admin.auth.multifactorconfig.md#multifactorconfig_interface) | The multi-factor auth configuration to update on the tenant. |
+|  [testPhoneNumbers](./firebase-admin.auth.updatetenantrequest.md#updatetenantrequesttestphonenumbers) | { \[phoneNumber: string\]: string; } \| null | The updated map containing the test phone number / code pairs for the tenant. Passing null clears the previously save phone number / code pairs. |
+
+## UpdateTenantRequest.displayName
+
+The tenant display name.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## UpdateTenantRequest.emailSignInConfig
+
+The email sign in configuration.
+
+<b>Signature:</b>
+
+```typescript
+emailSignInConfig?: EmailSignInProviderConfig;
+```
+
+## UpdateTenantRequest.multiFactorConfig
+
+The multi-factor auth configuration to update on the tenant.
+
+<b>Signature:</b>
+
+```typescript
+multiFactorConfig?: MultiFactorConfig;
+```
+
+## UpdateTenantRequest.testPhoneNumbers
+
+The updated map containing the test phone number / code pairs for the tenant. Passing null clears the previously save phone number / code pairs.
+
+<b>Signature:</b>
+
+```typescript
+testPhoneNumbers?: {
+        [phoneNumber: string]: string;
+    } | null;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userimportoptions.md
+++ b/docgen/markdown/firebase-admin.auth.userimportoptions.md
@@ -1,0 +1,36 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserImportOptions interface{% endblock title %}
+{% block body %}
+Interface representing the user import options needed for  method. This is used to provide the password hashing algorithm information.
+
+<b>Signature:</b>
+
+```typescript
+export interface UserImportOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [hash](./firebase-admin.auth.userimportoptions.md#userimportoptionshash) | { algorithm: [HashAlgorithmType](./firebase-admin.auth.md#hashalgorithmtype)<!-- -->; key?: Buffer; saltSeparator?: Buffer; rounds?: number; memoryCost?: number; parallelization?: number; blockSize?: number; derivedKeyLength?: number; } | The password hashing information. |
+
+## UserImportOptions.hash
+
+The password hashing information.
+
+<b>Signature:</b>
+
+```typescript
+hash: {
+        algorithm: HashAlgorithmType;
+        key?: Buffer;
+        saltSeparator?: Buffer;
+        rounds?: number;
+        memoryCost?: number;
+        parallelization?: number;
+        blockSize?: number;
+        derivedKeyLength?: number;
+    };
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userimportrecord.md
+++ b/docgen/markdown/firebase-admin.auth.userimportrecord.md
@@ -1,0 +1,172 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserImportRecord interface{% endblock title %}
+{% block body %}
+Interface representing a user to import to Firebase Auth via the  method.
+
+<b>Signature:</b>
+
+```typescript
+export interface UserImportRecord 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [customClaims](./firebase-admin.auth.userimportrecord.md#userimportrecordcustomclaims) | { \[key: string\]: any; } | The user's custom claims object if available, typically used to define user roles and propagated to an authenticated user's ID token. |
+|  [disabled](./firebase-admin.auth.userimportrecord.md#userimportrecorddisabled) | boolean | Whether or not the user is disabled: <code>true</code> for disabled; <code>false</code> for enabled. |
+|  [displayName](./firebase-admin.auth.userimportrecord.md#userimportrecorddisplayname) | string | The user's display name. |
+|  [email](./firebase-admin.auth.userimportrecord.md#userimportrecordemail) | string | The user's primary email, if set. |
+|  [emailVerified](./firebase-admin.auth.userimportrecord.md#userimportrecordemailverified) | boolean | Whether or not the user's primary email is verified. |
+|  [metadata](./firebase-admin.auth.userimportrecord.md#userimportrecordmetadata) | [UserMetadataRequest](./firebase-admin.auth.usermetadatarequest.md#usermetadatarequest_interface) | Additional metadata about the user. |
+|  [multiFactor](./firebase-admin.auth.userimportrecord.md#userimportrecordmultifactor) | [MultiFactorUpdateSettings](./firebase-admin.auth.multifactorupdatesettings.md#multifactorupdatesettings_interface) | The user's multi-factor related properties. |
+|  [passwordHash](./firebase-admin.auth.userimportrecord.md#userimportrecordpasswordhash) | Buffer | The buffer of bytes representing the user's hashed password. When a user is to be imported with a password hash,  are required to be specified to identify the hashing algorithm used to generate this hash. |
+|  [passwordSalt](./firebase-admin.auth.userimportrecord.md#userimportrecordpasswordsalt) | Buffer | The buffer of bytes representing the user's password salt. |
+|  [phoneNumber](./firebase-admin.auth.userimportrecord.md#userimportrecordphonenumber) | string | The user's primary phone number, if set. |
+|  [photoURL](./firebase-admin.auth.userimportrecord.md#userimportrecordphotourl) | string | The user's photo URL. |
+|  [providerData](./firebase-admin.auth.userimportrecord.md#userimportrecordproviderdata) | [UserProviderRequest](./firebase-admin.auth.userproviderrequest.md#userproviderrequest_interface)<!-- -->\[\] | An array of providers (for example, Google, Facebook) linked to the user. |
+|  [tenantId](./firebase-admin.auth.userimportrecord.md#userimportrecordtenantid) | string | The identifier of the tenant where user is to be imported to. When not provided in an <code>admin.auth.Auth</code> context, the user is uploaded to the default parent project. When not provided in an <code>admin.auth.TenantAwareAuth</code> context, the user is uploaded to the tenant corresponding to that <code>TenantAwareAuth</code> instance's tenant ID. |
+|  [uid](./firebase-admin.auth.userimportrecord.md#userimportrecorduid) | string | The user's <code>uid</code>. |
+
+## UserImportRecord.customClaims
+
+The user's custom claims object if available, typically used to define user roles and propagated to an authenticated user's ID token.
+
+<b>Signature:</b>
+
+```typescript
+customClaims?: {
+        [key: string]: any;
+    };
+```
+
+## UserImportRecord.disabled
+
+Whether or not the user is disabled: `true` for disabled; `false` for enabled.
+
+<b>Signature:</b>
+
+```typescript
+disabled?: boolean;
+```
+
+## UserImportRecord.displayName
+
+The user's display name.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## UserImportRecord.email
+
+The user's primary email, if set.
+
+<b>Signature:</b>
+
+```typescript
+email?: string;
+```
+
+## UserImportRecord.emailVerified
+
+Whether or not the user's primary email is verified.
+
+<b>Signature:</b>
+
+```typescript
+emailVerified?: boolean;
+```
+
+## UserImportRecord.metadata
+
+Additional metadata about the user.
+
+<b>Signature:</b>
+
+```typescript
+metadata?: UserMetadataRequest;
+```
+
+## UserImportRecord.multiFactor
+
+The user's multi-factor related properties.
+
+<b>Signature:</b>
+
+```typescript
+multiFactor?: MultiFactorUpdateSettings;
+```
+
+## UserImportRecord.passwordHash
+
+The buffer of bytes representing the user's hashed password. When a user is to be imported with a password hash,  are required to be specified to identify the hashing algorithm used to generate this hash.
+
+<b>Signature:</b>
+
+```typescript
+passwordHash?: Buffer;
+```
+
+## UserImportRecord.passwordSalt
+
+The buffer of bytes representing the user's password salt.
+
+<b>Signature:</b>
+
+```typescript
+passwordSalt?: Buffer;
+```
+
+## UserImportRecord.phoneNumber
+
+The user's primary phone number, if set.
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber?: string;
+```
+
+## UserImportRecord.photoURL
+
+The user's photo URL.
+
+<b>Signature:</b>
+
+```typescript
+photoURL?: string;
+```
+
+## UserImportRecord.providerData
+
+An array of providers (for example, Google, Facebook) linked to the user.
+
+<b>Signature:</b>
+
+```typescript
+providerData?: UserProviderRequest[];
+```
+
+## UserImportRecord.tenantId
+
+The identifier of the tenant where user is to be imported to. When not provided in an `admin.auth.Auth` context, the user is uploaded to the default parent project. When not provided in an `admin.auth.TenantAwareAuth` context, the user is uploaded to the tenant corresponding to that `TenantAwareAuth` instance's tenant ID.
+
+<b>Signature:</b>
+
+```typescript
+tenantId?: string;
+```
+
+## UserImportRecord.uid
+
+The user's `uid`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+uid: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userimportresult.md
+++ b/docgen/markdown/firebase-admin.auth.userimportresult.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserImportResult interface{% endblock title %}
+{% block body %}
+Interface representing the response from the  method for batch importing users to Firebase Auth.
+
+<b>Signature:</b>
+
+```typescript
+export interface UserImportResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [errors](./firebase-admin.auth.userimportresult.md#userimportresulterrors) | FirebaseArrayIndexError\[\] | An array of errors corresponding to the provided users to import. The length of this array is equal to \[<code>failureCount</code>\](\#failureCount). |
+|  [failureCount](./firebase-admin.auth.userimportresult.md#userimportresultfailurecount) | number | The number of user records that failed to import to Firebase Auth. |
+|  [successCount](./firebase-admin.auth.userimportresult.md#userimportresultsuccesscount) | number | The number of user records that successfully imported to Firebase Auth. |
+
+## UserImportResult.errors
+
+An array of errors corresponding to the provided users to import. The length of this array is equal to \[`failureCount`<!-- -->\](\#failureCount).
+
+<b>Signature:</b>
+
+```typescript
+errors: FirebaseArrayIndexError[];
+```
+
+## UserImportResult.failureCount
+
+The number of user records that failed to import to Firebase Auth.
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## UserImportResult.successCount
+
+The number of user records that successfully imported to Firebase Auth.
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userinfo.md
+++ b/docgen/markdown/firebase-admin.auth.userinfo.md
@@ -1,0 +1,102 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserInfo class{% endblock title %}
+{% block body %}
+Represents a user's info from a third-party identity provider such as Google or Facebook.
+
+<b>Signature:</b>
+
+```typescript
+export declare class UserInfo 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [displayName](./firebase-admin.auth.userinfo.md#userinfodisplayname) |  | string | The display name for the linked provider. |
+|  [email](./firebase-admin.auth.userinfo.md#userinfoemail) |  | string | The email for the linked provider. |
+|  [phoneNumber](./firebase-admin.auth.userinfo.md#userinfophonenumber) |  | string | The phone number for the linked provider. |
+|  [photoURL](./firebase-admin.auth.userinfo.md#userinfophotourl) |  | string | The photo URL for the linked provider. |
+|  [providerId](./firebase-admin.auth.userinfo.md#userinfoproviderid) |  | string | The linked provider ID (for example, "google.com" for the Google provider). |
+|  [uid](./firebase-admin.auth.userinfo.md#userinfouid) |  | string | The user identifier for the linked provider. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.userinfo.md#userinfotojson) |  |  A JSON-serializable representation of this object. |
+
+## UserInfo.displayName
+
+The display name for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+readonly displayName: string;
+```
+
+## UserInfo.email
+
+The email for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+readonly email: string;
+```
+
+## UserInfo.phoneNumber
+
+The phone number for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+readonly phoneNumber: string;
+```
+
+## UserInfo.photoURL
+
+The photo URL for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+readonly photoURL: string;
+```
+
+## UserInfo.providerId
+
+The linked provider ID (for example, "google.com" for the Google provider).
+
+<b>Signature:</b>
+
+```typescript
+readonly providerId: string;
+```
+
+## UserInfo.uid
+
+The user identifier for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+readonly uid: string;
+```
+
+## UserInfo.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.usermetadata.md
+++ b/docgen/markdown/firebase-admin.auth.usermetadata.md
@@ -1,0 +1,69 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserMetadata class{% endblock title %}
+{% block body %}
+Represents a user's metadata.
+
+<b>Signature:</b>
+
+```typescript
+export declare class UserMetadata 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [creationTime](./firebase-admin.auth.usermetadata.md#usermetadatacreationtime) |  | string | The date the user was created, formatted as a UTC string. |
+|  [lastRefreshTime](./firebase-admin.auth.usermetadata.md#usermetadatalastrefreshtime) |  | string \| null | The time at which the user was last active (ID token refreshed), formatted as a UTC Date string (eg 'Sat, 03 Feb 2001 04:05:06 GMT'). Returns null if the user was never active. |
+|  [lastSignInTime](./firebase-admin.auth.usermetadata.md#usermetadatalastsignintime) |  | string | The date the user last signed in, formatted as a UTC string. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.usermetadata.md#usermetadatatojson) |  |  A JSON-serializable representation of this object. |
+
+## UserMetadata.creationTime
+
+The date the user was created, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+readonly creationTime: string;
+```
+
+## UserMetadata.lastRefreshTime
+
+The time at which the user was last active (ID token refreshed), formatted as a UTC Date string (eg 'Sat, 03 Feb 2001 04:05:06 GMT'). Returns null if the user was never active.
+
+<b>Signature:</b>
+
+```typescript
+readonly lastRefreshTime: string | null;
+```
+
+## UserMetadata.lastSignInTime
+
+The date the user last signed in, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+readonly lastSignInTime: string;
+```
+
+## UserMetadata.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.usermetadatarequest.md
+++ b/docgen/markdown/firebase-admin.auth.usermetadatarequest.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserMetadataRequest interface{% endblock title %}
+{% block body %}
+User metadata to include when importing a user.
+
+<b>Signature:</b>
+
+```typescript
+export interface UserMetadataRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [creationTime](./firebase-admin.auth.usermetadatarequest.md#usermetadatarequestcreationtime) | string | The date the user was created, formatted as a UTC string. |
+|  [lastSignInTime](./firebase-admin.auth.usermetadatarequest.md#usermetadatarequestlastsignintime) | string | The date the user last signed in, formatted as a UTC string. |
+
+## UserMetadataRequest.creationTime
+
+The date the user was created, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+creationTime?: string;
+```
+
+## UserMetadataRequest.lastSignInTime
+
+The date the user last signed in, formatted as a UTC string.
+
+<b>Signature:</b>
+
+```typescript
+lastSignInTime?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userproviderrequest.md
+++ b/docgen/markdown/firebase-admin.auth.userproviderrequest.md
@@ -1,0 +1,82 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserProviderRequest interface{% endblock title %}
+{% block body %}
+User provider data to include when importing a user.
+
+<b>Signature:</b>
+
+```typescript
+export interface UserProviderRequest 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.auth.userproviderrequest.md#userproviderrequestdisplayname) | string | The display name for the linked provider. |
+|  [email](./firebase-admin.auth.userproviderrequest.md#userproviderrequestemail) | string | The email for the linked provider. |
+|  [phoneNumber](./firebase-admin.auth.userproviderrequest.md#userproviderrequestphonenumber) | string | The phone number for the linked provider. |
+|  [photoURL](./firebase-admin.auth.userproviderrequest.md#userproviderrequestphotourl) | string | The photo URL for the linked provider. |
+|  [providerId](./firebase-admin.auth.userproviderrequest.md#userproviderrequestproviderid) | string | The linked provider ID (for example, "google.com" for the Google provider). |
+|  [uid](./firebase-admin.auth.userproviderrequest.md#userproviderrequestuid) | string | The user identifier for the linked provider. |
+
+## UserProviderRequest.displayName
+
+The display name for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## UserProviderRequest.email
+
+The email for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+email?: string;
+```
+
+## UserProviderRequest.phoneNumber
+
+The phone number for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+phoneNumber?: string;
+```
+
+## UserProviderRequest.photoURL
+
+The photo URL for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+photoURL?: string;
+```
+
+## UserProviderRequest.providerId
+
+The linked provider ID (for example, "google.com" for the Google provider).
+
+<b>Signature:</b>
+
+```typescript
+providerId: string;
+```
+
+## UserProviderRequest.uid
+
+The user identifier for the linked provider.
+
+<b>Signature:</b>
+
+```typescript
+uid: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.auth.userrecord.md
+++ b/docgen/markdown/firebase-admin.auth.userrecord.md
@@ -1,0 +1,203 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}UserRecord class{% endblock title %}
+{% block body %}
+Represents a user.
+
+<b>Signature:</b>
+
+```typescript
+export declare class UserRecord 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [customClaims](./firebase-admin.auth.userrecord.md#userrecordcustomclaims) |  | { \[key: string\]: any; } | The user's custom claims object if available, typically used to define user roles and propagated to an authenticated user's ID token. This is set via  |
+|  [disabled](./firebase-admin.auth.userrecord.md#userrecorddisabled) |  | boolean | Whether or not the user is disabled: <code>true</code> for disabled; <code>false</code> for enabled. |
+|  [displayName](./firebase-admin.auth.userrecord.md#userrecorddisplayname) |  | string | The user's display name. |
+|  [email](./firebase-admin.auth.userrecord.md#userrecordemail) |  | string | The user's primary email, if set. |
+|  [emailVerified](./firebase-admin.auth.userrecord.md#userrecordemailverified) |  | boolean | Whether or not the user's primary email is verified. |
+|  [metadata](./firebase-admin.auth.userrecord.md#userrecordmetadata) |  | [UserMetadata](./firebase-admin.auth.usermetadata.md#usermetadata_class) | Additional metadata about the user. |
+|  [multiFactor](./firebase-admin.auth.userrecord.md#userrecordmultifactor) |  | [MultiFactorSettings](./firebase-admin.auth.multifactorsettings.md#multifactorsettings_class) | The multi-factor related properties for the current user, if available. |
+|  [passwordHash](./firebase-admin.auth.userrecord.md#userrecordpasswordhash) |  | string | The user's hashed password (base64-encoded), only if Firebase Auth hashing algorithm (SCRYPT) is used. If a different hashing algorithm had been used when uploading this user, as is typical when migrating from another Auth system, this will be an empty string. If no password is set, this is null. This is only available when the user is obtained from . |
+|  [passwordSalt](./firebase-admin.auth.userrecord.md#userrecordpasswordsalt) |  | string | The user's password salt (base64-encoded), only if Firebase Auth hashing algorithm (SCRYPT) is used. If a different hashing algorithm had been used to upload this user, typical when migrating from another Auth system, this will be an empty string. If no password is set, this is null. This is only available when the user is obtained from . |
+|  [phoneNumber](./firebase-admin.auth.userrecord.md#userrecordphonenumber) |  | string | The user's primary phone number, if set. |
+|  [photoURL](./firebase-admin.auth.userrecord.md#userrecordphotourl) |  | string | The user's photo URL. |
+|  [providerData](./firebase-admin.auth.userrecord.md#userrecordproviderdata) |  | [UserInfo](./firebase-admin.auth.userinfo.md#userinfo_class)<!-- -->\[\] | An array of providers (for example, Google, Facebook) linked to the user. |
+|  [tenantId](./firebase-admin.auth.userrecord.md#userrecordtenantid) |  | string \| null | The ID of the tenant the user belongs to, if available. |
+|  [tokensValidAfterTime](./firebase-admin.auth.userrecord.md#userrecordtokensvalidaftertime) |  | string | The date the user's tokens are valid after, formatted as a UTC string. This is updated every time the user's refresh token are revoked either from the  API or from the Firebase Auth backend on big account changes (password resets, password or email updates, etc). |
+|  [uid](./firebase-admin.auth.userrecord.md#userrecorduid) |  | string | The user's <code>uid</code>. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.auth.userrecord.md#userrecordtojson) |  |  A JSON-serializable representation of this object. |
+
+## UserRecord.customClaims
+
+The user's custom claims object if available, typically used to define user roles and propagated to an authenticated user's ID token. This is set via 
+
+<b>Signature:</b>
+
+```typescript
+readonly customClaims?: {
+        [key: string]: any;
+    };
+```
+
+## UserRecord.disabled
+
+Whether or not the user is disabled: `true` for disabled; `false` for enabled.
+
+<b>Signature:</b>
+
+```typescript
+readonly disabled: boolean;
+```
+
+## UserRecord.displayName
+
+The user's display name.
+
+<b>Signature:</b>
+
+```typescript
+readonly displayName?: string;
+```
+
+## UserRecord.email
+
+The user's primary email, if set.
+
+<b>Signature:</b>
+
+```typescript
+readonly email?: string;
+```
+
+## UserRecord.emailVerified
+
+Whether or not the user's primary email is verified.
+
+<b>Signature:</b>
+
+```typescript
+readonly emailVerified: boolean;
+```
+
+## UserRecord.metadata
+
+Additional metadata about the user.
+
+<b>Signature:</b>
+
+```typescript
+readonly metadata: UserMetadata;
+```
+
+## UserRecord.multiFactor
+
+The multi-factor related properties for the current user, if available.
+
+<b>Signature:</b>
+
+```typescript
+readonly multiFactor?: MultiFactorSettings;
+```
+
+## UserRecord.passwordHash
+
+The user's hashed password (base64-encoded), only if Firebase Auth hashing algorithm (SCRYPT) is used. If a different hashing algorithm had been used when uploading this user, as is typical when migrating from another Auth system, this will be an empty string. If no password is set, this is null. This is only available when the user is obtained from .
+
+<b>Signature:</b>
+
+```typescript
+readonly passwordHash?: string;
+```
+
+## UserRecord.passwordSalt
+
+The user's password salt (base64-encoded), only if Firebase Auth hashing algorithm (SCRYPT) is used. If a different hashing algorithm had been used to upload this user, typical when migrating from another Auth system, this will be an empty string. If no password is set, this is null. This is only available when the user is obtained from .
+
+<b>Signature:</b>
+
+```typescript
+readonly passwordSalt?: string;
+```
+
+## UserRecord.phoneNumber
+
+The user's primary phone number, if set.
+
+<b>Signature:</b>
+
+```typescript
+readonly phoneNumber?: string;
+```
+
+## UserRecord.photoURL
+
+The user's photo URL.
+
+<b>Signature:</b>
+
+```typescript
+readonly photoURL?: string;
+```
+
+## UserRecord.providerData
+
+An array of providers (for example, Google, Facebook) linked to the user.
+
+<b>Signature:</b>
+
+```typescript
+readonly providerData: UserInfo[];
+```
+
+## UserRecord.tenantId
+
+The ID of the tenant the user belongs to, if available.
+
+<b>Signature:</b>
+
+```typescript
+readonly tenantId?: string | null;
+```
+
+## UserRecord.tokensValidAfterTime
+
+The date the user's tokens are valid after, formatted as a UTC string. This is updated every time the user's refresh token are revoked either from the  API or from the Firebase Auth backend on big account changes (password resets, password or email updates, etc).
+
+<b>Signature:</b>
+
+```typescript
+readonly tokensValidAfterTime?: string;
+```
+
+## UserRecord.uid
+
+The user's `uid`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+readonly uid: string;
+```
+
+## UserRecord.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.database.database.md
+++ b/docgen/markdown/firebase-admin.database.database.md
@@ -1,0 +1,69 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Database interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface Database extends FirebaseDatabase 
+```
+<b>Extends:</b> FirebaseDatabase
+
+## Methods
+
+|  Method | Description |
+|  --- | --- |
+|  [getRules()](./firebase-admin.database.database.md#databasegetrules) | Gets the currently applied security rules as a string. The return value consists of the rules source including comments. A promise fulfilled with the rules as a raw string. |
+|  [getRulesJSON()](./firebase-admin.database.database.md#databasegetrulesjson) | Gets the currently applied security rules as a parsed JSON object. Any comments in the original source are stripped away. A promise fulfilled with the parsed rules object. |
+|  [setRules(source)](./firebase-admin.database.database.md#databasesetrules) | Sets the specified rules on the Firebase Realtime Database instance. If the rules source is specified as a string or a Buffer, it may include comments. |
+
+## Database.getRules()
+
+Gets the currently applied security rules as a string. The return value consists of the rules source including comments.
+
+ A promise fulfilled with the rules as a raw string.
+
+<b>Signature:</b>
+
+```typescript
+getRules(): Promise<string>;
+```
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## Database.getRulesJSON()
+
+Gets the currently applied security rules as a parsed JSON object. Any comments in the original source are stripped away.
+
+ A promise fulfilled with the parsed rules object.
+
+<b>Signature:</b>
+
+```typescript
+getRulesJSON(): Promise<object>;
+```
+<b>Returns:</b>
+
+Promise&lt;object&gt;
+
+## Database.setRules()
+
+Sets the specified rules on the Firebase Realtime Database instance. If the rules source is specified as a string or a Buffer, it may include comments.
+
+<b>Signature:</b>
+
+```typescript
+setRules(source: string | Buffer | object): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  source | string \| Buffer \| object | Source of the rules to apply. Must not be <code>null</code> or empty.  Resolves when the rules are set on the Realtime Database. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.database.md
+++ b/docgen/markdown/firebase-admin.database.md
@@ -1,0 +1,125 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.database package{% endblock title %}
+{% block body %}
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getDatabase(app)](./firebase-admin.database.md#getdatabase) | Gets the  service for the default app or a given app.<code>getDatabase()</code> can be called with no arguments to access the default app's  service or as <code>getDatabase(app)</code> to access the  service associated with a specific app. |
+|  [getDatabaseWithUrl(url, app)](./firebase-admin.database.md#getdatabasewithurl) | Gets the  service for the default app or a given app.<code>getDatabaseWithUrl()</code> can be called with no arguments to access the default app's  service or as <code>getDatabaseWithUrl(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [Database](./firebase-admin.database.database.md#database_interface) |  |
+
+## Variables
+
+|  Variable | Description |
+|  --- | --- |
+|  [enableLogging](./firebase-admin.database.md#enablelogging) | \[<code>enableLogging</code>\](https://firebase.google.com/docs/reference/js/firebase.database\#enablelogging) function from the <code>@firebase/database</code> package. |
+|  [ServerValue](./firebase-admin.database.md#servervalue) | \[<code>ServerValue</code>\](https://firebase.google.com/docs/reference/js/firebase.database.ServerValue) module from the <code>@firebase/database</code> package. |
+
+## getDatabase()
+
+Gets the  service for the default app or a given app.
+
+`getDatabase()` can be called with no arguments to access the default app's  service or as `getDatabase(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getDatabase(app?: App): Database;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App |  |
+
+<b>Returns:</b>
+
+[Database](./firebase-admin.database.database.md#database_interface)
+
+### Example 1
+
+
+```javascript
+// Get the Database service for the default app
+const defaultDatabase = getDatabase();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Database service for a specific app
+const otherDatabase = getDatabase(app);
+
+```
+
+## getDatabaseWithUrl()
+
+Gets the  service for the default app or a given app.
+
+`getDatabaseWithUrl()` can be called with no arguments to access the default app's  service or as `getDatabaseWithUrl(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getDatabaseWithUrl(url: string, app?: App): Database;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  url | string |  |
+|  app | App |  |
+
+<b>Returns:</b>
+
+[Database](./firebase-admin.database.database.md#database_interface)
+
+### Example 1
+
+
+```javascript
+// Get the Database service for the default app
+const defaultDatabase = getDatabaseWithUrl('https://example.firebaseio.com');
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Database service for a specific app
+const otherDatabase = getDatabaseWithUrl('https://example.firebaseio.com', app);
+
+```
+
+## enableLogging
+
+\[`enableLogging`<!-- -->\](https://firebase.google.com/docs/reference/js/firebase.database\#enablelogging) function from the `@firebase/database` package.
+
+<b>Signature:</b>
+
+```typescript
+enableLogging: typeof rtdb.enableLogging
+```
+
+## ServerValue
+
+\[`ServerValue`<!-- -->\](https://firebase.google.com/docs/reference/js/firebase.database.ServerValue) module from the `@firebase/database` package.
+
+<b>Signature:</b>
+
+```typescript
+ServerValue: rtdb.ServerValue
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.firebasearrayindexerror.md
+++ b/docgen/markdown/firebase-admin.firebasearrayindexerror.md
@@ -1,0 +1,62 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}FirebaseArrayIndexError interface{% endblock title %}
+{% block body %}
+Composite type which includes both a `FirebaseError` object and an index which can be used to get the errored item.
+
+<b>Signature:</b>
+
+```typescript
+export interface FirebaseArrayIndexError 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [error](./firebase-admin.firebasearrayindexerror.md#firebasearrayindexerrorerror) | [FirebaseError](./firebase-admin.firebaseerror.md#firebaseerror_interface) | The error object. |
+|  [index](./firebase-admin.firebasearrayindexerror.md#firebasearrayindexerrorindex) | number | The index of the errored item within the original array passed as part of the called API method. |
+
+## FirebaseArrayIndexError.error
+
+The error object.
+
+<b>Signature:</b>
+
+```typescript
+error: FirebaseError;
+```
+
+## FirebaseArrayIndexError.index
+
+The index of the errored item within the original array passed as part of the called API method.
+
+<b>Signature:</b>
+
+```typescript
+index: number;
+```
+
+### Example
+
+
+```javascript
+var registrationTokens = [token1, token2, token3];
+admin.messaging().subscribeToTopic(registrationTokens, 'topic-name')
+  .then(function(response) {
+    if (response.failureCount > 0) {
+      console.log("Following devices unsucessfully subscribed to topic:");
+      response.errors.forEach(function(error) {
+        var invalidToken = registrationTokens[error.index];
+        console.log(invalidToken, error.error);
+      });
+    } else {
+      console.log("All devices successfully subscribed to topic:", response);
+    }
+  })
+  .catch(function(error) {
+    console.log("Error subscribing to topic:", error);
+  });
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.firebaseerror.md
+++ b/docgen/markdown/firebase-admin.firebaseerror.md
@@ -1,0 +1,75 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}FirebaseError interface{% endblock title %}
+{% block body %}
+`FirebaseError` is a subclass of the standard JavaScript `Error` object. In addition to a message string and stack trace, it contains a string code.
+
+<b>Signature:</b>
+
+```typescript
+export interface FirebaseError 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [code](./firebase-admin.firebaseerror.md#firebaseerrorcode) | string | Error codes are strings using the following format: <code>&quot;service/string-code&quot;</code>. Some examples include <code>&quot;auth/invalid-uid&quot;</code> and <code>&quot;messaging/invalid-recipient&quot;</code>.<!-- -->While the message for a given error can change, the code will remain the same between backward-compatible versions of the Firebase SDK. |
+|  [message](./firebase-admin.firebaseerror.md#firebaseerrormessage) | string | An explanatory message for the error that just occurred.<!-- -->This message is designed to be helpful to you, the developer. Because it generally does not convey meaningful information to end users, this message should not be displayed in your application. |
+|  [stack](./firebase-admin.firebaseerror.md#firebaseerrorstack) | string | A string value containing the execution backtrace when the error originally occurred.<!-- -->This information can be useful to you and can be sent to  to help explain the cause of an error. |
+
+## Methods
+
+|  Method | Description |
+|  --- | --- |
+|  [toJSON()](./firebase-admin.firebaseerror.md#firebaseerrortojson) |  A JSON-serializable representation of this object. |
+
+## FirebaseError.code
+
+Error codes are strings using the following format: `"service/string-code"`<!-- -->. Some examples include `"auth/invalid-uid"` and `"messaging/invalid-recipient"`<!-- -->.
+
+While the message for a given error can change, the code will remain the same between backward-compatible versions of the Firebase SDK.
+
+<b>Signature:</b>
+
+```typescript
+code: string;
+```
+
+## FirebaseError.message
+
+An explanatory message for the error that just occurred.
+
+This message is designed to be helpful to you, the developer. Because it generally does not convey meaningful information to end users, this message should not be displayed in your application.
+
+<b>Signature:</b>
+
+```typescript
+message: string;
+```
+
+## FirebaseError.stack
+
+A string value containing the execution backtrace when the error originally occurred.
+
+This information can be useful to you and can be sent to  to help explain the cause of an error.
+
+<b>Signature:</b>
+
+```typescript
+stack?: string;
+```
+
+## FirebaseError.toJSON()
+
+ A JSON-serializable representation of this object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.firestore.md
+++ b/docgen/markdown/firebase-admin.firestore.md
@@ -1,0 +1,29 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.firestore package{% endblock title %}
+{% block body %}
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getFirestore(app)](./firebase-admin.firestore.md#getfirestore) |  |
+
+## getFirestore()
+
+<b>Signature:</b>
+
+```typescript
+export declare function getFirestore(app?: App): _firestore.Firestore;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App |  |
+
+<b>Returns:</b>
+
+\_firestore.Firestore
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.googleoauthaccesstoken.md
+++ b/docgen/markdown/firebase-admin.googleoauthaccesstoken.md
@@ -1,0 +1,34 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}GoogleOAuthAccessToken interface{% endblock title %}
+{% block body %}
+Interface for Google OAuth 2.0 access tokens.
+
+<b>Signature:</b>
+
+```typescript
+export interface GoogleOAuthAccessToken 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [access\_token](./firebase-admin.googleoauthaccesstoken.md#googleoauthaccesstokenaccess_token) | string |  |
+|  [expires\_in](./firebase-admin.googleoauthaccesstoken.md#googleoauthaccesstokenexpires_in) | number |  |
+
+## GoogleOAuthAccessToken.access\_token
+
+<b>Signature:</b>
+
+```typescript
+access_token: string;
+```
+
+## GoogleOAuthAccessToken.expires\_in
+
+<b>Signature:</b>
+
+```typescript
+expires_in: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.instance-id.instanceid.md
+++ b/docgen/markdown/firebase-admin.instance-id.instanceid.md
@@ -1,0 +1,58 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}InstanceId class{% endblock title %}
+{% block body %}
+The `InstanceId` service enables deleting the Firebase instance IDs associated with Firebase client app instances.
+
+<b>Signature:</b>
+
+```typescript
+export declare class InstanceId 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.instance-id.instanceid.md#instanceidapp) |  | App | Returns the app associated with this InstanceId instance. The app associated with this InstanceId instance. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [deleteInstanceId(instanceId)](./firebase-admin.instance-id.instanceid.md#instanceiddeleteinstanceid) |  | Deletes the specified instance ID and the associated data from Firebase.<!-- -->Note that Google Analytics for Firebase uses its own form of Instance ID to keep track of analytics data. Therefore deleting a Firebase Instance ID does not delete Analytics data. See \[Delete an Instance ID\](/support/privacy/manage-iids\#delete\_an\_instance\_id) for more information. |
+
+## InstanceId.app
+
+Returns the app associated with this InstanceId instance.
+
+ The app associated with this InstanceId instance.
+
+<b>Signature:</b>
+
+```typescript
+get app(): App;
+```
+
+## InstanceId.deleteInstanceId()
+
+Deletes the specified instance ID and the associated data from Firebase.
+
+Note that Google Analytics for Firebase uses its own form of Instance ID to keep track of analytics data. Therefore deleting a Firebase Instance ID does not delete Analytics data. See \[Delete an Instance ID\](/support/privacy/manage-iids\#delete\_an\_instance\_id) for more information.
+
+<b>Signature:</b>
+
+```typescript
+deleteInstanceId(instanceId: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  instanceId | string | The instance ID to be deleted. A promise fulfilled when the instance ID is deleted. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.instance-id.md
+++ b/docgen/markdown/firebase-admin.instance-id.md
@@ -1,0 +1,57 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.instance-id package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [InstanceId](./firebase-admin.instance-id.instanceid.md#instanceid_class) | The <code>InstanceId</code> service enables deleting the Firebase instance IDs associated with Firebase client app instances. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getInstanceId(app)](./firebase-admin.instance-id.md#getinstanceid) | Gets the  service for the default app or a given app.<code>getInstanceId()</code> can be called with no arguments to access the default app's  service or as <code>getInstanceId(app)</code> to access the  service associated with a specific app. |
+
+## getInstanceId()
+
+Gets the  service for the default app or a given app.
+
+`getInstanceId()` can be called with no arguments to access the default app's  service or as `getInstanceId(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getInstanceId(app?: App): InstanceId;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app whose <code>InstanceId</code> service to return. If not provided, the default <code>InstanceId</code> service will be returned. The default <code>InstanceId</code> service if no app is provided or the <code>InstanceId</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[InstanceId](./firebase-admin.instance-id.instanceid.md#instanceid_class)
+
+### Example 1
+
+
+```javascript
+// Get the Instance ID service for the default app
+const defaultInstanceId = getInstanceId();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Instance ID service for a given app
+const otherInstanceId = getInstanceId(otherApp);
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.automltflitemodeloptions.md
+++ b/docgen/markdown/firebase-admin.machine-learning.automltflitemodeloptions.md
@@ -1,0 +1,26 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AutoMLTfliteModelOptions interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface AutoMLTfliteModelOptions extends ModelOptionsBase 
+```
+<b>Extends:</b> [ModelOptionsBase](./firebase-admin.machine-learning.modeloptionsbase.md#modeloptionsbase_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [tfliteModel](./firebase-admin.machine-learning.automltflitemodeloptions.md#automltflitemodeloptionstflitemodel) | { automlModel: string; } |  |
+
+## AutoMLTfliteModelOptions.tfliteModel
+
+<b>Signature:</b>
+
+```typescript
+tfliteModel: {
+        automlModel: string;
+    };
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.gcstflitemodeloptions.md
+++ b/docgen/markdown/firebase-admin.machine-learning.gcstflitemodeloptions.md
@@ -1,0 +1,26 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}GcsTfliteModelOptions interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface GcsTfliteModelOptions extends ModelOptionsBase 
+```
+<b>Extends:</b> [ModelOptionsBase](./firebase-admin.machine-learning.modeloptionsbase.md#modeloptionsbase_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [tfliteModel](./firebase-admin.machine-learning.gcstflitemodeloptions.md#gcstflitemodeloptionstflitemodel) | { gcsTfliteUri: string; } |  |
+
+## GcsTfliteModelOptions.tfliteModel
+
+<b>Signature:</b>
+
+```typescript
+tfliteModel: {
+        gcsTfliteUri: string;
+    };
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.listmodelsoptions.md
+++ b/docgen/markdown/firebase-admin.machine-learning.listmodelsoptions.md
@@ -1,0 +1,68 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListModelsOptions interface{% endblock title %}
+{% block body %}
+Interface representing options for listing Models.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListModelsOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [filter](./firebase-admin.machine-learning.listmodelsoptions.md#listmodelsoptionsfilter) | string | An expression that specifies how to filter the results.<!-- -->Examples:
+```
+display_name = your_model
+display_name : experimental_*
+tags: face_detector AND tags: experimental
+state.published = true
+
+```
+See https://firebase.google.com/docs/ml/manage-hosted-models\#list\_your\_projects\_models |
+|  [pageSize](./firebase-admin.machine-learning.listmodelsoptions.md#listmodelsoptionspagesize) | number | The number of results to return in each page. |
+|  [pageToken](./firebase-admin.machine-learning.listmodelsoptions.md#listmodelsoptionspagetoken) | string | A token that specifies the result page to return. |
+
+## ListModelsOptions.filter
+
+An expression that specifies how to filter the results.
+
+Examples:
+
+```
+display_name = your_model
+display_name : experimental_*
+tags: face_detector AND tags: experimental
+state.published = true
+
+```
+See https://firebase.google.com/docs/ml/manage-hosted-models\#list\_your\_projects\_models
+
+<b>Signature:</b>
+
+```typescript
+filter?: string;
+```
+
+## ListModelsOptions.pageSize
+
+The number of results to return in each page.
+
+<b>Signature:</b>
+
+```typescript
+pageSize?: number;
+```
+
+## ListModelsOptions.pageToken
+
+A token that specifies the result page to return.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.listmodelsresult.md
+++ b/docgen/markdown/firebase-admin.machine-learning.listmodelsresult.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListModelsResult interface{% endblock title %}
+{% block body %}
+Response object for a listModels operation.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListModelsResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [models](./firebase-admin.machine-learning.listmodelsresult.md#listmodelsresultmodels) | [Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->\[\] | A list of models in your project. |
+|  [pageToken](./firebase-admin.machine-learning.listmodelsresult.md#listmodelsresultpagetoken) | string | A token you can use to retrieve the next page of results. If null, the current page is the final page. |
+
+## ListModelsResult.models
+
+A list of models in your project.
+
+<b>Signature:</b>
+
+```typescript
+readonly models: Model[];
+```
+
+## ListModelsResult.pageToken
+
+A token you can use to retrieve the next page of results. If null, the current page is the final page.
+
+<b>Signature:</b>
+
+```typescript
+readonly pageToken?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.machinelearning.md
+++ b/docgen/markdown/firebase-admin.machine-learning.machinelearning.md
@@ -1,0 +1,183 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MachineLearning class{% endblock title %}
+{% block body %}
+The Firebase `MachineLearning` service interface.
+
+<b>Signature:</b>
+
+```typescript
+export declare class MachineLearning 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.machine-learning.machinelearning.md#machinelearningapp) |  | App | The  associated with the current <code>MachineLearning</code> service instance. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [createModel(model)](./firebase-admin.machine-learning.machinelearning.md#machinelearningcreatemodel) |  | Creates a model in the current Firebase project. |
+|  [deleteModel(modelId)](./firebase-admin.machine-learning.machinelearning.md#machinelearningdeletemodel) |  | Deletes a model from the current project. |
+|  [getModel(modelId)](./firebase-admin.machine-learning.machinelearning.md#machinelearninggetmodel) |  | Gets the model specified by the given ID. |
+|  [listModels(options)](./firebase-admin.machine-learning.machinelearning.md#machinelearninglistmodels) |  | Lists the current project's models. |
+|  [publishModel(modelId)](./firebase-admin.machine-learning.machinelearning.md#machinelearningpublishmodel) |  | Publishes a Firebase ML model.<!-- -->A published model can be downloaded to client apps. |
+|  [unpublishModel(modelId)](./firebase-admin.machine-learning.machinelearning.md#machinelearningunpublishmodel) |  | Unpublishes a Firebase ML model. |
+|  [updateModel(modelId, model)](./firebase-admin.machine-learning.machinelearning.md#machinelearningupdatemodel) |  | Updates a model's metadata or model file. |
+
+## MachineLearning.app
+
+The  associated with the current `MachineLearning` service instance.
+
+<b>Signature:</b>
+
+```typescript
+get app(): App;
+```
+
+## MachineLearning.createModel()
+
+Creates a model in the current Firebase project.
+
+<b>Signature:</b>
+
+```typescript
+createModel(model: ModelOptions): Promise<Model>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  model | [ModelOptions](./firebase-admin.machine-learning.md#modeloptions) | The model to create. A Promise fulfilled with the created model. |
+
+<b>Returns:</b>
+
+Promise&lt;[Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->&gt;
+
+## MachineLearning.deleteModel()
+
+Deletes a model from the current project.
+
+<b>Signature:</b>
+
+```typescript
+deleteModel(modelId: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  modelId | string | The ID of the model to delete. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## MachineLearning.getModel()
+
+Gets the model specified by the given ID.
+
+<b>Signature:</b>
+
+```typescript
+getModel(modelId: string): Promise<Model>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  modelId | string | The ID of the model to get. A Promise fulfilled with the model object. |
+
+<b>Returns:</b>
+
+Promise&lt;[Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->&gt;
+
+## MachineLearning.listModels()
+
+Lists the current project's models.
+
+<b>Signature:</b>
+
+```typescript
+listModels(options?: ListModelsOptions): Promise<ListModelsResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  options | [ListModelsOptions](./firebase-admin.machine-learning.listmodelsoptions.md#listmodelsoptions_interface) | The listing options. A promise that resolves with the current (filtered) list of models and the next page token. For the last page, an empty list of models and no page token are returned. |
+
+<b>Returns:</b>
+
+Promise&lt;[ListModelsResult](./firebase-admin.machine-learning.listmodelsresult.md#listmodelsresult_interface)<!-- -->&gt;
+
+## MachineLearning.publishModel()
+
+Publishes a Firebase ML model.
+
+A published model can be downloaded to client apps.
+
+<b>Signature:</b>
+
+```typescript
+publishModel(modelId: string): Promise<Model>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  modelId | string | The ID of the model to publish. A Promise fulfilled with the published model. |
+
+<b>Returns:</b>
+
+Promise&lt;[Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->&gt;
+
+## MachineLearning.unpublishModel()
+
+Unpublishes a Firebase ML model.
+
+<b>Signature:</b>
+
+```typescript
+unpublishModel(modelId: string): Promise<Model>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  modelId | string | The ID of the model to unpublish. A Promise fulfilled with the unpublished model. |
+
+<b>Returns:</b>
+
+Promise&lt;[Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->&gt;
+
+## MachineLearning.updateModel()
+
+Updates a model's metadata or model file.
+
+<b>Signature:</b>
+
+```typescript
+updateModel(modelId: string, model: ModelOptions): Promise<Model>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  modelId | string | The ID of the model to update. |
+|  model | [ModelOptions](./firebase-admin.machine-learning.md#modeloptions) | The model fields to update. A Promise fulfilled with the updated model. |
+
+<b>Returns:</b>
+
+Promise&lt;[Model](./firebase-admin.machine-learning.model.md#model_class)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.md
+++ b/docgen/markdown/firebase-admin.machine-learning.md
@@ -1,0 +1,82 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.machine-learning package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [MachineLearning](./firebase-admin.machine-learning.machinelearning.md#machinelearning_class) | The Firebase <code>MachineLearning</code> service interface. |
+|  [Model](./firebase-admin.machine-learning.model.md#model_class) | A Firebase ML Model output object. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getMachineLearning(app)](./firebase-admin.machine-learning.md#getmachinelearning) | Gets the  service for the default app or a given app.<code>getMachineLearning()</code> can be called with no arguments to access the default app's  service or as <code>getMachineLearning(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [AutoMLTfliteModelOptions](./firebase-admin.machine-learning.automltflitemodeloptions.md#automltflitemodeloptions_interface) |  |
+|  [GcsTfliteModelOptions](./firebase-admin.machine-learning.gcstflitemodeloptions.md#gcstflitemodeloptions_interface) |  |
+|  [ListModelsOptions](./firebase-admin.machine-learning.listmodelsoptions.md#listmodelsoptions_interface) | Interface representing options for listing Models. |
+|  [ListModelsResult](./firebase-admin.machine-learning.listmodelsresult.md#listmodelsresult_interface) | Response object for a listModels operation. |
+|  [ModelOptionsBase](./firebase-admin.machine-learning.modeloptionsbase.md#modeloptionsbase_interface) | Firebase ML Model input objects |
+|  [TFLiteModel](./firebase-admin.machine-learning.tflitemodel.md#tflitemodel_interface) | A TensorFlow Lite Model output object<!-- -->One of either the <code>gcsTfliteUri</code> or <code>automlModel</code> properties will be defined. |
+
+## Type Aliases
+
+|  Type Alias | Description |
+|  --- | --- |
+|  [ModelOptions](./firebase-admin.machine-learning.md#modeloptions) |  |
+
+## getMachineLearning()
+
+Gets the  service for the default app or a given app.
+
+`getMachineLearning()` can be called with no arguments to access the default app's  service or as `getMachineLearning(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getMachineLearning(app?: App): MachineLearning;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app whose <code>MachineLearning</code> service to return. If not provided, the default <code>MachineLearning</code> service will be returned. The default <code>MachineLearning</code> service if no app is provided or the <code>MachineLearning</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[MachineLearning](./firebase-admin.machine-learning.machinelearning.md#machinelearning_class)
+
+### Example 1
+
+
+```javascript
+// Get the MachineLearning service for the default app
+const defaultMachineLearning = getMachineLearning();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the MachineLearning service for a given app
+const otherMachineLearning = getMachineLearning(otherApp);
+
+```
+
+## ModelOptions
+
+<b>Signature:</b>
+
+```typescript
+export declare type ModelOptions = ModelOptionsBase | GcsTfliteModelOptions | AutoMLTfliteModelOptions;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.model.md
+++ b/docgen/markdown/firebase-admin.machine-learning.model.md
@@ -1,0 +1,180 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Model class{% endblock title %}
+{% block body %}
+A Firebase ML Model output object.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Model 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [createTime](./firebase-admin.machine-learning.model.md#modelcreatetime) |  | string | The timestamp of the model's creation. |
+|  [displayName](./firebase-admin.machine-learning.model.md#modeldisplayname) |  | string | The model's name. This is the name you use from your app to load the model. |
+|  [etag](./firebase-admin.machine-learning.model.md#modeletag) |  | string | The ETag identifier of the current version of the model. This value changes whenever you update any of the model's properties. |
+|  [locked](./firebase-admin.machine-learning.model.md#modellocked) |  | boolean | True if the model is locked by a server-side operation. You can't make changes to a locked model. See . |
+|  [modelHash](./firebase-admin.machine-learning.model.md#modelmodelhash) |  | string \| undefined | The hash of the model's <code>tflite</code> file. This value changes only when you upload a new TensorFlow Lite model. |
+|  [modelId](./firebase-admin.machine-learning.model.md#modelmodelid) |  | string | The ID of the model. |
+|  [published](./firebase-admin.machine-learning.model.md#modelpublished) |  | boolean | True if the model is published. |
+|  [tags](./firebase-admin.machine-learning.model.md#modeltags) |  | string\[\] | The model's tags, which can be used to group or filter models in list operations. |
+|  [tfliteModel](./firebase-admin.machine-learning.model.md#modeltflitemodel) |  | [TFLiteModel](./firebase-admin.machine-learning.tflitemodel.md#tflitemodel_interface) \| undefined | Metadata about the model's TensorFlow Lite model file. |
+|  [updateTime](./firebase-admin.machine-learning.model.md#modelupdatetime) |  | string | The timestamp of the model's most recent update. |
+|  [validationError](./firebase-admin.machine-learning.model.md#modelvalidationerror) |  | string \| undefined | Error message when model validation fails. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [toJSON()](./firebase-admin.machine-learning.model.md#modeltojson) |  | Return the model as a JSON object. |
+|  [waitForUnlocked(maxTimeMillis)](./firebase-admin.machine-learning.model.md#modelwaitforunlocked) |  | Wait for the model to be unlocked. |
+
+## Model.createTime
+
+The timestamp of the model's creation.
+
+<b>Signature:</b>
+
+```typescript
+get createTime(): string;
+```
+
+## Model.displayName
+
+The model's name. This is the name you use from your app to load the model.
+
+<b>Signature:</b>
+
+```typescript
+get displayName(): string;
+```
+
+## Model.etag
+
+The ETag identifier of the current version of the model. This value changes whenever you update any of the model's properties.
+
+<b>Signature:</b>
+
+```typescript
+get etag(): string;
+```
+
+## Model.locked
+
+True if the model is locked by a server-side operation. You can't make changes to a locked model. See .
+
+<b>Signature:</b>
+
+```typescript
+get locked(): boolean;
+```
+
+## Model.modelHash
+
+The hash of the model's `tflite` file. This value changes only when you upload a new TensorFlow Lite model.
+
+<b>Signature:</b>
+
+```typescript
+get modelHash(): string | undefined;
+```
+
+## Model.modelId
+
+The ID of the model.
+
+<b>Signature:</b>
+
+```typescript
+get modelId(): string;
+```
+
+## Model.published
+
+True if the model is published.
+
+<b>Signature:</b>
+
+```typescript
+get published(): boolean;
+```
+
+## Model.tags
+
+The model's tags, which can be used to group or filter models in list operations.
+
+<b>Signature:</b>
+
+```typescript
+get tags(): string[];
+```
+
+## Model.tfliteModel
+
+Metadata about the model's TensorFlow Lite model file.
+
+<b>Signature:</b>
+
+```typescript
+get tfliteModel(): TFLiteModel | undefined;
+```
+
+## Model.updateTime
+
+The timestamp of the model's most recent update.
+
+<b>Signature:</b>
+
+```typescript
+get updateTime(): string;
+```
+
+## Model.validationError
+
+Error message when model validation fails.
+
+<b>Signature:</b>
+
+```typescript
+get validationError(): string | undefined;
+```
+
+## Model.toJSON()
+
+Return the model as a JSON object.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): {
+        [key: string]: any;
+    };
+```
+<b>Returns:</b>
+
+{ \[key: string\]: any; }
+
+## Model.waitForUnlocked()
+
+Wait for the model to be unlocked.
+
+<b>Signature:</b>
+
+```typescript
+waitForUnlocked(maxTimeMillis?: number): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  maxTimeMillis | number | The maximum time in milliseconds to wait. If not specified, a default maximum of 2 minutes is used. A promise that resolves when the model is unlocked or the maximum wait time has passed. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.modeloptionsbase.md
+++ b/docgen/markdown/firebase-admin.machine-learning.modeloptionsbase.md
@@ -1,0 +1,34 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ModelOptionsBase interface{% endblock title %}
+{% block body %}
+Firebase ML Model input objects
+
+<b>Signature:</b>
+
+```typescript
+export interface ModelOptionsBase 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [displayName](./firebase-admin.machine-learning.modeloptionsbase.md#modeloptionsbasedisplayname) | string |  |
+|  [tags](./firebase-admin.machine-learning.modeloptionsbase.md#modeloptionsbasetags) | string\[\] |  |
+
+## ModelOptionsBase.displayName
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+## ModelOptionsBase.tags
+
+<b>Signature:</b>
+
+```typescript
+tags?: string[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.machine-learning.tflitemodel.md
+++ b/docgen/markdown/firebase-admin.machine-learning.tflitemodel.md
@@ -1,0 +1,51 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}TFLiteModel interface{% endblock title %}
+{% block body %}
+A TensorFlow Lite Model output object
+
+One of either the `gcsTfliteUri` or `automlModel` properties will be defined.
+
+<b>Signature:</b>
+
+```typescript
+export interface TFLiteModel 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [automlModel](./firebase-admin.machine-learning.tflitemodel.md#tflitemodelautomlmodel) | string | The AutoML model reference from which the model was originally provided to Firebase. |
+|  [gcsTfliteUri](./firebase-admin.machine-learning.tflitemodel.md#tflitemodelgcstfliteuri) | string | The URI from which the model was originally provided to Firebase. |
+|  [sizeBytes](./firebase-admin.machine-learning.tflitemodel.md#tflitemodelsizebytes) | number | The size of the model. |
+
+## TFLiteModel.automlModel
+
+The AutoML model reference from which the model was originally provided to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+readonly automlModel?: string;
+```
+
+## TFLiteModel.gcsTfliteUri
+
+The URI from which the model was originally provided to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+readonly gcsTfliteUri?: string;
+```
+
+## TFLiteModel.sizeBytes
+
+The size of the model.
+
+<b>Signature:</b>
+
+```typescript
+readonly sizeBytes: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.md
+++ b/docgen/markdown/firebase-admin.md
@@ -1,0 +1,484 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin package{% endblock title %}
+{% block body %}
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [app(name)](./firebase-admin.md#app) |  |
+|  [auth(app)](./firebase-admin.md#auth) | Gets the  service for the default app or a given app.<code>admin.auth()</code> can be called with no arguments to access the default app's  service or as <code>admin.auth(app)</code> to access the  service associated with a specific app. |
+|  [database(app)](./firebase-admin.md#database) | Gets the  service for the default app or a given app.<code>admin.database()</code> can be called with no arguments to access the default app's  service or as <code>admin.database(app)</code> to access the  service associated with a specific app.<code>admin.database</code> is also a namespace that can be used to access global constants and methods associated with the <code>Database</code> service. |
+|  [firestore(app)](./firebase-admin.md#firestore) |  |
+|  [initializeApp(options, name)](./firebase-admin.md#initializeapp) |  |
+|  [instanceId(app)](./firebase-admin.md#instanceid) | Gets the  service for the default app or a given app.<code>admin.instanceId()</code> can be called with no arguments to access the default app's  service or as <code>admin.instanceId(app)</code> to access the  service associated with a specific app. |
+|  [machineLearning(app)](./firebase-admin.md#machinelearning) | Gets the  service for the default app or a given app.<code>admin.machineLearning()</code> can be called with no arguments to access the default app's  service or as <code>admin.machineLearning(app)</code> to access the  service associated with a specific app. |
+|  [messaging(app)](./firebase-admin.md#messaging) | Gets the  service for the default app or a given app.<code>admin.messaging()</code> can be called with no arguments to access the default app's  service or as <code>admin.messaging(app)</code> to access the  service associated with a specific app. |
+|  [projectManagement(app)](./firebase-admin.md#projectmanagement) | Gets the  service for the default app or a given app.<code>admin.projectManagement()</code> can be called with no arguments to access the default app's  service, or as <code>admin.projectManagement(app)</code> to access the  service associated with a specific app. |
+|  [remoteConfig(app)](./firebase-admin.md#remoteconfig) | Gets the  service for the default app or a given app.<code>admin.remoteConfig()</code> can be called with no arguments to access the default app's  service or as <code>admin.remoteConfig(app)</code> to access the  service associated with a specific app. |
+|  [securityRules(app)](./firebase-admin.md#securityrules) | Gets the  service for the default app or a given app.<code>admin.securityRules()</code> can be called with no arguments to access the default app's  service, or as <code>admin.securityRules(app)</code> to access the  service associated with a specific app. |
+|  [storage(app)](./firebase-admin.md#storage) | Gets the  service for the default app or a given app.<code>admin.storage()</code> can be called with no arguments to access the default app's  service or as <code>admin.storage(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [App](./firebase-admin.app.md#app_interface) | A Firebase app holds the initialization information for a collection of services.<!-- -->Do not call this constructor directly. Instead, use  to create an app. |
+|  [AppOptions](./firebase-admin.appoptions.md#appoptions_interface) | Available options to pass to \[<code>initializeApp()</code>\](admin\#.initializeApp). |
+|  [FirebaseArrayIndexError](./firebase-admin.firebasearrayindexerror.md#firebasearrayindexerror_interface) | Composite type which includes both a <code>FirebaseError</code> object and an index which can be used to get the errored item. |
+|  [FirebaseError](./firebase-admin.firebaseerror.md#firebaseerror_interface) | <code>FirebaseError</code> is a subclass of the standard JavaScript <code>Error</code> object. In addition to a message string and stack trace, it contains a string code. |
+|  [GoogleOAuthAccessToken](./firebase-admin.googleoauthaccesstoken.md#googleoauthaccesstoken_interface) | Interface for Google OAuth 2.0 access tokens. |
+|  [ServiceAccount](./firebase-admin.serviceaccount.md#serviceaccount_interface) |  |
+
+## Namespaces
+
+|  Namespace | Description |
+|  --- | --- |
+|  [app](./firebase-admin.md#app_namespace) |  |
+|  [auth](./firebase-admin.md#auth_namespace) |  |
+|  [credential](./firebase-admin.md#credential_namespace) |  |
+|  [database](./firebase-admin.md#database_namespace) |  |
+|  [firestore](./firebase-admin.md#firestore_namespace) |  |
+|  [instanceId](./firebase-admin.md#instanceid_namespace) |  |
+|  [machineLearning](./firebase-admin.md#machinelearning_namespace) |  |
+|  [messaging](./firebase-admin.md#messaging_namespace) |  |
+|  [projectManagement](./firebase-admin.md#projectmanagement_namespace) |  |
+|  [remoteConfig](./firebase-admin.md#remoteconfig_namespace) |  |
+|  [securityRules](./firebase-admin.md#securityrules_namespace) |  |
+|  [storage](./firebase-admin.md#storage_namespace) |  |
+
+## Variables
+
+|  Variable | Description |
+|  --- | --- |
+|  [apps](./firebase-admin.md#apps) |  |
+|  [SDK\_VERSION](./firebase-admin.md#sdk_version) |  |
+
+## app()
+
+<b>Signature:</b>
+
+```typescript
+export declare function app(name?: string): app.App;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string |  |
+
+<b>Returns:</b>
+
+[app.App](./firebase-admin.app.md#appapp_interface)
+
+## auth()
+
+Gets the  service for the default app or a given app.
+
+`admin.auth()` can be called with no arguments to access the default app's  service or as `admin.auth(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function auth(app?: App): auth.Auth;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) |  |
+
+<b>Returns:</b>
+
+[auth.Auth](./firebase-admin.md#authauth)
+
+### Example 1
+
+
+```javascript
+// Get the Auth service for the default app
+var defaultAuth = admin.auth();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Auth service for a given app
+var otherAuth = admin.auth(otherApp);
+
+```
+
+## database()
+
+Gets the  service for the default app or a given app.
+
+`admin.database()` can be called with no arguments to access the default app's  service or as `admin.database(app)` to access the  service associated with a specific app.
+
+`admin.database` is also a namespace that can be used to access global constants and methods associated with the `Database` service.
+
+<b>Signature:</b>
+
+```typescript
+export declare function database(app?: App): database.Database;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) |  |
+
+<b>Returns:</b>
+
+[database.Database](./firebase-admin.md#databasedatabase)
+
+### Example 1
+
+
+```javascript
+// Get the Database service for the default app
+var defaultDatabase = admin.database();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Database service for a specific app
+var otherDatabase = admin.database(app);
+
+```
+
+## firestore()
+
+<b>Signature:</b>
+
+```typescript
+export declare function firestore(app?: App): _firestore.Firestore;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) |  |
+
+<b>Returns:</b>
+
+\_firestore.Firestore
+
+## initializeApp()
+
+<b>Signature:</b>
+
+```typescript
+export declare function initializeApp(options?: AppOptions, name?: string): app.App;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  options | [AppOptions](./firebase-admin.appoptions.md#appoptions_interface) |  |
+|  name | string |  |
+
+<b>Returns:</b>
+
+[app.App](./firebase-admin.app.md#appapp_interface)
+
+## instanceId()
+
+Gets the  service for the default app or a given app.
+
+`admin.instanceId()` can be called with no arguments to access the default app's  service or as `admin.instanceId(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function instanceId(app?: App): instanceId.InstanceId;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app whose <code>InstanceId</code> service to return. If not provided, the default <code>InstanceId</code> service will be returned. The default <code>InstanceId</code> service if no app is provided or the <code>InstanceId</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[instanceId.InstanceId](./firebase-admin.md#instanceidinstanceid)
+
+### Example 1
+
+
+```javascript
+// Get the Instance ID service for the default app
+var defaultInstanceId = admin.instanceId();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Instance ID service for a given app
+var otherInstanceId = admin.instanceId(otherApp);
+
+```
+
+## machineLearning()
+
+Gets the  service for the default app or a given app.
+
+`admin.machineLearning()` can be called with no arguments to access the default app's  service or as `admin.machineLearning(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function machineLearning(app?: App): machineLearning.MachineLearning;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app whose <code>MachineLearning</code> service to return. If not provided, the default <code>MachineLearning</code> service will be returned. The default <code>MachineLearning</code> service if no app is provided or the <code>MachineLearning</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[machineLearning.MachineLearning](./firebase-admin.md#machinelearningmachinelearning)
+
+### Example 1
+
+
+```javascript
+// Get the MachineLearning service for the default app
+var defaultMachineLearning = admin.machineLearning();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the MachineLearning service for a given app
+var otherMachineLearning = admin.machineLearning(otherApp);
+
+```
+
+## messaging()
+
+Gets the  service for the default app or a given app.
+
+`admin.messaging()` can be called with no arguments to access the default app's  service or as `admin.messaging(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function messaging(app?: App): messaging.Messaging;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app whose <code>Messaging</code> service to return. If not provided, the default <code>Messaging</code> service will be returned. The default <code>Messaging</code> service if no app is provided or the <code>Messaging</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[messaging.Messaging](./firebase-admin.md#messagingmessaging)
+
+### Example 1
+
+
+```javascript
+// Get the Messaging service for the default app
+var defaultMessaging = admin.messaging();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Messaging service for a given app
+var otherMessaging = admin.messaging(otherApp);
+
+```
+
+## projectManagement()
+
+Gets the  service for the default app or a given app.
+
+`admin.projectManagement()` can be called with no arguments to access the default app's  service, or as `admin.projectManagement(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function projectManagement(app?: App): projectManagement.ProjectManagement;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app whose <code>ProjectManagement</code> service to return. If not provided, the default <code>ProjectManagement</code> service will be returned. \*  The default <code>ProjectManagement</code> service if no app is provided or the <code>ProjectManagement</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[projectManagement.ProjectManagement](./firebase-admin.md#projectmanagementprojectmanagement)
+
+### Example 1
+
+
+```javascript
+// Get the ProjectManagement service for the default app
+var defaultProjectManagement = admin.projectManagement();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the ProjectManagement service for a given app
+var otherProjectManagement = admin.projectManagement(otherApp);
+
+```
+
+## remoteConfig()
+
+Gets the  service for the default app or a given app.
+
+`admin.remoteConfig()` can be called with no arguments to access the default app's  service or as `admin.remoteConfig(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function remoteConfig(app?: App): remoteConfig.RemoteConfig;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app for which to return the <code>RemoteConfig</code> service. If not provided, the default <code>RemoteConfig</code> service is returned. The default <code>RemoteConfig</code> service if no app is provided, or the <code>RemoteConfig</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[remoteConfig.RemoteConfig](./firebase-admin.md#remoteconfigremoteconfig)
+
+### Example 1
+
+
+```javascript
+// Get the `RemoteConfig` service for the default app
+var defaultRemoteConfig = admin.remoteConfig();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the `RemoteConfig` service for a given app
+var otherRemoteConfig = admin.remoteConfig(otherApp);
+
+```
+
+## securityRules()
+
+Gets the  service for the default app or a given app.
+
+`admin.securityRules()` can be called with no arguments to access the default app's  service, or as `admin.securityRules(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function securityRules(app?: App): securityRules.SecurityRules;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) | Optional app to return the <code>SecurityRules</code> service for. If not provided, the default <code>SecurityRules</code> service is returned.  The default <code>SecurityRules</code> service if no app is provided, or the <code>SecurityRules</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[securityRules.SecurityRules](./firebase-admin.md#securityrulessecurityrules)
+
+### Example 1
+
+
+```javascript
+// Get the SecurityRules service for the default app
+var defaultSecurityRules = admin.securityRules();
+
+```
+
+### Example 2
+
+\`\`\`<!-- -->javascript // Get the SecurityRules service for a given app var otherSecurityRules = admin.securityRules(otherApp); \`\`\`
+
+## storage()
+
+Gets the  service for the default app or a given app.
+
+`admin.storage()` can be called with no arguments to access the default app's  service or as `admin.storage(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function storage(app?: App): storage.Storage;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [App](./firebase-admin.app.md#app_interface) |  |
+
+<b>Returns:</b>
+
+[storage.Storage](./firebase-admin.md#storagestorage)
+
+### Example 1
+
+
+```javascript
+// Get the Storage service for the default app
+var defaultStorage = admin.storage();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Storage service for a given app
+var otherStorage = admin.storage(otherApp);
+
+```
+
+## apps
+
+<b>Signature:</b>
+
+```typescript
+apps: (app.App | null)[]
+```
+
+## SDK\_VERSION
+
+<b>Signature:</b>
+
+```typescript
+SDK_VERSION: string
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.androidconfig.md
+++ b/docgen/markdown/firebase-admin.messaging.androidconfig.md
@@ -1,0 +1,95 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AndroidConfig interface{% endblock title %}
+{% block body %}
+Represents the Android-specific options that can be included in an .
+
+<b>Signature:</b>
+
+```typescript
+export interface AndroidConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [collapseKey](./firebase-admin.messaging.androidconfig.md#androidconfigcollapsekey) | string | Collapse key for the message. Collapse key serves as an identifier for a group of messages that can be collapsed, so that only the last message gets sent when delivery can be resumed. A maximum of four different collapse keys may be active at any given time. |
+|  [data](./firebase-admin.messaging.androidconfig.md#androidconfigdata) | { \[key: string\]: string; } | A collection of data fields to be included in the message. All values must be strings. When provided, overrides any data fields set on the top-level <code>admin.messaging.Message</code>.<!-- -->} |
+|  [fcmOptions](./firebase-admin.messaging.androidconfig.md#androidconfigfcmoptions) | [AndroidFcmOptions](./firebase-admin.messaging.androidfcmoptions.md#androidfcmoptions_interface) | Options for features provided by the FCM SDK for Android. |
+|  [notification](./firebase-admin.messaging.androidconfig.md#androidconfignotification) | [AndroidNotification](./firebase-admin.messaging.androidnotification.md#androidnotification_interface) | Android notification to be included in the message. |
+|  [priority](./firebase-admin.messaging.androidconfig.md#androidconfigpriority) | ('high' \| 'normal') | Priority of the message. Must be either <code>normal</code> or <code>high</code>. |
+|  [restrictedPackageName](./firebase-admin.messaging.androidconfig.md#androidconfigrestrictedpackagename) | string | Package name of the application where the registration tokens must match in order to receive the message. |
+|  [ttl](./firebase-admin.messaging.androidconfig.md#androidconfigttl) | number | Time-to-live duration of the message in milliseconds. |
+
+## AndroidConfig.collapseKey
+
+Collapse key for the message. Collapse key serves as an identifier for a group of messages that can be collapsed, so that only the last message gets sent when delivery can be resumed. A maximum of four different collapse keys may be active at any given time.
+
+<b>Signature:</b>
+
+```typescript
+collapseKey?: string;
+```
+
+## AndroidConfig.data
+
+A collection of data fields to be included in the message. All values must be strings. When provided, overrides any data fields set on the top-level `admin.messaging.Message`<!-- -->.<!-- -->}
+
+<b>Signature:</b>
+
+```typescript
+data?: {
+        [key: string]: string;
+    };
+```
+
+## AndroidConfig.fcmOptions
+
+Options for features provided by the FCM SDK for Android.
+
+<b>Signature:</b>
+
+```typescript
+fcmOptions?: AndroidFcmOptions;
+```
+
+## AndroidConfig.notification
+
+Android notification to be included in the message.
+
+<b>Signature:</b>
+
+```typescript
+notification?: AndroidNotification;
+```
+
+## AndroidConfig.priority
+
+Priority of the message. Must be either `normal` or `high`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+priority?: ('high' | 'normal');
+```
+
+## AndroidConfig.restrictedPackageName
+
+Package name of the application where the registration tokens must match in order to receive the message.
+
+<b>Signature:</b>
+
+```typescript
+restrictedPackageName?: string;
+```
+
+## AndroidConfig.ttl
+
+Time-to-live duration of the message in milliseconds.
+
+<b>Signature:</b>
+
+```typescript
+ttl?: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.androidfcmoptions.md
+++ b/docgen/markdown/firebase-admin.messaging.androidfcmoptions.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AndroidFcmOptions interface{% endblock title %}
+{% block body %}
+Represents options for features provided by the FCM SDK for Android.
+
+<b>Signature:</b>
+
+```typescript
+export interface AndroidFcmOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [analyticsLabel](./firebase-admin.messaging.androidfcmoptions.md#androidfcmoptionsanalyticslabel) | string | The label associated with the message's analytics data. |
+
+## AndroidFcmOptions.analyticsLabel
+
+The label associated with the message's analytics data.
+
+<b>Signature:</b>
+
+```typescript
+analyticsLabel?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.androidnotification.md
+++ b/docgen/markdown/firebase-admin.messaging.androidnotification.md
@@ -1,0 +1,291 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AndroidNotification interface{% endblock title %}
+{% block body %}
+Represents the Android-specific notification options that can be included in .
+
+<b>Signature:</b>
+
+```typescript
+export interface AndroidNotification 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [body](./firebase-admin.messaging.androidnotification.md#androidnotificationbody) | string | Body of the Android notification. When provided, overrides the body set via <code>admin.messaging.Notification</code>. |
+|  [bodyLocArgs](./firebase-admin.messaging.androidnotification.md#androidnotificationbodylocargs) | string\[\] | An array of resource keys that will be used in place of the format specifiers in <code>bodyLocKey</code>. |
+|  [bodyLocKey](./firebase-admin.messaging.androidnotification.md#androidnotificationbodylockey) | string | Key of the body string in the app's string resource to use to localize the body text. |
+|  [channelId](./firebase-admin.messaging.androidnotification.md#androidnotificationchannelid) | string | The Android notification channel ID (new in Android O). The app must create a channel with this channel ID before any notification with this channel ID can be received. If you don't send this channel ID in the request, or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the app manifest. |
+|  [clickAction](./firebase-admin.messaging.androidnotification.md#androidnotificationclickaction) | string | Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification. |
+|  [color](./firebase-admin.messaging.androidnotification.md#androidnotificationcolor) | string | Notification icon color in <code>#rrggbb</code> format. |
+|  [defaultLightSettings](./firebase-admin.messaging.androidnotification.md#androidnotificationdefaultlightsettings) | boolean | If set to <code>true</code>, use the Android framework's default LED light settings for the notification. Default values are specified in \[<code>config.xml</code>\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If <code>default_light_settings</code> is set to <code>true</code> and <code>light_settings</code> is also set, the user-specified <code>light_settings</code> is used instead of the default value. |
+|  [defaultSound](./firebase-admin.messaging.androidnotification.md#androidnotificationdefaultsound) | boolean | If set to <code>true</code>, use the Android framework's default sound for the notification. Default values are specified in \[<code>config.xml</code>\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). |
+|  [defaultVibrateTimings](./firebase-admin.messaging.androidnotification.md#androidnotificationdefaultvibratetimings) | boolean | If set to <code>true</code>, use the Android framework's default vibrate pattern for the notification. Default values are specified in \[<code>config.xml</code>\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If <code>default_vibrate_timings</code> is set to <code>true</code> and <code>vibrate_timings</code> is also set, the default value is used instead of the user-specified <code>vibrate_timings</code>. |
+|  [eventTimestamp](./firebase-admin.messaging.androidnotification.md#androidnotificationeventtimestamp) | Date | For notifications that inform users about events with an absolute time reference, sets the time that the event in the notification occurred. Notifications in the panel are sorted by this time. |
+|  [icon](./firebase-admin.messaging.androidnotification.md#androidnotificationicon) | string | Icon resource for the Android notification. |
+|  [imageUrl](./firebase-admin.messaging.androidnotification.md#androidnotificationimageurl) | string | URL of an image to be displayed in the notification. |
+|  [lightSettings](./firebase-admin.messaging.androidnotification.md#androidnotificationlightsettings) | [LightSettings](./firebase-admin.messaging.lightsettings.md#lightsettings_interface) | Settings to control the notification's LED blinking rate and color if LED is available on the device. The total blinking time is controlled by the OS. |
+|  [localOnly](./firebase-admin.messaging.androidnotification.md#androidnotificationlocalonly) | boolean | Sets whether or not this notification is relevant only to the current device. Some notifications can be bridged to other devices for remote display, such as a Wear OS watch. This hint can be set to recommend this notification not be bridged. See \[Wear OS guides\](https://developer.android.com/training/wearables/notifications/bridger\#existing-method-of-preventing-bridging) |
+|  [notificationCount](./firebase-admin.messaging.androidnotification.md#androidnotificationnotificationcount) | number | Sets the number of items this notification represents. May be displayed as a badge count for Launchers that support badging. See \[<code>NotificationBadge</code>(https://developer.android.com/training/notify-user/badges). For example, this might be useful if you're using just one notification to represent multiple new messages but you want the count here to represent the number of total new messages. If zero or unspecified, systems that support badging use the default, which is to increment a number displayed on the long-press menu each time a new notification arrives. |
+|  [priority](./firebase-admin.messaging.androidnotification.md#androidnotificationpriority) | ('min' \| 'low' \| 'default' \| 'high' \| 'max') | Sets the relative priority for this notification. Low-priority notifications may be hidden from the user in certain situations. Note this priority differs from <code>AndroidMessagePriority</code>. This priority is processed by the client after the message has been delivered. Whereas <code>AndroidMessagePriority</code> is an FCM concept that controls when the message is delivered. |
+|  [sound](./firebase-admin.messaging.androidnotification.md#androidnotificationsound) | string | File name of the sound to be played when the device receives the notification. |
+|  [sticky](./firebase-admin.messaging.androidnotification.md#androidnotificationsticky) | boolean | When set to <code>false</code> or unset, the notification is automatically dismissed when the user clicks it in the panel. When set to <code>true</code>, the notification persists even when the user clicks it. |
+|  [tag](./firebase-admin.messaging.androidnotification.md#androidnotificationtag) | string | Notification tag. This is an identifier used to replace existing notifications in the notification drawer. If not specified, each request creates a new notification. |
+|  [ticker](./firebase-admin.messaging.androidnotification.md#androidnotificationticker) | string | Sets the "ticker" text, which is sent to accessibility services. Prior to API level 21 (Lollipop), sets the text that is displayed in the status bar when the notification first arrives. |
+|  [title](./firebase-admin.messaging.androidnotification.md#androidnotificationtitle) | string | Title of the Android notification. When provided, overrides the title set via <code>admin.messaging.Notification</code>. |
+|  [titleLocArgs](./firebase-admin.messaging.androidnotification.md#androidnotificationtitlelocargs) | string\[\] | An array of resource keys that will be used in place of the format specifiers in <code>titleLocKey</code>. |
+|  [titleLocKey](./firebase-admin.messaging.androidnotification.md#androidnotificationtitlelockey) | string | Key of the title string in the app's string resource to use to localize the title text. |
+|  [vibrateTimingsMillis](./firebase-admin.messaging.androidnotification.md#androidnotificationvibratetimingsmillis) | number\[\] | Sets the vibration pattern to use. Pass in an array of milliseconds to turn the vibrator on or off. The first value indicates the duration to wait before turning the vibrator on. The next value indicates the duration to keep the vibrator on. Subsequent values alternate between duration to turn the vibrator off and to turn the vibrator on. If <code>vibrate_timings</code> is set and <code>default_vibrate_timings</code> is set to <code>true</code>, the default value is used instead of the user-specified <code>vibrate_timings</code>. |
+|  [visibility](./firebase-admin.messaging.androidnotification.md#androidnotificationvisibility) | ('private' \| 'public' \| 'secret') | Sets the visibility of the notification. Must be either <code>private</code>, <code>public</code>, or <code>secret</code>. If unspecified, defaults to <code>private</code>. |
+
+## AndroidNotification.body
+
+Body of the Android notification. When provided, overrides the body set via `admin.messaging.Notification`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+body?: string;
+```
+
+## AndroidNotification.bodyLocArgs
+
+An array of resource keys that will be used in place of the format specifiers in `bodyLocKey`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+bodyLocArgs?: string[];
+```
+
+## AndroidNotification.bodyLocKey
+
+Key of the body string in the app's string resource to use to localize the body text.
+
+<b>Signature:</b>
+
+```typescript
+bodyLocKey?: string;
+```
+
+## AndroidNotification.channelId
+
+The Android notification channel ID (new in Android O). The app must create a channel with this channel ID before any notification with this channel ID can be received. If you don't send this channel ID in the request, or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the app manifest.
+
+<b>Signature:</b>
+
+```typescript
+channelId?: string;
+```
+
+## AndroidNotification.clickAction
+
+Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.
+
+<b>Signature:</b>
+
+```typescript
+clickAction?: string;
+```
+
+## AndroidNotification.color
+
+Notification icon color in `#rrggbb` format.
+
+<b>Signature:</b>
+
+```typescript
+color?: string;
+```
+
+## AndroidNotification.defaultLightSettings
+
+If set to `true`<!-- -->, use the Android framework's default LED light settings for the notification. Default values are specified in \[`config.xml`<!-- -->\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If `default_light_settings` is set to `true` and `light_settings` is also set, the user-specified `light_settings` is used instead of the default value.
+
+<b>Signature:</b>
+
+```typescript
+defaultLightSettings?: boolean;
+```
+
+## AndroidNotification.defaultSound
+
+If set to `true`<!-- -->, use the Android framework's default sound for the notification. Default values are specified in \[`config.xml`<!-- -->\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml).
+
+<b>Signature:</b>
+
+```typescript
+defaultSound?: boolean;
+```
+
+## AndroidNotification.defaultVibrateTimings
+
+If set to `true`<!-- -->, use the Android framework's default vibrate pattern for the notification. Default values are specified in \[`config.xml`<!-- -->\](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If `default_vibrate_timings` is set to `true` and `vibrate_timings` is also set, the default value is used instead of the user-specified `vibrate_timings`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+defaultVibrateTimings?: boolean;
+```
+
+## AndroidNotification.eventTimestamp
+
+For notifications that inform users about events with an absolute time reference, sets the time that the event in the notification occurred. Notifications in the panel are sorted by this time.
+
+<b>Signature:</b>
+
+```typescript
+eventTimestamp?: Date;
+```
+
+## AndroidNotification.icon
+
+Icon resource for the Android notification.
+
+<b>Signature:</b>
+
+```typescript
+icon?: string;
+```
+
+## AndroidNotification.imageUrl
+
+URL of an image to be displayed in the notification.
+
+<b>Signature:</b>
+
+```typescript
+imageUrl?: string;
+```
+
+## AndroidNotification.lightSettings
+
+Settings to control the notification's LED blinking rate and color if LED is available on the device. The total blinking time is controlled by the OS.
+
+<b>Signature:</b>
+
+```typescript
+lightSettings?: LightSettings;
+```
+
+## AndroidNotification.localOnly
+
+Sets whether or not this notification is relevant only to the current device. Some notifications can be bridged to other devices for remote display, such as a Wear OS watch. This hint can be set to recommend this notification not be bridged. See \[Wear OS guides\](https://developer.android.com/training/wearables/notifications/bridger\#existing-method-of-preventing-bridging)
+
+<b>Signature:</b>
+
+```typescript
+localOnly?: boolean;
+```
+
+## AndroidNotification.notificationCount
+
+Sets the number of items this notification represents. May be displayed as a badge count for Launchers that support badging. See \[`NotificationBadge`<!-- -->(https://developer.android.com/training/notify-user/badges). For example, this might be useful if you're using just one notification to represent multiple new messages but you want the count here to represent the number of total new messages. If zero or unspecified, systems that support badging use the default, which is to increment a number displayed on the long-press menu each time a new notification arrives.
+
+<b>Signature:</b>
+
+```typescript
+notificationCount?: number;
+```
+
+## AndroidNotification.priority
+
+Sets the relative priority for this notification. Low-priority notifications may be hidden from the user in certain situations. Note this priority differs from `AndroidMessagePriority`<!-- -->. This priority is processed by the client after the message has been delivered. Whereas `AndroidMessagePriority` is an FCM concept that controls when the message is delivered.
+
+<b>Signature:</b>
+
+```typescript
+priority?: ('min' | 'low' | 'default' | 'high' | 'max');
+```
+
+## AndroidNotification.sound
+
+File name of the sound to be played when the device receives the notification.
+
+<b>Signature:</b>
+
+```typescript
+sound?: string;
+```
+
+## AndroidNotification.sticky
+
+When set to `false` or unset, the notification is automatically dismissed when the user clicks it in the panel. When set to `true`<!-- -->, the notification persists even when the user clicks it.
+
+<b>Signature:</b>
+
+```typescript
+sticky?: boolean;
+```
+
+## AndroidNotification.tag
+
+Notification tag. This is an identifier used to replace existing notifications in the notification drawer. If not specified, each request creates a new notification.
+
+<b>Signature:</b>
+
+```typescript
+tag?: string;
+```
+
+## AndroidNotification.ticker
+
+Sets the "ticker" text, which is sent to accessibility services. Prior to API level 21 (Lollipop), sets the text that is displayed in the status bar when the notification first arrives.
+
+<b>Signature:</b>
+
+```typescript
+ticker?: string;
+```
+
+## AndroidNotification.title
+
+Title of the Android notification. When provided, overrides the title set via `admin.messaging.Notification`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+title?: string;
+```
+
+## AndroidNotification.titleLocArgs
+
+An array of resource keys that will be used in place of the format specifiers in `titleLocKey`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+titleLocArgs?: string[];
+```
+
+## AndroidNotification.titleLocKey
+
+Key of the title string in the app's string resource to use to localize the title text.
+
+<b>Signature:</b>
+
+```typescript
+titleLocKey?: string;
+```
+
+## AndroidNotification.vibrateTimingsMillis
+
+Sets the vibration pattern to use. Pass in an array of milliseconds to turn the vibrator on or off. The first value indicates the duration to wait before turning the vibrator on. The next value indicates the duration to keep the vibrator on. Subsequent values alternate between duration to turn the vibrator off and to turn the vibrator on. If `vibrate_timings` is set and `default_vibrate_timings` is set to `true`<!-- -->, the default value is used instead of the user-specified `vibrate_timings`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+vibrateTimingsMillis?: number[];
+```
+
+## AndroidNotification.visibility
+
+Sets the visibility of the notification. Must be either `private`<!-- -->, `public`<!-- -->, or `secret`<!-- -->. If unspecified, defaults to `private`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+visibility?: ('private' | 'public' | 'secret');
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.apnsconfig.md
+++ b/docgen/markdown/firebase-admin.messaging.apnsconfig.md
@@ -1,0 +1,51 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ApnsConfig interface{% endblock title %}
+{% block body %}
+Represents the APNs-specific options that can be included in an . Refer to \[Apple documentation\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for various headers and payload fields supported by APNs.
+
+<b>Signature:</b>
+
+```typescript
+export interface ApnsConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [fcmOptions](./firebase-admin.messaging.apnsconfig.md#apnsconfigfcmoptions) | [ApnsFcmOptions](./firebase-admin.messaging.apnsfcmoptions.md#apnsfcmoptions_interface) | Options for features provided by the FCM SDK for iOS. |
+|  [headers](./firebase-admin.messaging.apnsconfig.md#apnsconfigheaders) | { \[key: string\]: string; } | A collection of APNs headers. Header values must be strings. |
+|  [payload](./firebase-admin.messaging.apnsconfig.md#apnsconfigpayload) | [ApnsPayload](./firebase-admin.messaging.apnspayload.md#apnspayload_interface) | An APNs payload to be included in the message. |
+
+## ApnsConfig.fcmOptions
+
+Options for features provided by the FCM SDK for iOS.
+
+<b>Signature:</b>
+
+```typescript
+fcmOptions?: ApnsFcmOptions;
+```
+
+## ApnsConfig.headers
+
+A collection of APNs headers. Header values must be strings.
+
+<b>Signature:</b>
+
+```typescript
+headers?: {
+        [key: string]: string;
+    };
+```
+
+## ApnsConfig.payload
+
+An APNs payload to be included in the message.
+
+<b>Signature:</b>
+
+```typescript
+payload?: ApnsPayload;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.apnsfcmoptions.md
+++ b/docgen/markdown/firebase-admin.messaging.apnsfcmoptions.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ApnsFcmOptions interface{% endblock title %}
+{% block body %}
+Represents options for features provided by the FCM SDK for iOS.
+
+<b>Signature:</b>
+
+```typescript
+export interface ApnsFcmOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [analyticsLabel](./firebase-admin.messaging.apnsfcmoptions.md#apnsfcmoptionsanalyticslabel) | string | The label associated with the message's analytics data. |
+|  [imageUrl](./firebase-admin.messaging.apnsfcmoptions.md#apnsfcmoptionsimageurl) | string | URL of an image to be displayed in the notification. |
+
+## ApnsFcmOptions.analyticsLabel
+
+The label associated with the message's analytics data.
+
+<b>Signature:</b>
+
+```typescript
+analyticsLabel?: string;
+```
+
+## ApnsFcmOptions.imageUrl
+
+URL of an image to be displayed in the notification.
+
+<b>Signature:</b>
+
+```typescript
+imageUrl?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.apnspayload.md
+++ b/docgen/markdown/firebase-admin.messaging.apnspayload.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ApnsPayload interface{% endblock title %}
+{% block body %}
+Represents the payload of an APNs message. Mainly consists of the `aps` dictionary. But may also contain other arbitrary custom keys.
+
+<b>Signature:</b>
+
+```typescript
+export interface ApnsPayload 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [aps](./firebase-admin.messaging.apnspayload.md#apnspayloadaps) | [Aps](./firebase-admin.messaging.aps.md#aps_interface) | The <code>aps</code> dictionary to be included in the message. |
+
+## ApnsPayload.aps
+
+The `aps` dictionary to be included in the message.
+
+<b>Signature:</b>
+
+```typescript
+aps: Aps;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.aps.md
+++ b/docgen/markdown/firebase-admin.messaging.aps.md
@@ -1,0 +1,93 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Aps interface{% endblock title %}
+{% block body %}
+Represents the \[aps dictionary\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) that is part of APNs messages.
+
+<b>Signature:</b>
+
+```typescript
+export interface Aps 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [alert](./firebase-admin.messaging.aps.md#apsalert) | string \| [ApsAlert](./firebase-admin.messaging.apsalert.md#apsalert_interface) | Alert to be included in the message. This may be a string or an object of type <code>admin.messaging.ApsAlert</code>. |
+|  [badge](./firebase-admin.messaging.aps.md#apsbadge) | number | Badge to be displayed with the message. Set to 0 to remove the badge. When not specified, the badge will remain unchanged. |
+|  [category](./firebase-admin.messaging.aps.md#apscategory) | string | Type of the notification. |
+|  [contentAvailable](./firebase-admin.messaging.aps.md#apscontentavailable) | boolean | Specifies whether to configure a background update notification. |
+|  [mutableContent](./firebase-admin.messaging.aps.md#apsmutablecontent) | boolean | Specifies whether to set the <code>mutable-content</code> property on the message so the clients can modify the notification via app extensions. |
+|  [sound](./firebase-admin.messaging.aps.md#apssound) | string \| [CriticalSound](./firebase-admin.messaging.criticalsound.md#criticalsound_interface) | Sound to be played with the message. |
+|  [threadId](./firebase-admin.messaging.aps.md#apsthreadid) | string | An app-specific identifier for grouping notifications. |
+
+## Aps.alert
+
+Alert to be included in the message. This may be a string or an object of type `admin.messaging.ApsAlert`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+alert?: string | ApsAlert;
+```
+
+## Aps.badge
+
+Badge to be displayed with the message. Set to 0 to remove the badge. When not specified, the badge will remain unchanged.
+
+<b>Signature:</b>
+
+```typescript
+badge?: number;
+```
+
+## Aps.category
+
+Type of the notification.
+
+<b>Signature:</b>
+
+```typescript
+category?: string;
+```
+
+## Aps.contentAvailable
+
+Specifies whether to configure a background update notification.
+
+<b>Signature:</b>
+
+```typescript
+contentAvailable?: boolean;
+```
+
+## Aps.mutableContent
+
+Specifies whether to set the `mutable-content` property on the message so the clients can modify the notification via app extensions.
+
+<b>Signature:</b>
+
+```typescript
+mutableContent?: boolean;
+```
+
+## Aps.sound
+
+Sound to be played with the message.
+
+<b>Signature:</b>
+
+```typescript
+sound?: string | CriticalSound;
+```
+
+## Aps.threadId
+
+An app-specific identifier for grouping notifications.
+
+<b>Signature:</b>
+
+```typescript
+threadId?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.apsalert.md
+++ b/docgen/markdown/firebase-admin.messaging.apsalert.md
@@ -1,0 +1,113 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ApsAlert interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface ApsAlert 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [actionLocKey](./firebase-admin.messaging.apsalert.md#apsalertactionlockey) | string |  |
+|  [body](./firebase-admin.messaging.apsalert.md#apsalertbody) | string |  |
+|  [launchImage](./firebase-admin.messaging.apsalert.md#apsalertlaunchimage) | string |  |
+|  [locArgs](./firebase-admin.messaging.apsalert.md#apsalertlocargs) | string\[\] |  |
+|  [locKey](./firebase-admin.messaging.apsalert.md#apsalertlockey) | string |  |
+|  [subtitle](./firebase-admin.messaging.apsalert.md#apsalertsubtitle) | string |  |
+|  [subtitleLocArgs](./firebase-admin.messaging.apsalert.md#apsalertsubtitlelocargs) | string\[\] |  |
+|  [subtitleLocKey](./firebase-admin.messaging.apsalert.md#apsalertsubtitlelockey) | string |  |
+|  [title](./firebase-admin.messaging.apsalert.md#apsalerttitle) | string |  |
+|  [titleLocArgs](./firebase-admin.messaging.apsalert.md#apsalerttitlelocargs) | string\[\] |  |
+|  [titleLocKey](./firebase-admin.messaging.apsalert.md#apsalerttitlelockey) | string |  |
+
+## ApsAlert.actionLocKey
+
+<b>Signature:</b>
+
+```typescript
+actionLocKey?: string;
+```
+
+## ApsAlert.body
+
+<b>Signature:</b>
+
+```typescript
+body?: string;
+```
+
+## ApsAlert.launchImage
+
+<b>Signature:</b>
+
+```typescript
+launchImage?: string;
+```
+
+## ApsAlert.locArgs
+
+<b>Signature:</b>
+
+```typescript
+locArgs?: string[];
+```
+
+## ApsAlert.locKey
+
+<b>Signature:</b>
+
+```typescript
+locKey?: string;
+```
+
+## ApsAlert.subtitle
+
+<b>Signature:</b>
+
+```typescript
+subtitle?: string;
+```
+
+## ApsAlert.subtitleLocArgs
+
+<b>Signature:</b>
+
+```typescript
+subtitleLocArgs?: string[];
+```
+
+## ApsAlert.subtitleLocKey
+
+<b>Signature:</b>
+
+```typescript
+subtitleLocKey?: string;
+```
+
+## ApsAlert.title
+
+<b>Signature:</b>
+
+```typescript
+title?: string;
+```
+
+## ApsAlert.titleLocArgs
+
+<b>Signature:</b>
+
+```typescript
+titleLocArgs?: string[];
+```
+
+## ApsAlert.titleLocKey
+
+<b>Signature:</b>
+
+```typescript
+titleLocKey?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.basemessage.md
+++ b/docgen/markdown/firebase-admin.messaging.basemessage.md
@@ -1,0 +1,70 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}BaseMessage interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface BaseMessage 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [android](./firebase-admin.messaging.basemessage.md#basemessageandroid) | [AndroidConfig](./firebase-admin.messaging.androidconfig.md#androidconfig_interface) |  |
+|  [apns](./firebase-admin.messaging.basemessage.md#basemessageapns) | [ApnsConfig](./firebase-admin.messaging.apnsconfig.md#apnsconfig_interface) |  |
+|  [data](./firebase-admin.messaging.basemessage.md#basemessagedata) | { \[key: string\]: string; } |  |
+|  [fcmOptions](./firebase-admin.messaging.basemessage.md#basemessagefcmoptions) | [FcmOptions](./firebase-admin.messaging.fcmoptions.md#fcmoptions_interface) |  |
+|  [notification](./firebase-admin.messaging.basemessage.md#basemessagenotification) | [Notification](./firebase-admin.messaging.notification.md#notification_interface) |  |
+|  [webpush](./firebase-admin.messaging.basemessage.md#basemessagewebpush) | [WebpushConfig](./firebase-admin.messaging.webpushconfig.md#webpushconfig_interface) |  |
+
+## BaseMessage.android
+
+<b>Signature:</b>
+
+```typescript
+android?: AndroidConfig;
+```
+
+## BaseMessage.apns
+
+<b>Signature:</b>
+
+```typescript
+apns?: ApnsConfig;
+```
+
+## BaseMessage.data
+
+<b>Signature:</b>
+
+```typescript
+data?: {
+        [key: string]: string;
+    };
+```
+
+## BaseMessage.fcmOptions
+
+<b>Signature:</b>
+
+```typescript
+fcmOptions?: FcmOptions;
+```
+
+## BaseMessage.notification
+
+<b>Signature:</b>
+
+```typescript
+notification?: Notification;
+```
+
+## BaseMessage.webpush
+
+<b>Signature:</b>
+
+```typescript
+webpush?: WebpushConfig;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.batchresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.batchresponse.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}BatchResponse interface{% endblock title %}
+{% block body %}
+Interface representing the server response from the  and  methods.
+
+<b>Signature:</b>
+
+```typescript
+export interface BatchResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [failureCount](./firebase-admin.messaging.batchresponse.md#batchresponsefailurecount) | number | The number of messages that resulted in errors when sending. |
+|  [responses](./firebase-admin.messaging.batchresponse.md#batchresponseresponses) | [SendResponse](./firebase-admin.messaging.sendresponse.md#sendresponse_interface)<!-- -->\[\] | An array of responses, each corresponding to a message. |
+|  [successCount](./firebase-admin.messaging.batchresponse.md#batchresponsesuccesscount) | number | The number of messages that were successfully handed off for sending. |
+
+## BatchResponse.failureCount
+
+The number of messages that resulted in errors when sending.
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## BatchResponse.responses
+
+An array of responses, each corresponding to a message.
+
+<b>Signature:</b>
+
+```typescript
+responses: SendResponse[];
+```
+
+## BatchResponse.successCount
+
+The number of messages that were successfully handed off for sending.
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.conditionmessage.md
+++ b/docgen/markdown/firebase-admin.messaging.conditionmessage.md
@@ -1,0 +1,24 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ConditionMessage interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface ConditionMessage extends BaseMessage 
+```
+<b>Extends:</b> [BaseMessage](./firebase-admin.messaging.basemessage.md#basemessage_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [condition](./firebase-admin.messaging.conditionmessage.md#conditionmessagecondition) | string |  |
+
+## ConditionMessage.condition
+
+<b>Signature:</b>
+
+```typescript
+condition: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.criticalsound.md
+++ b/docgen/markdown/firebase-admin.messaging.criticalsound.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}CriticalSound interface{% endblock title %}
+{% block body %}
+Represents a critical sound configuration that can be included in the `aps` dictionary of an APNs payload.
+
+<b>Signature:</b>
+
+```typescript
+export interface CriticalSound 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [critical](./firebase-admin.messaging.criticalsound.md#criticalsoundcritical) | boolean | The critical alert flag. Set to <code>true</code> to enable the critical alert. |
+|  [name](./firebase-admin.messaging.criticalsound.md#criticalsoundname) | string | The name of a sound file in the app's main bundle or in the <code>Library/Sounds</code> folder of the app's container directory. Specify the string "default" to play the system sound. |
+|  [volume](./firebase-admin.messaging.criticalsound.md#criticalsoundvolume) | number | The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume). |
+
+## CriticalSound.critical
+
+The critical alert flag. Set to `true` to enable the critical alert.
+
+<b>Signature:</b>
+
+```typescript
+critical?: boolean;
+```
+
+## CriticalSound.name
+
+The name of a sound file in the app's main bundle or in the `Library/Sounds` folder of the app's container directory. Specify the string "default" to play the system sound.
+
+<b>Signature:</b>
+
+```typescript
+name: string;
+```
+
+## CriticalSound.volume
+
+The volume for the critical alert's sound. Must be a value between 0.0 (silent) and 1.0 (full volume).
+
+<b>Signature:</b>
+
+```typescript
+volume?: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.datamessagepayload.md
+++ b/docgen/markdown/firebase-admin.messaging.datamessagepayload.md
@@ -1,0 +1,15 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}DataMessagePayload interface{% endblock title %}
+{% block body %}
+Interface representing an FCM legacy API data message payload. Data messages let developers send up to 4KB of custom key-value pairs. The keys and values must both be strings. Keys can be any custom string, except for the following reserved strings:
+
+\* `"from"` \* Anything starting with `"google."`<!-- -->.
+
+See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface DataMessagePayload 
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.fcmoptions.md
+++ b/docgen/markdown/firebase-admin.messaging.fcmoptions.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}FcmOptions interface{% endblock title %}
+{% block body %}
+Represents platform-independent options for features provided by the FCM SDKs.
+
+<b>Signature:</b>
+
+```typescript
+export interface FcmOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [analyticsLabel](./firebase-admin.messaging.fcmoptions.md#fcmoptionsanalyticslabel) | string | The label associated with the message's analytics data. |
+
+## FcmOptions.analyticsLabel
+
+The label associated with the message's analytics data.
+
+<b>Signature:</b>
+
+```typescript
+analyticsLabel?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.lightsettings.md
+++ b/docgen/markdown/firebase-admin.messaging.lightsettings.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}LightSettings interface{% endblock title %}
+{% block body %}
+Represents settings to control notification LED that can be included in .
+
+<b>Signature:</b>
+
+```typescript
+export interface LightSettings 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [color](./firebase-admin.messaging.lightsettings.md#lightsettingscolor) | string | Required. Sets color of the LED in <code>#rrggbb</code> or <code>#rrggbbaa</code> format. |
+|  [lightOffDurationMillis](./firebase-admin.messaging.lightsettings.md#lightsettingslightoffdurationmillis) | number | Required. Along with <code>light_on_duration</code>, defines the blink rate of LED flashes. |
+|  [lightOnDurationMillis](./firebase-admin.messaging.lightsettings.md#lightsettingslightondurationmillis) | number | Required. Along with <code>light_off_duration</code>, defines the blink rate of LED flashes. |
+
+## LightSettings.color
+
+Required. Sets color of the LED in `#rrggbb` or `#rrggbbaa` format.
+
+<b>Signature:</b>
+
+```typescript
+color: string;
+```
+
+## LightSettings.lightOffDurationMillis
+
+Required. Along with `light_on_duration`<!-- -->, defines the blink rate of LED flashes.
+
+<b>Signature:</b>
+
+```typescript
+lightOffDurationMillis: number;
+```
+
+## LightSettings.lightOnDurationMillis
+
+Required. Along with `light_off_duration`<!-- -->, defines the blink rate of LED flashes.
+
+<b>Signature:</b>
+
+```typescript
+lightOnDurationMillis: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.md
+++ b/docgen/markdown/firebase-admin.messaging.md
@@ -1,0 +1,109 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.messaging package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [Messaging](./firebase-admin.messaging.messaging.md#messaging_class) | Messaging service bound to the provided app. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getMessaging(app)](./firebase-admin.messaging.md#getmessaging) | Gets the  service for the default app or a given app.<code>admin.messaging()</code> can be called with no arguments to access the default app's  service or as <code>admin.messaging(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [AndroidConfig](./firebase-admin.messaging.androidconfig.md#androidconfig_interface) | Represents the Android-specific options that can be included in an . |
+|  [AndroidFcmOptions](./firebase-admin.messaging.androidfcmoptions.md#androidfcmoptions_interface) | Represents options for features provided by the FCM SDK for Android. |
+|  [AndroidNotification](./firebase-admin.messaging.androidnotification.md#androidnotification_interface) | Represents the Android-specific notification options that can be included in . |
+|  [ApnsConfig](./firebase-admin.messaging.apnsconfig.md#apnsconfig_interface) | Represents the APNs-specific options that can be included in an . Refer to \[Apple documentation\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html) for various headers and payload fields supported by APNs. |
+|  [ApnsFcmOptions](./firebase-admin.messaging.apnsfcmoptions.md#apnsfcmoptions_interface) | Represents options for features provided by the FCM SDK for iOS. |
+|  [ApnsPayload](./firebase-admin.messaging.apnspayload.md#apnspayload_interface) | Represents the payload of an APNs message. Mainly consists of the <code>aps</code> dictionary. But may also contain other arbitrary custom keys. |
+|  [Aps](./firebase-admin.messaging.aps.md#aps_interface) | Represents the \[aps dictionary\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) that is part of APNs messages. |
+|  [ApsAlert](./firebase-admin.messaging.apsalert.md#apsalert_interface) |  |
+|  [BaseMessage](./firebase-admin.messaging.basemessage.md#basemessage_interface) |  |
+|  [BatchResponse](./firebase-admin.messaging.batchresponse.md#batchresponse_interface) | Interface representing the server response from the  and  methods. |
+|  [ConditionMessage](./firebase-admin.messaging.conditionmessage.md#conditionmessage_interface) |  |
+|  [CriticalSound](./firebase-admin.messaging.criticalsound.md#criticalsound_interface) | Represents a critical sound configuration that can be included in the <code>aps</code> dictionary of an APNs payload. |
+|  [DataMessagePayload](./firebase-admin.messaging.datamessagepayload.md#datamessagepayload_interface) | Interface representing an FCM legacy API data message payload. Data messages let developers send up to 4KB of custom key-value pairs. The keys and values must both be strings. Keys can be any custom string, except for the following reserved strings:<!-- -->\* <code>&quot;from&quot;</code> \* Anything starting with <code>&quot;google.&quot;</code>.<!-- -->See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation. |
+|  [FcmOptions](./firebase-admin.messaging.fcmoptions.md#fcmoptions_interface) | Represents platform-independent options for features provided by the FCM SDKs. |
+|  [LightSettings](./firebase-admin.messaging.lightsettings.md#lightsettings_interface) | Represents settings to control notification LED that can be included in . |
+|  [MessagingConditionResponse](./firebase-admin.messaging.messagingconditionresponse.md#messagingconditionresponse_interface) | Interface representing the server response from the legacy  method.<!-- -->See \[Send to a condition\](/docs/cloud-messaging/admin/send-messages\#send\_to\_a\_condition) for code samples and detailed documentation. |
+|  [MessagingDeviceGroupResponse](./firebase-admin.messaging.messagingdevicegroupresponse.md#messagingdevicegroupresponse_interface) | Interface representing the server response from the  method.<!-- -->See \[Send messages to device groups\](/docs/cloud-messaging/send-message?authuser=0\#send\_messages\_to\_device\_groups) for code samples and detailed documentation. |
+|  [MessagingDeviceResult](./firebase-admin.messaging.messagingdeviceresult.md#messagingdeviceresult_interface) |  |
+|  [MessagingDevicesResponse](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponse_interface) | Interface representing the status of a message sent to an individual device via the FCM legacy APIs.<!-- -->See \[Send to individual devices\](/docs/cloud-messaging/admin/send-messages\#send\_to\_individual\_devices) for code samples and detailed documentation. |
+|  [MessagingOptions](./firebase-admin.messaging.messagingoptions.md#messagingoptions_interface) | Interface representing the options that can be provided when sending a message via the FCM legacy APIs.<!-- -->See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation. |
+|  [MessagingPayload](./firebase-admin.messaging.messagingpayload.md#messagingpayload_interface) | Interface representing a Firebase Cloud Messaging message payload. One or both of the <code>data</code> and <code>notification</code> keys are required.<!-- -->See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation. |
+|  [MessagingTopicManagementResponse](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponse_interface) | Interface representing the server response from the  and  methods.<!-- -->See \[Manage topics from the server\](/docs/cloud-messaging/manage-topics) for code samples and detailed documentation. |
+|  [MessagingTopicResponse](./firebase-admin.messaging.messagingtopicresponse.md#messagingtopicresponse_interface) | Interface representing the server response from the legacy  method.<!-- -->See \[Send to a topic\](/docs/cloud-messaging/admin/send-messages\#send\_to\_a\_topic) for code samples and detailed documentation. |
+|  [MulticastMessage](./firebase-admin.messaging.multicastmessage.md#multicastmessage_interface) | Payload for the admin.messaing.sendMulticast() method. The payload contains all the fields in the BaseMessage type, and a list of tokens. |
+|  [Notification](./firebase-admin.messaging.notification.md#notification_interface) | A notification that can be included in . |
+|  [NotificationMessagePayload](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayload_interface) | Interface representing an FCM legacy API notification message payload. Notification messages let developers send up to 4KB of predefined key-value pairs. Accepted keys are outlined below.<!-- -->See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation. |
+|  [SendResponse](./firebase-admin.messaging.sendresponse.md#sendresponse_interface) | Interface representing the status of an individual message that was sent as part of a batch request. |
+|  [TokenMessage](./firebase-admin.messaging.tokenmessage.md#tokenmessage_interface) |  |
+|  [TopicMessage](./firebase-admin.messaging.topicmessage.md#topicmessage_interface) |  |
+|  [WebpushConfig](./firebase-admin.messaging.webpushconfig.md#webpushconfig_interface) | Represents the WebPush protocol options that can be included in an . |
+|  [WebpushFcmOptions](./firebase-admin.messaging.webpushfcmoptions.md#webpushfcmoptions_interface) | Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard). |
+|  [WebpushNotification](./firebase-admin.messaging.webpushnotification.md#webpushnotification_interface) | Represents the WebPush-specific notification options that can be included in . This supports most of the standard options as defined in the Web Notification \[specification\](https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification). |
+
+## Type Aliases
+
+|  Type Alias | Description |
+|  --- | --- |
+|  [Message](./firebase-admin.messaging.md#message) | Payload for the admin.messaging.send() operation. The payload contains all the fields in the BaseMessage type, and exactly one of token, topic or condition. |
+
+## getMessaging()
+
+Gets the  service for the default app or a given app.
+
+`admin.messaging()` can be called with no arguments to access the default app's  service or as `admin.messaging(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getMessaging(app?: App): Messaging;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app whose <code>Messaging</code> service to return. If not provided, the default <code>Messaging</code> service will be returned. The default <code>Messaging</code> service if no app is provided or the <code>Messaging</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[Messaging](./firebase-admin.messaging.messaging.md#messaging_class)
+
+### Example 1
+
+
+```javascript
+// Get the Messaging service for the default app
+const defaultMessaging = getMessaging();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Messaging service for a given app
+const otherMessaging = getMessaging(otherApp);
+
+```
+
+## Message
+
+Payload for the admin.messaging.send() operation. The payload contains all the fields in the BaseMessage type, and exactly one of token, topic or condition.
+
+<b>Signature:</b>
+
+```typescript
+export declare type Message = TokenMessage | TopicMessage | ConditionMessage;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messaging.md
+++ b/docgen/markdown/firebase-admin.messaging.messaging.md
@@ -1,0 +1,292 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Messaging class{% endblock title %}
+{% block body %}
+Messaging service bound to the provided app.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Messaging 
+```
+
+## Constructors
+
+|  Constructor | Modifiers | Description |
+|  --- | --- | --- |
+|  [(constructor)(app)](./firebase-admin.messaging.messaging.md#messagingconstructor) |  | Gets the  service for the current app. |
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.messaging.messaging.md#messagingapp) |  | App | The  associated with the current <code>Messaging</code> service instance. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [send(message, dryRun)](./firebase-admin.messaging.messaging.md#messagingsend) |  | Sends the given message via FCM. |
+|  [sendAll(messages, dryRun)](./firebase-admin.messaging.messaging.md#messagingsendall) |  | Sends all the messages in the given array via Firebase Cloud Messaging. Employs batching to send the entire list as a single RPC call. Compared to the <code>send()</code> method, this method is a significantly more efficient way to send multiple messages.<!-- -->The responses list obtained from the return value corresponds to the order of tokens in the <code>MulticastMessage</code>. An error from this method indicates a total failure -- i.e. none of the messages in the list could be sent. Partial failures are indicated by a <code>BatchResponse</code> return value. |
+|  [sendMulticast(message, dryRun)](./firebase-admin.messaging.messaging.md#messagingsendmulticast) |  | Sends the given multicast message to all the FCM registration tokens specified in it.<!-- -->This method uses the <code>sendAll()</code> API under the hood to send the given message to all the target recipients. The responses list obtained from the return value corresponds to the order of tokens in the <code>MulticastMessage</code>. An error from this method indicates a total failure -- i.e. the message was not sent to any of the tokens in the list. Partial failures are indicated by a <code>BatchResponse</code> return value. |
+|  [sendToCondition(condition, payload, options)](./firebase-admin.messaging.messaging.md#messagingsendtocondition) |  | Sends an FCM message to a condition.<!-- -->See \[Send to a condition\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_condition) for code samples and detailed documentation. |
+|  [sendToDevice(registrationTokenOrTokens, payload, options)](./firebase-admin.messaging.messaging.md#messagingsendtodevice) |  | Sends an FCM message to a single device corresponding to the provided registration token.<!-- -->See \[Send to individual devices\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_individual\_devices) for code samples and detailed documentation. Takes either a <code>registrationToken</code> to send to a single device or a <code>registrationTokens</code> parameter containing an array of tokens to send to multiple devices. |
+|  [sendToDeviceGroup(notificationKey, payload, options)](./firebase-admin.messaging.messaging.md#messagingsendtodevicegroup) |  | Sends an FCM message to a device group corresponding to the provided notification key.<!-- -->See \[Send to a device group\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_device\_group) for code samples and detailed documentation. |
+|  [sendToTopic(topic, payload, options)](./firebase-admin.messaging.messaging.md#messagingsendtotopic) |  | Sends an FCM message to a topic.<!-- -->See \[Send to a topic\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_topic) for code samples and detailed documentation. |
+|  [subscribeToTopic(registrationTokenOrTokens, topic)](./firebase-admin.messaging.messaging.md#messagingsubscribetotopic) |  | Subscribes a device to an FCM topic.<!-- -->See \[Subscribe to a topic\](/docs/cloud-messaging/manage-topics\#suscribe\_and\_unsubscribe\_using\_the) for code samples and detailed documentation. Optionally, you can provide an array of tokens to subscribe multiple devices. |
+|  [unsubscribeFromTopic(registrationTokenOrTokens, topic)](./firebase-admin.messaging.messaging.md#messagingunsubscribefromtopic) |  | Unsubscribes a device from an FCM topic.<!-- -->See \[Unsubscribe from a topic\](/docs/cloud-messaging/admin/manage-topic-subscriptions\#unsubscribe\_from\_a\_topic) for code samples and detailed documentation. Optionally, you can provide an array of tokens to unsubscribe multiple devices. |
+
+## Messaging.(constructor)
+
+Gets the  service for the current app.
+
+<b>Signature:</b>
+
+```typescript
+constructor(app: App);
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App |  |
+
+### Example
+
+
+```javascript
+var messaging = app.messaging();
+// The above is shorthand for:
+// var messaging = admin.messaging(app);
+
+```
+ The `Messaging` service for the current app.
+
+## Messaging.app
+
+The  associated with the current `Messaging` service instance.
+
+<b>Signature:</b>
+
+```typescript
+get app(): App;
+```
+
+### Example
+
+
+```javascript
+var app = messaging.app;
+
+```
+
+## Messaging.send()
+
+Sends the given message via FCM.
+
+<b>Signature:</b>
+
+```typescript
+send(message: Message, dryRun?: boolean): Promise<string>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  message | [Message](./firebase-admin.messaging.md#message) | The message payload. |
+|  dryRun | boolean | Whether to send the message in the dry-run (validation only) mode.  A promise fulfilled with a unique message ID string after the message has been successfully handed off to the FCM service for delivery. |
+
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## Messaging.sendAll()
+
+Sends all the messages in the given array via Firebase Cloud Messaging. Employs batching to send the entire list as a single RPC call. Compared to the `send()` method, this method is a significantly more efficient way to send multiple messages.
+
+The responses list obtained from the return value corresponds to the order of tokens in the `MulticastMessage`<!-- -->. An error from this method indicates a total failure -- i.e. none of the messages in the list could be sent. Partial failures are indicated by a `BatchResponse` return value.
+
+<b>Signature:</b>
+
+```typescript
+sendAll(messages: Message[], dryRun?: boolean): Promise<BatchResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messages | [Message](./firebase-admin.messaging.md#message)<!-- -->\[\] | A non-empty array containing up to 500 messages. |
+|  dryRun | boolean | Whether to send the messages in the dry-run (validation only) mode.  A Promise fulfilled with an object representing the result of the send operation. |
+
+<b>Returns:</b>
+
+Promise&lt;[BatchResponse](./firebase-admin.messaging.batchresponse.md#batchresponse_interface)<!-- -->&gt;
+
+## Messaging.sendMulticast()
+
+Sends the given multicast message to all the FCM registration tokens specified in it.
+
+This method uses the `sendAll()` API under the hood to send the given message to all the target recipients. The responses list obtained from the return value corresponds to the order of tokens in the `MulticastMessage`<!-- -->. An error from this method indicates a total failure -- i.e. the message was not sent to any of the tokens in the list. Partial failures are indicated by a `BatchResponse` return value.
+
+<b>Signature:</b>
+
+```typescript
+sendMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  message | [MulticastMessage](./firebase-admin.messaging.multicastmessage.md#multicastmessage_interface) | A multicast message containing up to 500 tokens. |
+|  dryRun | boolean | Whether to send the message in the dry-run (validation only) mode.  A Promise fulfilled with an object representing the result of the send operation. |
+
+<b>Returns:</b>
+
+Promise&lt;[BatchResponse](./firebase-admin.messaging.batchresponse.md#batchresponse_interface)<!-- -->&gt;
+
+## Messaging.sendToCondition()
+
+Sends an FCM message to a condition.
+
+See \[Send to a condition\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_condition) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+sendToCondition(condition: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingConditionResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  condition | string | The condition determining to which topics to send the message. |
+|  payload | [MessagingPayload](./firebase-admin.messaging.messagingpayload.md#messagingpayload_interface) | The message payload. |
+|  options | [MessagingOptions](./firebase-admin.messaging.messagingoptions.md#messagingoptions_interface) | Optional options to alter the message. A promise fulfilled with the server's response after the message has been sent. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingConditionResponse](./firebase-admin.messaging.messagingconditionresponse.md#messagingconditionresponse_interface)<!-- -->&gt;
+
+## Messaging.sendToDevice()
+
+Sends an FCM message to a single device corresponding to the provided registration token.
+
+See \[Send to individual devices\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_individual\_devices) for code samples and detailed documentation. Takes either a `registrationToken` to send to a single device or a `registrationTokens` parameter containing an array of tokens to send to multiple devices.
+
+<b>Signature:</b>
+
+```typescript
+sendToDevice(registrationTokenOrTokens: string | string[], payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingDevicesResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  registrationTokenOrTokens | string \| string\[\] |  |
+|  payload | [MessagingPayload](./firebase-admin.messaging.messagingpayload.md#messagingpayload_interface) | The message payload. |
+|  options | [MessagingOptions](./firebase-admin.messaging.messagingoptions.md#messagingoptions_interface) | Optional options to alter the message. A promise fulfilled with the server's response after the message has been sent. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingDevicesResponse](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponse_interface)<!-- -->&gt;
+
+## Messaging.sendToDeviceGroup()
+
+Sends an FCM message to a device group corresponding to the provided notification key.
+
+See \[Send to a device group\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_device\_group) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+sendToDeviceGroup(notificationKey: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingDeviceGroupResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  notificationKey | string | The notification key for the device group to which to send the message. |
+|  payload | [MessagingPayload](./firebase-admin.messaging.messagingpayload.md#messagingpayload_interface) | The message payload. |
+|  options | [MessagingOptions](./firebase-admin.messaging.messagingoptions.md#messagingoptions_interface) | Optional options to alter the message. A promise fulfilled with the server's response after the message has been sent. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingDeviceGroupResponse](./firebase-admin.messaging.messagingdevicegroupresponse.md#messagingdevicegroupresponse_interface)<!-- -->&gt;
+
+## Messaging.sendToTopic()
+
+Sends an FCM message to a topic.
+
+See \[Send to a topic\](/docs/cloud-messaging/admin/legacy-fcm\#send\_to\_a\_topic) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+sendToTopic(topic: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingTopicResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  topic | string | The topic to which to send the message. |
+|  payload | [MessagingPayload](./firebase-admin.messaging.messagingpayload.md#messagingpayload_interface) | The message payload. |
+|  options | [MessagingOptions](./firebase-admin.messaging.messagingoptions.md#messagingoptions_interface) | Optional options to alter the message. A promise fulfilled with the server's response after the message has been sent. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingTopicResponse](./firebase-admin.messaging.messagingtopicresponse.md#messagingtopicresponse_interface)<!-- -->&gt;
+
+## Messaging.subscribeToTopic()
+
+Subscribes a device to an FCM topic.
+
+See \[Subscribe to a topic\](/docs/cloud-messaging/manage-topics\#suscribe\_and\_unsubscribe\_using\_the) for code samples and detailed documentation. Optionally, you can provide an array of tokens to subscribe multiple devices.
+
+<b>Signature:</b>
+
+```typescript
+subscribeToTopic(registrationTokenOrTokens: string | string[], topic: string): Promise<MessagingTopicManagementResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  registrationTokenOrTokens | string \| string\[\] |  |
+|  topic | string | The topic to which to subscribe. A promise fulfilled with the server's response after the device has been subscribed to the topic. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingTopicManagementResponse](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponse_interface)<!-- -->&gt;
+
+## Messaging.unsubscribeFromTopic()
+
+Unsubscribes a device from an FCM topic.
+
+See \[Unsubscribe from a topic\](/docs/cloud-messaging/admin/manage-topic-subscriptions\#unsubscribe\_from\_a\_topic) for code samples and detailed documentation. Optionally, you can provide an array of tokens to unsubscribe multiple devices.
+
+<b>Signature:</b>
+
+```typescript
+unsubscribeFromTopic(registrationTokenOrTokens: string | string[], topic: string): Promise<MessagingTopicManagementResponse>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  registrationTokenOrTokens | string \| string\[\] |  |
+|  topic | string | The topic from which to unsubscribe. A promise fulfilled with the server's response after the device has been unsubscribed from the topic. |
+
+<b>Returns:</b>
+
+Promise&lt;[MessagingTopicManagementResponse](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponse_interface)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingconditionresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingconditionresponse.md
@@ -1,0 +1,29 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingConditionResponse interface{% endblock title %}
+{% block body %}
+Interface representing the server response from the legacy  method.
+
+See \[Send to a condition\](/docs/cloud-messaging/admin/send-messages\#send\_to\_a\_condition) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingConditionResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [messageId](./firebase-admin.messaging.messagingconditionresponse.md#messagingconditionresponsemessageid) | number | The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices. |
+
+## MessagingConditionResponse.messageId
+
+The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+
+<b>Signature:</b>
+
+```typescript
+messageId: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingdevicegroupresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingdevicegroupresponse.md
@@ -1,0 +1,51 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingDeviceGroupResponse interface{% endblock title %}
+{% block body %}
+Interface representing the server response from the  method.
+
+See \[Send messages to device groups\](/docs/cloud-messaging/send-message?authuser=0\#send\_messages\_to\_device\_groups) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingDeviceGroupResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [failedRegistrationTokens](./firebase-admin.messaging.messagingdevicegroupresponse.md#messagingdevicegroupresponsefailedregistrationtokens) | string\[\] | An array of registration tokens that failed to receive the message. |
+|  [failureCount](./firebase-admin.messaging.messagingdevicegroupresponse.md#messagingdevicegroupresponsefailurecount) | number | The number of messages that could not be processed and resulted in an error. |
+|  [successCount](./firebase-admin.messaging.messagingdevicegroupresponse.md#messagingdevicegroupresponsesuccesscount) | number | The number of messages that could not be processed and resulted in an error. |
+
+## MessagingDeviceGroupResponse.failedRegistrationTokens
+
+An array of registration tokens that failed to receive the message.
+
+<b>Signature:</b>
+
+```typescript
+failedRegistrationTokens: string[];
+```
+
+## MessagingDeviceGroupResponse.failureCount
+
+The number of messages that could not be processed and resulted in an error.
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## MessagingDeviceGroupResponse.successCount
+
+The number of messages that could not be processed and resulted in an error.
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingdeviceresult.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingdeviceresult.md
@@ -1,0 +1,47 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingDeviceResult interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface MessagingDeviceResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [canonicalRegistrationToken](./firebase-admin.messaging.messagingdeviceresult.md#messagingdeviceresultcanonicalregistrationtoken) | string | The canonical registration token for the client app that the message was processed and sent to. You should use this value as the registration token for future requests. Otherwise, future messages might be rejected. |
+|  [error](./firebase-admin.messaging.messagingdeviceresult.md#messagingdeviceresulterror) | FirebaseError | The error that occurred when processing the message for the recipient. |
+|  [messageId](./firebase-admin.messaging.messagingdeviceresult.md#messagingdeviceresultmessageid) | string | A unique ID for the successfully processed message. |
+
+## MessagingDeviceResult.canonicalRegistrationToken
+
+The canonical registration token for the client app that the message was processed and sent to. You should use this value as the registration token for future requests. Otherwise, future messages might be rejected.
+
+<b>Signature:</b>
+
+```typescript
+canonicalRegistrationToken?: string;
+```
+
+## MessagingDeviceResult.error
+
+The error that occurred when processing the message for the recipient.
+
+<b>Signature:</b>
+
+```typescript
+error?: FirebaseError;
+```
+
+## MessagingDeviceResult.messageId
+
+A unique ID for the successfully processed message.
+
+<b>Signature:</b>
+
+```typescript
+messageId?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingdevicesresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingdevicesresponse.md
@@ -1,0 +1,63 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingDevicesResponse interface{% endblock title %}
+{% block body %}
+Interface representing the status of a message sent to an individual device via the FCM legacy APIs.
+
+See \[Send to individual devices\](/docs/cloud-messaging/admin/send-messages\#send\_to\_individual\_devices) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingDevicesResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [canonicalRegistrationTokenCount](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponsecanonicalregistrationtokencount) | number |  |
+|  [failureCount](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponsefailurecount) | number |  |
+|  [multicastId](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponsemulticastid) | number |  |
+|  [results](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponseresults) | [MessagingDeviceResult](./firebase-admin.messaging.messagingdeviceresult.md#messagingdeviceresult_interface)<!-- -->\[\] |  |
+|  [successCount](./firebase-admin.messaging.messagingdevicesresponse.md#messagingdevicesresponsesuccesscount) | number |  |
+
+## MessagingDevicesResponse.canonicalRegistrationTokenCount
+
+<b>Signature:</b>
+
+```typescript
+canonicalRegistrationTokenCount: number;
+```
+
+## MessagingDevicesResponse.failureCount
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## MessagingDevicesResponse.multicastId
+
+<b>Signature:</b>
+
+```typescript
+multicastId: number;
+```
+
+## MessagingDevicesResponse.results
+
+<b>Signature:</b>
+
+```typescript
+results: MessagingDeviceResult[];
+```
+
+## MessagingDevicesResponse.successCount
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingoptions.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingoptions.md
@@ -1,0 +1,121 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingOptions interface{% endblock title %}
+{% block body %}
+Interface representing the options that can be provided when sending a message via the FCM legacy APIs.
+
+See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [collapseKey](./firebase-admin.messaging.messagingoptions.md#messagingoptionscollapsekey) | string | String identifying a group of messages (for example, "Updates Available") that can be collapsed, so that only the last message gets sent when delivery can be resumed. This is used to avoid sending too many of the same messages when the device comes back online or becomes active.<!-- -->There is no guarantee of the order in which messages get sent.<!-- -->A maximum of four different collapse keys is allowed at any given time. This means FCM server can simultaneously store four different send-to-sync messages per client app. If you exceed this number, there is no guarantee which four collapse keys the FCM server will keep.<!-- -->\*\*Default value:\*\* None |
+|  [contentAvailable](./firebase-admin.messaging.messagingoptions.md#messagingoptionscontentavailable) | boolean | On iOS, use this field to represent <code>content-available</code> in the APNs payload. When a notification or data message is sent and this is set to <code>true</code>, an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, this flag is currently not supported.<!-- -->\*\*Default value:\*\* <code>false</code> |
+|  [dryRun](./firebase-admin.messaging.messagingoptions.md#messagingoptionsdryrun) | boolean | Whether or not the message should actually be sent. When set to <code>true</code>, allows developers to test a request without actually sending a message. When set to <code>false</code>, the message will be sent.<!-- -->\*\*Default value:\*\* <code>false</code> |
+|  [mutableContent](./firebase-admin.messaging.messagingoptions.md#messagingoptionsmutablecontent) | boolean | On iOS, use this field to represent <code>mutable-content</code> in the APNs payload. When a notification is sent and this is set to <code>true</code>, the content of the notification can be modified before it is displayed, using a \[Notification Service app extension\](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension)<!-- -->On Android and Web, this parameter will be ignored.<!-- -->\*\*Default value:\*\* <code>false</code> |
+|  [priority](./firebase-admin.messaging.messagingoptions.md#messagingoptionspriority) | string | The priority of the message. Valid values are <code>&quot;normal&quot;</code> and <code>&quot;high&quot;.</code> On iOS, these correspond to APNs priorities <code>5</code> and <code>10</code>.<!-- -->By default, notification messages are sent with high priority, and data messages are sent with normal priority. Normal priority optimizes the client app's battery consumption and should be used unless immediate delivery is required. For messages with normal priority, the app may receive the message with unspecified delay.<!-- -->When a message is sent with high priority, it is sent immediately, and the app can wake a sleeping device and open a network connection to your server.<!-- -->For more information, see \[Setting the priority of a message\](/docs/cloud-messaging/concept-options\#setting-the-priority-of-a-message).<!-- -->\*\*Default value:\*\* <code>&quot;high&quot;</code> for notification messages, <code>&quot;normal&quot;</code> for data messages |
+|  [restrictedPackageName](./firebase-admin.messaging.messagingoptions.md#messagingoptionsrestrictedpackagename) | string | The package name of the application which the registration tokens must match in order to receive the message.<!-- -->\*\*Default value:\*\* None |
+|  [timeToLive](./firebase-admin.messaging.messagingoptions.md#messagingoptionstimetolive) | number | How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. For more information, see \[Setting the lifespan of a message\](/docs/cloud-messaging/concept-options\#ttl).<!-- -->\*\*Default value:\*\* <code>2419200</code> (representing four weeks, in seconds) |
+
+## MessagingOptions.collapseKey
+
+String identifying a group of messages (for example, "Updates Available") that can be collapsed, so that only the last message gets sent when delivery can be resumed. This is used to avoid sending too many of the same messages when the device comes back online or becomes active.
+
+There is no guarantee of the order in which messages get sent.
+
+A maximum of four different collapse keys is allowed at any given time. This means FCM server can simultaneously store four different send-to-sync messages per client app. If you exceed this number, there is no guarantee which four collapse keys the FCM server will keep.
+
+\*\*Default value:\*\* None
+
+<b>Signature:</b>
+
+```typescript
+collapseKey?: string;
+```
+
+## MessagingOptions.contentAvailable
+
+On iOS, use this field to represent `content-available` in the APNs payload. When a notification or data message is sent and this is set to `true`<!-- -->, an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, this flag is currently not supported.
+
+\*\*Default value:\*\* `false`
+
+<b>Signature:</b>
+
+```typescript
+contentAvailable?: boolean;
+```
+
+## MessagingOptions.dryRun
+
+Whether or not the message should actually be sent. When set to `true`<!-- -->, allows developers to test a request without actually sending a message. When set to `false`<!-- -->, the message will be sent.
+
+\*\*Default value:\*\* `false`
+
+<b>Signature:</b>
+
+```typescript
+dryRun?: boolean;
+```
+
+## MessagingOptions.mutableContent
+
+On iOS, use this field to represent `mutable-content` in the APNs payload. When a notification is sent and this is set to `true`<!-- -->, the content of the notification can be modified before it is displayed, using a \[Notification Service app extension\](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension)
+
+On Android and Web, this parameter will be ignored.
+
+\*\*Default value:\*\* `false`
+
+<b>Signature:</b>
+
+```typescript
+mutableContent?: boolean;
+```
+
+## MessagingOptions.priority
+
+The priority of the message. Valid values are `"normal"` and `"high".` On iOS, these correspond to APNs priorities `5` and `10`<!-- -->.
+
+By default, notification messages are sent with high priority, and data messages are sent with normal priority. Normal priority optimizes the client app's battery consumption and should be used unless immediate delivery is required. For messages with normal priority, the app may receive the message with unspecified delay.
+
+When a message is sent with high priority, it is sent immediately, and the app can wake a sleeping device and open a network connection to your server.
+
+For more information, see \[Setting the priority of a message\](/docs/cloud-messaging/concept-options\#setting-the-priority-of-a-message).
+
+\*\*Default value:\*\* `"high"` for notification messages, `"normal"` for data messages
+
+<b>Signature:</b>
+
+```typescript
+priority?: string;
+```
+
+## MessagingOptions.restrictedPackageName
+
+The package name of the application which the registration tokens must match in order to receive the message.
+
+\*\*Default value:\*\* None
+
+<b>Signature:</b>
+
+```typescript
+restrictedPackageName?: string;
+```
+
+## MessagingOptions.timeToLive
+
+How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is four weeks, and the default value is also four weeks. For more information, see \[Setting the lifespan of a message\](/docs/cloud-messaging/concept-options\#ttl).
+
+\*\*Default value:\*\* `2419200` (representing four weeks, in seconds)
+
+<b>Signature:</b>
+
+```typescript
+timeToLive?: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingpayload.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingpayload.md
@@ -1,0 +1,40 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingPayload interface{% endblock title %}
+{% block body %}
+Interface representing a Firebase Cloud Messaging message payload. One or both of the `data` and `notification` keys are required.
+
+See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingPayload 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [data](./firebase-admin.messaging.messagingpayload.md#messagingpayloaddata) | [DataMessagePayload](./firebase-admin.messaging.datamessagepayload.md#datamessagepayload_interface) | The data message payload. |
+|  [notification](./firebase-admin.messaging.messagingpayload.md#messagingpayloadnotification) | [NotificationMessagePayload](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayload_interface) | The notification message payload. |
+
+## MessagingPayload.data
+
+The data message payload.
+
+<b>Signature:</b>
+
+```typescript
+data?: DataMessagePayload;
+```
+
+## MessagingPayload.notification
+
+The notification message payload.
+
+<b>Signature:</b>
+
+```typescript
+notification?: NotificationMessagePayload;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingtopicmanagementresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingtopicmanagementresponse.md
@@ -1,0 +1,51 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingTopicManagementResponse interface{% endblock title %}
+{% block body %}
+Interface representing the server response from the  and  methods.
+
+See \[Manage topics from the server\](/docs/cloud-messaging/manage-topics) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingTopicManagementResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [errors](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponseerrors) | FirebaseArrayIndexError\[\] | An array of errors corresponding to the provided registration token(s). The length of this array will be equal to \[<code>failureCount</code>\](\#failureCount). |
+|  [failureCount](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponsefailurecount) | number | The number of registration tokens that could not be subscribed to the topic and resulted in an error. |
+|  [successCount](./firebase-admin.messaging.messagingtopicmanagementresponse.md#messagingtopicmanagementresponsesuccesscount) | number | The number of registration tokens that were successfully subscribed to the topic. |
+
+## MessagingTopicManagementResponse.errors
+
+An array of errors corresponding to the provided registration token(s). The length of this array will be equal to \[`failureCount`<!-- -->\](\#failureCount).
+
+<b>Signature:</b>
+
+```typescript
+errors: FirebaseArrayIndexError[];
+```
+
+## MessagingTopicManagementResponse.failureCount
+
+The number of registration tokens that could not be subscribed to the topic and resulted in an error.
+
+<b>Signature:</b>
+
+```typescript
+failureCount: number;
+```
+
+## MessagingTopicManagementResponse.successCount
+
+The number of registration tokens that were successfully subscribed to the topic.
+
+<b>Signature:</b>
+
+```typescript
+successCount: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.messagingtopicresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.messagingtopicresponse.md
@@ -1,0 +1,29 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MessagingTopicResponse interface{% endblock title %}
+{% block body %}
+Interface representing the server response from the legacy  method.
+
+See \[Send to a topic\](/docs/cloud-messaging/admin/send-messages\#send\_to\_a\_topic) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface MessagingTopicResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [messageId](./firebase-admin.messaging.messagingtopicresponse.md#messagingtopicresponsemessageid) | number | The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices. |
+
+## MessagingTopicResponse.messageId
+
+The message ID for a successfully received request which FCM will attempt to deliver to all subscribed devices.
+
+<b>Signature:</b>
+
+```typescript
+messageId: number;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.multicastmessage.md
+++ b/docgen/markdown/firebase-admin.messaging.multicastmessage.md
@@ -1,0 +1,26 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}MulticastMessage interface{% endblock title %}
+{% block body %}
+Payload for the admin.messaing.sendMulticast() method. The payload contains all the fields in the BaseMessage type, and a list of tokens.
+
+<b>Signature:</b>
+
+```typescript
+export interface MulticastMessage extends BaseMessage 
+```
+<b>Extends:</b> [BaseMessage](./firebase-admin.messaging.basemessage.md#basemessage_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [tokens](./firebase-admin.messaging.multicastmessage.md#multicastmessagetokens) | string\[\] |  |
+
+## MulticastMessage.tokens
+
+<b>Signature:</b>
+
+```typescript
+tokens: string[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.notification.md
+++ b/docgen/markdown/firebase-admin.messaging.notification.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Notification interface{% endblock title %}
+{% block body %}
+A notification that can be included in .
+
+<b>Signature:</b>
+
+```typescript
+export interface Notification 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [body](./firebase-admin.messaging.notification.md#notificationbody) | string | The notification body |
+|  [imageUrl](./firebase-admin.messaging.notification.md#notificationimageurl) | string | URL of an image to be displayed in the notification. |
+|  [title](./firebase-admin.messaging.notification.md#notificationtitle) | string | The title of the notification. |
+
+## Notification.body
+
+The notification body
+
+<b>Signature:</b>
+
+```typescript
+body?: string;
+```
+
+## Notification.imageUrl
+
+URL of an image to be displayed in the notification.
+
+<b>Signature:</b>
+
+```typescript
+imageUrl?: string;
+```
+
+## Notification.title
+
+The title of the notification.
+
+<b>Signature:</b>
+
+```typescript
+title?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.notificationmessagepayload.md
+++ b/docgen/markdown/firebase-admin.messaging.notificationmessagepayload.md
@@ -1,0 +1,206 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}NotificationMessagePayload interface{% endblock title %}
+{% block body %}
+Interface representing an FCM legacy API notification message payload. Notification messages let developers send up to 4KB of predefined key-value pairs. Accepted keys are outlined below.
+
+See \[Build send requests\](/docs/cloud-messaging/send-message) for code samples and detailed documentation.
+
+<b>Signature:</b>
+
+```typescript
+export interface NotificationMessagePayload 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [badge](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadbadge) | string | The value of the badge on the home screen app icon.<!-- -->If not specified, the badge is not changed.<!-- -->If set to <code>0</code>, the badge is removed.<!-- -->\*\*Platforms:\*\* iOS |
+|  [body](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadbody) | string | The notification's body text.<!-- -->\*\*Platforms:\*\* iOS, Android, Web |
+|  [bodyLocArgs](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadbodylocargs) | string | Variable string values to be used in place of the format specifiers in <code>body_loc_key</code> to use to localize the body text to the user's current localization.<!-- -->The value should be a stringified JSON array.<!-- -->\*\*iOS:\*\* Corresponds to <code>loc-args</code> in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.<!-- -->\*\*Android:\*\* See \[Formatting and Styling\](http://developer.android.com/guide/topics/resources/string-resource.html\#FormattingAndStyling) for more information.<!-- -->\*\*Platforms:\*\* iOS, Android |
+|  [bodyLocKey](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadbodylockey) | string | The key to the body string in the app's string resources to use to localize the body text to the user's current localization.<!-- -->\*\*iOS:\*\* Corresponds to <code>loc-key</code> in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.<!-- -->\*\*Android:\*\* See \[String Resources\](http://developer.android.com/guide/topics/resources/string-resource.html) \* for more information.<!-- -->\*\*Platforms:\*\* iOS, Android |
+|  [clickAction](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadclickaction) | string | Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.<!-- -->\* \*\*Platforms:\*\* Android |
+|  [color](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadcolor) | string | The notification icon's color, expressed in <code>#rrggbb</code> format.<!-- -->\*\*Platforms:\*\* Android |
+|  [icon](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadicon) | string | The notification's icon.<!-- -->\*\*Android:\*\* Sets the notification icon to <code>myicon</code> for drawable resource <code>myicon</code>. If you don't send this key in the request, FCM displays the launcher icon specified in your app manifest.<!-- -->\*\*Web:\*\* The URL to use for the notification's icon.<!-- -->\*\*Platforms:\*\* Android, Web |
+|  [sound](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadsound) | string | The sound to be played when the device receives a notification. Supports "default" for the default notification sound of the device or the filename of a sound resource bundled in the app. Sound files must reside in <code>/res/raw/</code>.<!-- -->\*\*Platforms:\*\* Android |
+|  [tag](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadtag) | string | Identifier used to replace existing notifications in the notification drawer.<!-- -->If not specified, each request creates a new notification.<!-- -->If specified and a notification with the same tag is already being shown, the new notification replaces the existing one in the notification drawer.<!-- -->\*\*Platforms:\*\* Android |
+|  [title](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadtitle) | string | The notification's title.<!-- -->\*\*Platforms:\*\* iOS, Android, Web |
+|  [titleLocArgs](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadtitlelocargs) | string | Variable string values to be used in place of the format specifiers in <code>title_loc_key</code> to use to localize the title text to the user's current localization.<!-- -->The value should be a stringified JSON array.<!-- -->\*\*iOS:\*\* Corresponds to <code>title-loc-args</code> in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.<!-- -->\*\*Android:\*\* See \[Formatting and Styling\](http://developer.android.com/guide/topics/resources/string-resource.html\#FormattingAndStyling) for more information.<!-- -->\*\*Platforms:\*\* iOS, Android |
+|  [titleLocKey](./firebase-admin.messaging.notificationmessagepayload.md#notificationmessagepayloadtitlelockey) | string | The key to the title string in the app's string resources to use to localize the title text to the user's current localization.<!-- -->\*\*iOS:\*\* Corresponds to <code>title-loc-key</code> in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.<!-- -->\*\*Android:\*\* See \[String Resources\](http://developer.android.com/guide/topics/resources/string-resource.html) for more information.<!-- -->\*\*Platforms:\*\* iOS, Android |
+
+## NotificationMessagePayload.badge
+
+The value of the badge on the home screen app icon.
+
+If not specified, the badge is not changed.
+
+If set to `0`<!-- -->, the badge is removed.
+
+\*\*Platforms:\*\* iOS
+
+<b>Signature:</b>
+
+```typescript
+badge?: string;
+```
+
+## NotificationMessagePayload.body
+
+The notification's body text.
+
+\*\*Platforms:\*\* iOS, Android, Web
+
+<b>Signature:</b>
+
+```typescript
+body?: string;
+```
+
+## NotificationMessagePayload.bodyLocArgs
+
+Variable string values to be used in place of the format specifiers in `body_loc_key` to use to localize the body text to the user's current localization.
+
+The value should be a stringified JSON array.
+
+\*\*iOS:\*\* Corresponds to `loc-args` in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.
+
+\*\*Android:\*\* See \[Formatting and Styling\](http://developer.android.com/guide/topics/resources/string-resource.html\#FormattingAndStyling) for more information.
+
+\*\*Platforms:\*\* iOS, Android
+
+<b>Signature:</b>
+
+```typescript
+bodyLocArgs?: string;
+```
+
+## NotificationMessagePayload.bodyLocKey
+
+The key to the body string in the app's string resources to use to localize the body text to the user's current localization.
+
+\*\*iOS:\*\* Corresponds to `loc-key` in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.
+
+\*\*Android:\*\* See \[String Resources\](http://developer.android.com/guide/topics/resources/string-resource.html) \* for more information.
+
+\*\*Platforms:\*\* iOS, Android
+
+<b>Signature:</b>
+
+```typescript
+bodyLocKey?: string;
+```
+
+## NotificationMessagePayload.clickAction
+
+Action associated with a user click on the notification. If specified, an activity with a matching Intent Filter is launched when a user clicks on the notification.
+
+\* \*\*Platforms:\*\* Android
+
+<b>Signature:</b>
+
+```typescript
+clickAction?: string;
+```
+
+## NotificationMessagePayload.color
+
+The notification icon's color, expressed in `#rrggbb` format.
+
+\*\*Platforms:\*\* Android
+
+<b>Signature:</b>
+
+```typescript
+color?: string;
+```
+
+## NotificationMessagePayload.icon
+
+The notification's icon.
+
+\*\*Android:\*\* Sets the notification icon to `myicon` for drawable resource `myicon`<!-- -->. If you don't send this key in the request, FCM displays the launcher icon specified in your app manifest.
+
+\*\*Web:\*\* The URL to use for the notification's icon.
+
+\*\*Platforms:\*\* Android, Web
+
+<b>Signature:</b>
+
+```typescript
+icon?: string;
+```
+
+## NotificationMessagePayload.sound
+
+The sound to be played when the device receives a notification. Supports "default" for the default notification sound of the device or the filename of a sound resource bundled in the app. Sound files must reside in `/res/raw/`<!-- -->.
+
+\*\*Platforms:\*\* Android
+
+<b>Signature:</b>
+
+```typescript
+sound?: string;
+```
+
+## NotificationMessagePayload.tag
+
+Identifier used to replace existing notifications in the notification drawer.
+
+If not specified, each request creates a new notification.
+
+If specified and a notification with the same tag is already being shown, the new notification replaces the existing one in the notification drawer.
+
+\*\*Platforms:\*\* Android
+
+<b>Signature:</b>
+
+```typescript
+tag?: string;
+```
+
+## NotificationMessagePayload.title
+
+The notification's title.
+
+\*\*Platforms:\*\* iOS, Android, Web
+
+<b>Signature:</b>
+
+```typescript
+title?: string;
+```
+
+## NotificationMessagePayload.titleLocArgs
+
+Variable string values to be used in place of the format specifiers in `title_loc_key` to use to localize the title text to the user's current localization.
+
+The value should be a stringified JSON array.
+
+\*\*iOS:\*\* Corresponds to `title-loc-args` in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.
+
+\*\*Android:\*\* See \[Formatting and Styling\](http://developer.android.com/guide/topics/resources/string-resource.html\#FormattingAndStyling) for more information.
+
+\*\*Platforms:\*\* iOS, Android
+
+<b>Signature:</b>
+
+```typescript
+titleLocArgs?: string;
+```
+
+## NotificationMessagePayload.titleLocKey
+
+The key to the title string in the app's string resources to use to localize the title text to the user's current localization.
+
+\*\*iOS:\*\* Corresponds to `title-loc-key` in the APNs payload. See \[Payload Key Reference\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html) and \[Localizing the Content of Your Remote Notifications\](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html\#//apple\_ref/doc/uid/TP40008194-CH10-SW9) for more information.
+
+\*\*Android:\*\* See \[String Resources\](http://developer.android.com/guide/topics/resources/string-resource.html) for more information.
+
+\*\*Platforms:\*\* iOS, Android
+
+<b>Signature:</b>
+
+```typescript
+titleLocKey?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.sendresponse.md
+++ b/docgen/markdown/firebase-admin.messaging.sendresponse.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}SendResponse interface{% endblock title %}
+{% block body %}
+Interface representing the status of an individual message that was sent as part of a batch request.
+
+<b>Signature:</b>
+
+```typescript
+export interface SendResponse 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [error](./firebase-admin.messaging.sendresponse.md#sendresponseerror) | FirebaseError | An error, if the message was not handed off to FCM successfully. |
+|  [messageId](./firebase-admin.messaging.sendresponse.md#sendresponsemessageid) | string | A unique message ID string, if the message was handed off to FCM for delivery. |
+|  [success](./firebase-admin.messaging.sendresponse.md#sendresponsesuccess) | boolean | A boolean indicating if the message was successfully handed off to FCM or not. When true, the <code>messageId</code> attribute is guaranteed to be set. When false, the <code>error</code> attribute is guaranteed to be set. |
+
+## SendResponse.error
+
+An error, if the message was not handed off to FCM successfully.
+
+<b>Signature:</b>
+
+```typescript
+error?: FirebaseError;
+```
+
+## SendResponse.messageId
+
+A unique message ID string, if the message was handed off to FCM for delivery.
+
+<b>Signature:</b>
+
+```typescript
+messageId?: string;
+```
+
+## SendResponse.success
+
+A boolean indicating if the message was successfully handed off to FCM or not. When true, the `messageId` attribute is guaranteed to be set. When false, the `error` attribute is guaranteed to be set.
+
+<b>Signature:</b>
+
+```typescript
+success: boolean;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.tokenmessage.md
+++ b/docgen/markdown/firebase-admin.messaging.tokenmessage.md
@@ -1,0 +1,24 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}TokenMessage interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface TokenMessage extends BaseMessage 
+```
+<b>Extends:</b> [BaseMessage](./firebase-admin.messaging.basemessage.md#basemessage_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [token](./firebase-admin.messaging.tokenmessage.md#tokenmessagetoken) | string |  |
+
+## TokenMessage.token
+
+<b>Signature:</b>
+
+```typescript
+token: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.topicmessage.md
+++ b/docgen/markdown/firebase-admin.messaging.topicmessage.md
@@ -1,0 +1,24 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}TopicMessage interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface TopicMessage extends BaseMessage 
+```
+<b>Extends:</b> [BaseMessage](./firebase-admin.messaging.basemessage.md#basemessage_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [topic](./firebase-admin.messaging.topicmessage.md#topicmessagetopic) | string |  |
+
+## TopicMessage.topic
+
+<b>Signature:</b>
+
+```typescript
+topic: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.webpushconfig.md
+++ b/docgen/markdown/firebase-admin.messaging.webpushconfig.md
@@ -1,0 +1,66 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}WebpushConfig interface{% endblock title %}
+{% block body %}
+Represents the WebPush protocol options that can be included in an .
+
+<b>Signature:</b>
+
+```typescript
+export interface WebpushConfig 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [data](./firebase-admin.messaging.webpushconfig.md#webpushconfigdata) | { \[key: string\]: string; } | A collection of data fields. |
+|  [fcmOptions](./firebase-admin.messaging.webpushconfig.md#webpushconfigfcmoptions) | [WebpushFcmOptions](./firebase-admin.messaging.webpushfcmoptions.md#webpushfcmoptions_interface) | Options for features provided by the FCM SDK for Web. |
+|  [headers](./firebase-admin.messaging.webpushconfig.md#webpushconfigheaders) | { \[key: string\]: string; } | A collection of WebPush headers. Header values must be strings.<!-- -->See \[WebPush specification\](https://tools.ietf.org/html/rfc8030\#section-5) for supported headers. |
+|  [notification](./firebase-admin.messaging.webpushconfig.md#webpushconfignotification) | [WebpushNotification](./firebase-admin.messaging.webpushnotification.md#webpushnotification_interface) | A WebPush notification payload to be included in the message. |
+
+## WebpushConfig.data
+
+A collection of data fields.
+
+<b>Signature:</b>
+
+```typescript
+data?: {
+        [key: string]: string;
+    };
+```
+
+## WebpushConfig.fcmOptions
+
+Options for features provided by the FCM SDK for Web.
+
+<b>Signature:</b>
+
+```typescript
+fcmOptions?: WebpushFcmOptions;
+```
+
+## WebpushConfig.headers
+
+A collection of WebPush headers. Header values must be strings.
+
+See \[WebPush specification\](https://tools.ietf.org/html/rfc8030\#section-5) for supported headers.
+
+<b>Signature:</b>
+
+```typescript
+headers?: {
+        [key: string]: string;
+    };
+```
+
+## WebpushConfig.notification
+
+A WebPush notification payload to be included in the message.
+
+<b>Signature:</b>
+
+```typescript
+notification?: WebpushNotification;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.webpushfcmoptions.md
+++ b/docgen/markdown/firebase-admin.messaging.webpushfcmoptions.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}WebpushFcmOptions interface{% endblock title %}
+{% block body %}
+Represents options for features provided by the FCM SDK for Web (which are not part of the Webpush standard).
+
+<b>Signature:</b>
+
+```typescript
+export interface WebpushFcmOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [link](./firebase-admin.messaging.webpushfcmoptions.md#webpushfcmoptionslink) | string | The link to open when the user clicks on the notification. For all URL values, HTTPS is required. |
+
+## WebpushFcmOptions.link
+
+The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
+
+<b>Signature:</b>
+
+```typescript
+link?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.messaging.webpushnotification.md
+++ b/docgen/markdown/firebase-admin.messaging.webpushnotification.md
@@ -1,0 +1,185 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}WebpushNotification interface{% endblock title %}
+{% block body %}
+Represents the WebPush-specific notification options that can be included in . This supports most of the standard options as defined in the Web Notification \[specification\](https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification).
+
+<b>Signature:</b>
+
+```typescript
+export interface WebpushNotification 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [actions](./firebase-admin.messaging.webpushnotification.md#webpushnotificationactions) | Array&lt;{ action: string; icon?: string; title: string; }&gt; | An array of notification actions representing the actions available to the user when the notification is presented. |
+|  [badge](./firebase-admin.messaging.webpushnotification.md#webpushnotificationbadge) | string | URL of the image used to represent the notification when there is not enough space to display the notification itself. |
+|  [body](./firebase-admin.messaging.webpushnotification.md#webpushnotificationbody) | string | Body text of the notification. |
+|  [data](./firebase-admin.messaging.webpushnotification.md#webpushnotificationdata) | any | Arbitrary data that you want associated with the notification. This can be of any data type. |
+|  [dir](./firebase-admin.messaging.webpushnotification.md#webpushnotificationdir) | 'auto' \| 'ltr' \| 'rtl' | The direction in which to display the notification. Must be one of <code>auto</code>, <code>ltr</code> or <code>rtl</code>. |
+|  [icon](./firebase-admin.messaging.webpushnotification.md#webpushnotificationicon) | string | URL to the notification icon. |
+|  [image](./firebase-admin.messaging.webpushnotification.md#webpushnotificationimage) | string | URL of an image to be displayed in the notification. |
+|  [lang](./firebase-admin.messaging.webpushnotification.md#webpushnotificationlang) | string | The notification's language as a BCP 47 language tag. |
+|  [renotify](./firebase-admin.messaging.webpushnotification.md#webpushnotificationrenotify) | boolean | A boolean specifying whether the user should be notified after a new notification replaces an old one. Defaults to false. |
+|  [requireInteraction](./firebase-admin.messaging.webpushnotification.md#webpushnotificationrequireinteraction) | boolean | Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. Defaults to false. |
+|  [silent](./firebase-admin.messaging.webpushnotification.md#webpushnotificationsilent) | boolean | A boolean specifying whether the notification should be silent. Defaults to false. |
+|  [tag](./firebase-admin.messaging.webpushnotification.md#webpushnotificationtag) | string | An identifying tag for the notification. |
+|  [timestamp](./firebase-admin.messaging.webpushnotification.md#webpushnotificationtimestamp) | number | Timestamp of the notification. Refer to https://developer.mozilla.org/en-US/docs/Web/API/notification/timestamp for details. |
+|  [title](./firebase-admin.messaging.webpushnotification.md#webpushnotificationtitle) | string | Title text of the notification. |
+|  [vibrate](./firebase-admin.messaging.webpushnotification.md#webpushnotificationvibrate) | number \| number\[\] | A vibration pattern for the device's vibration hardware to emit when the notification fires. |
+
+## WebpushNotification.actions
+
+An array of notification actions representing the actions available to the user when the notification is presented.
+
+<b>Signature:</b>
+
+```typescript
+actions?: Array<{
+        action: string;
+        icon?: string;
+        title: string;
+    }>;
+```
+
+## WebpushNotification.badge
+
+URL of the image used to represent the notification when there is not enough space to display the notification itself.
+
+<b>Signature:</b>
+
+```typescript
+badge?: string;
+```
+
+## WebpushNotification.body
+
+Body text of the notification.
+
+<b>Signature:</b>
+
+```typescript
+body?: string;
+```
+
+## WebpushNotification.data
+
+Arbitrary data that you want associated with the notification. This can be of any data type.
+
+<b>Signature:</b>
+
+```typescript
+data?: any;
+```
+
+## WebpushNotification.dir
+
+The direction in which to display the notification. Must be one of `auto`<!-- -->, `ltr` or `rtl`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+dir?: 'auto' | 'ltr' | 'rtl';
+```
+
+## WebpushNotification.icon
+
+URL to the notification icon.
+
+<b>Signature:</b>
+
+```typescript
+icon?: string;
+```
+
+## WebpushNotification.image
+
+URL of an image to be displayed in the notification.
+
+<b>Signature:</b>
+
+```typescript
+image?: string;
+```
+
+## WebpushNotification.lang
+
+The notification's language as a BCP 47 language tag.
+
+<b>Signature:</b>
+
+```typescript
+lang?: string;
+```
+
+## WebpushNotification.renotify
+
+A boolean specifying whether the user should be notified after a new notification replaces an old one. Defaults to false.
+
+<b>Signature:</b>
+
+```typescript
+renotify?: boolean;
+```
+
+## WebpushNotification.requireInteraction
+
+Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. Defaults to false.
+
+<b>Signature:</b>
+
+```typescript
+requireInteraction?: boolean;
+```
+
+## WebpushNotification.silent
+
+A boolean specifying whether the notification should be silent. Defaults to false.
+
+<b>Signature:</b>
+
+```typescript
+silent?: boolean;
+```
+
+## WebpushNotification.tag
+
+An identifying tag for the notification.
+
+<b>Signature:</b>
+
+```typescript
+tag?: string;
+```
+
+## WebpushNotification.timestamp
+
+Timestamp of the notification. Refer to https://developer.mozilla.org/en-US/docs/Web/API/notification/timestamp for details.
+
+<b>Signature:</b>
+
+```typescript
+timestamp?: number;
+```
+
+## WebpushNotification.title
+
+Title text of the notification.
+
+<b>Signature:</b>
+
+```typescript
+title?: string;
+```
+
+## WebpushNotification.vibrate
+
+A vibration pattern for the device's vibration hardware to emit when the notification fires.
+
+<b>Signature:</b>
+
+```typescript
+vibrate?: number | number[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.androidapp.md
+++ b/docgen/markdown/firebase-admin.project-management.androidapp.md
@@ -1,0 +1,144 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AndroidApp class{% endblock title %}
+{% block body %}
+A reference to a Firebase Android app.
+
+Do not call this constructor directly. Instead, use \[`projectManagement.androidApp()`<!-- -->\](projectManagement.ProjectManagement\#androidApp).
+
+<b>Signature:</b>
+
+```typescript
+export declare class AndroidApp 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [appId](./firebase-admin.project-management.androidapp.md#androidappappid) |  | string |  |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [addShaCertificate(certificateToAdd)](./firebase-admin.project-management.androidapp.md#androidappaddshacertificate) |  | Adds the given SHA certificate to this Android app. |
+|  [deleteShaCertificate(certificateToDelete)](./firebase-admin.project-management.androidapp.md#androidappdeleteshacertificate) |  | Deletes the specified SHA certificate from this Android app. |
+|  [getConfig()](./firebase-admin.project-management.androidapp.md#androidappgetconfig) |  | Gets the configuration artifact associated with this app. A promise that resolves to the Android app's Firebase config file, in UTF-8 string format. This string is typically intended to be written to a JSON file that gets shipped with your Android app. |
+|  [getMetadata()](./firebase-admin.project-management.androidapp.md#androidappgetmetadata) |  | Retrieves metadata about this Android app. A promise that resolves to the retrieved metadata about this Android app. |
+|  [getShaCertificates()](./firebase-admin.project-management.androidapp.md#androidappgetshacertificates) |  | Gets the list of SHA certificates associated with this Android app in Firebase. The list of SHA-1 and SHA-256 certificates associated with this Android app in Firebase. |
+|  [setDisplayName(newDisplayName)](./firebase-admin.project-management.androidapp.md#androidappsetdisplayname) |  | Sets the optional user-assigned display name of the app. |
+
+## AndroidApp.appId
+
+<b>Signature:</b>
+
+```typescript
+readonly appId: string;
+```
+
+## AndroidApp.addShaCertificate()
+
+Adds the given SHA certificate to this Android app.
+
+<b>Signature:</b>
+
+```typescript
+addShaCertificate(certificateToAdd: ShaCertificate): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  certificateToAdd | [ShaCertificate](./firebase-admin.project-management.shacertificate.md#shacertificate_class) | The SHA certificate to add. A promise that resolves when the given certificate has been added to the Android app. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## AndroidApp.deleteShaCertificate()
+
+Deletes the specified SHA certificate from this Android app.
+
+<b>Signature:</b>
+
+```typescript
+deleteShaCertificate(certificateToDelete: ShaCertificate): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  certificateToDelete | [ShaCertificate](./firebase-admin.project-management.shacertificate.md#shacertificate_class) | The SHA certificate to delete. A promise that resolves when the specified certificate has been removed from the Android app. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## AndroidApp.getConfig()
+
+Gets the configuration artifact associated with this app.
+
+ A promise that resolves to the Android app's Firebase config file, in UTF-8 string format. This string is typically intended to be written to a JSON file that gets shipped with your Android app.
+
+<b>Signature:</b>
+
+```typescript
+getConfig(): Promise<string>;
+```
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## AndroidApp.getMetadata()
+
+Retrieves metadata about this Android app.
+
+ A promise that resolves to the retrieved metadata about this Android app.
+
+<b>Signature:</b>
+
+```typescript
+getMetadata(): Promise<AndroidAppMetadata>;
+```
+<b>Returns:</b>
+
+Promise&lt;[AndroidAppMetadata](./firebase-admin.project-management.androidappmetadata.md#androidappmetadata_interface)<!-- -->&gt;
+
+## AndroidApp.getShaCertificates()
+
+Gets the list of SHA certificates associated with this Android app in Firebase.
+
+ The list of SHA-1 and SHA-256 certificates associated with this Android app in Firebase.
+
+<b>Signature:</b>
+
+```typescript
+getShaCertificates(): Promise<ShaCertificate[]>;
+```
+<b>Returns:</b>
+
+Promise&lt;[ShaCertificate](./firebase-admin.project-management.shacertificate.md#shacertificate_class)<!-- -->\[\]&gt;
+
+## AndroidApp.setDisplayName()
+
+Sets the optional user-assigned display name of the app.
+
+<b>Signature:</b>
+
+```typescript
+setDisplayName(newDisplayName: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  newDisplayName | string | The new display name to set. A promise that resolves when the display name has been set. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.androidappmetadata.md
+++ b/docgen/markdown/firebase-admin.project-management.androidappmetadata.md
@@ -1,0 +1,45 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AndroidAppMetadata interface{% endblock title %}
+{% block body %}
+Metadata about a Firebase Android App.
+
+<b>Signature:</b>
+
+```typescript
+export interface AndroidAppMetadata extends AppMetadata 
+```
+<b>Extends:</b> [AppMetadata](./firebase-admin.project-management.appmetadata.md#appmetadata_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [packageName](./firebase-admin.project-management.androidappmetadata.md#androidappmetadatapackagename) | string | The canonical package name of the Android App, as would appear in the Google Play Developer Console. |
+|  [platform](./firebase-admin.project-management.androidappmetadata.md#androidappmetadataplatform) | [AppPlatform.ANDROID](./firebase-admin.project-management.md#appplatformandroid_enummember) |  |
+
+## AndroidAppMetadata.packageName
+
+The canonical package name of the Android App, as would appear in the Google Play Developer Console.
+
+<b>Signature:</b>
+
+```typescript
+packageName: string;
+```
+
+### Example
+
+
+```javascript
+var packageName = androidAppMetadata.packageName;
+
+```
+
+## AndroidAppMetadata.platform
+
+<b>Signature:</b>
+
+```typescript
+platform: AppPlatform.ANDROID;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.appmetadata.md
+++ b/docgen/markdown/firebase-admin.project-management.appmetadata.md
@@ -1,0 +1,114 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}AppMetadata interface{% endblock title %}
+{% block body %}
+Metadata about a Firebase app.
+
+<b>Signature:</b>
+
+```typescript
+export interface AppMetadata 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [appId](./firebase-admin.project-management.appmetadata.md#appmetadataappid) | string | The globally unique, Firebase-assigned identifier of the app. |
+|  [displayName](./firebase-admin.project-management.appmetadata.md#appmetadatadisplayname) | string | The optional user-assigned display name of the app. |
+|  [platform](./firebase-admin.project-management.appmetadata.md#appmetadataplatform) | [AppPlatform](./firebase-admin.project-management.md#appplatform) | The development platform of the app. Supporting Android and iOS app platforms. |
+|  [projectId](./firebase-admin.project-management.appmetadata.md#appmetadataprojectid) | string | The globally unique, user-assigned ID of the parent project for the app. |
+|  [resourceName](./firebase-admin.project-management.appmetadata.md#appmetadataresourcename) | string | The fully-qualified resource name that identifies this app.<!-- -->This is useful when manually constructing requests for Firebase's public API. |
+
+## AppMetadata.appId
+
+The globally unique, Firebase-assigned identifier of the app.
+
+<b>Signature:</b>
+
+```typescript
+appId: string;
+```
+
+### Example
+
+
+```javascript
+var appId = appMetadata.appId;
+
+```
+
+## AppMetadata.displayName
+
+The optional user-assigned display name of the app.
+
+<b>Signature:</b>
+
+```typescript
+displayName?: string;
+```
+
+### Example
+
+
+```javascript
+var displayName = appMetadata.displayName;
+
+```
+
+## AppMetadata.platform
+
+The development platform of the app. Supporting Android and iOS app platforms.
+
+<b>Signature:</b>
+
+```typescript
+platform: AppPlatform;
+```
+
+### Example
+
+
+```javascript
+var platform = AppPlatform.ANDROID;
+
+```
+
+## AppMetadata.projectId
+
+The globally unique, user-assigned ID of the parent project for the app.
+
+<b>Signature:</b>
+
+```typescript
+projectId: string;
+```
+
+### Example
+
+
+```javascript
+var projectId = appMetadata.projectId;
+
+```
+
+## AppMetadata.resourceName
+
+The fully-qualified resource name that identifies this app.
+
+This is useful when manually constructing requests for Firebase's public API.
+
+<b>Signature:</b>
+
+```typescript
+resourceName: string;
+```
+
+### Example
+
+
+```javascript
+var resourceName = androidAppMetadata.resourceName;
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.iosapp.md
+++ b/docgen/markdown/firebase-admin.project-management.iosapp.md
@@ -1,0 +1,86 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}IosApp class{% endblock title %}
+{% block body %}
+A reference to a Firebase iOS app.
+
+Do not call this constructor directly. Instead, use \[`projectManagement.iosApp()`<!-- -->\](projectManagement.ProjectManagement\#iosApp).
+
+<b>Signature:</b>
+
+```typescript
+export declare class IosApp 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [appId](./firebase-admin.project-management.iosapp.md#iosappappid) |  | string |  |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [getConfig()](./firebase-admin.project-management.iosapp.md#iosappgetconfig) |  | Gets the configuration artifact associated with this app. A promise that resolves to the iOS app's Firebase config file, in UTF-8 string format. This string is typically intended to be written to a plist file that gets shipped with your iOS app. |
+|  [getMetadata()](./firebase-admin.project-management.iosapp.md#iosappgetmetadata) |  | Retrieves metadata about this iOS app. A promise that resolves to the retrieved metadata about this iOS app. |
+|  [setDisplayName(newDisplayName)](./firebase-admin.project-management.iosapp.md#iosappsetdisplayname) |  | Sets the optional user-assigned display name of the app. |
+
+## IosApp.appId
+
+<b>Signature:</b>
+
+```typescript
+readonly appId: string;
+```
+
+## IosApp.getConfig()
+
+Gets the configuration artifact associated with this app.
+
+ A promise that resolves to the iOS app's Firebase config file, in UTF-8 string format. This string is typically intended to be written to a plist file that gets shipped with your iOS app.
+
+<b>Signature:</b>
+
+```typescript
+getConfig(): Promise<string>;
+```
+<b>Returns:</b>
+
+Promise&lt;string&gt;
+
+## IosApp.getMetadata()
+
+Retrieves metadata about this iOS app.
+
+ A promise that resolves to the retrieved metadata about this iOS app.
+
+<b>Signature:</b>
+
+```typescript
+getMetadata(): Promise<IosAppMetadata>;
+```
+<b>Returns:</b>
+
+Promise&lt;[IosAppMetadata](./firebase-admin.project-management.iosappmetadata.md#iosappmetadata_interface)<!-- -->&gt;
+
+## IosApp.setDisplayName()
+
+Sets the optional user-assigned display name of the app.
+
+<b>Signature:</b>
+
+```typescript
+setDisplayName(newDisplayName: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  newDisplayName | string | The new display name to set. A promise that resolves when the display name has been set. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.iosappmetadata.md
+++ b/docgen/markdown/firebase-admin.project-management.iosappmetadata.md
@@ -1,0 +1,45 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}IosAppMetadata interface{% endblock title %}
+{% block body %}
+Metadata about a Firebase iOS App.
+
+<b>Signature:</b>
+
+```typescript
+export interface IosAppMetadata extends AppMetadata 
+```
+<b>Extends:</b> [AppMetadata](./firebase-admin.project-management.appmetadata.md#appmetadata_interface)
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [bundleId](./firebase-admin.project-management.iosappmetadata.md#iosappmetadatabundleid) | string | The canonical bundle ID of the iOS App as it would appear in the iOS App Store. |
+|  [platform](./firebase-admin.project-management.iosappmetadata.md#iosappmetadataplatform) | [AppPlatform.IOS](./firebase-admin.project-management.md#appplatformios_enummember) |  |
+
+## IosAppMetadata.bundleId
+
+The canonical bundle ID of the iOS App as it would appear in the iOS App Store.
+
+<b>Signature:</b>
+
+```typescript
+bundleId: string;
+```
+
+### Example
+
+
+```javascript
+var bundleId = iosAppMetadata.bundleId;
+
+```
+
+## IosAppMetadata.platform
+
+<b>Signature:</b>
+
+```typescript
+platform: AppPlatform.IOS;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.md
+++ b/docgen/markdown/firebase-admin.project-management.md
@@ -1,0 +1,92 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.project-management package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [AndroidApp](./firebase-admin.project-management.androidapp.md#androidapp_class) | A reference to a Firebase Android app.<!-- -->Do not call this constructor directly. Instead, use \[<code>projectManagement.androidApp()</code>\](projectManagement.ProjectManagement\#androidApp). |
+|  [IosApp](./firebase-admin.project-management.iosapp.md#iosapp_class) | A reference to a Firebase iOS app.<!-- -->Do not call this constructor directly. Instead, use \[<code>projectManagement.iosApp()</code>\](projectManagement.ProjectManagement\#iosApp). |
+|  [ProjectManagement](./firebase-admin.project-management.projectmanagement.md#projectmanagement_class) | The Firebase ProjectManagement service interface.<!-- -->Do not call this constructor directly. Instead, use \[<code>admin.projectManagement()</code>\](projectManagement\#projectManagement). |
+|  [ShaCertificate](./firebase-admin.project-management.shacertificate.md#shacertificate_class) | A SHA-1 or SHA-256 certificate.<!-- -->Do not call this constructor directly. Instead, use \[<code>projectManagement.shaCertificate()</code>\](projectManagement.ProjectManagement\#shaCertificate). |
+
+## Enumerations
+
+|  Enumeration | Description |
+|  --- | --- |
+|  [AppPlatform](./firebase-admin.project-management.md#appplatform) | Platforms with which a Firebase App can be associated. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getProjectManagement(app)](./firebase-admin.project-management.md#getprojectmanagement) | Gets the  service for the default app or a given app.<code>getProjectManagement()</code> can be called with no arguments to access the default app's  service, or as <code>getProjectManagement(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [AndroidAppMetadata](./firebase-admin.project-management.androidappmetadata.md#androidappmetadata_interface) | Metadata about a Firebase Android App. |
+|  [AppMetadata](./firebase-admin.project-management.appmetadata.md#appmetadata_interface) | Metadata about a Firebase app. |
+|  [IosAppMetadata](./firebase-admin.project-management.iosappmetadata.md#iosappmetadata_interface) | Metadata about a Firebase iOS App. |
+
+## getProjectManagement()
+
+Gets the  service for the default app or a given app.
+
+`getProjectManagement()` can be called with no arguments to access the default app's  service, or as `getProjectManagement(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getProjectManagement(app?: App): ProjectManagement;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app whose <code>ProjectManagement</code> service to return. If not provided, the default <code>ProjectManagement</code> service will be returned. \*  The default <code>ProjectManagement</code> service if no app is provided or the <code>ProjectManagement</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[ProjectManagement](./firebase-admin.project-management.projectmanagement.md#projectmanagement_class)
+
+### Example 1
+
+
+```javascript
+// Get the ProjectManagement service for the default app
+const defaultProjectManagement = getProjectManagement();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the ProjectManagement service for a given app
+const otherProjectManagement = getProjectManagement(otherApp);
+
+```
+
+## AppPlatform
+
+Platforms with which a Firebase App can be associated.
+
+<b>Signature:</b>
+
+```typescript
+export declare enum AppPlatform 
+```
+
+## Enumeration Members
+
+|  Member | Value | Description |
+|  --- | --- | --- |
+|  ANDROID | <code>&quot;ANDROID&quot;</code> | The Firebase App is associated with Android. |
+|  IOS | <code>&quot;IOS&quot;</code> | The Firebase App is associated with iOS. |
+|  PLATFORM\_UNKNOWN | <code>&quot;PLATFORM_UNKNOWN&quot;</code> | Unknown state. This is only used for distinguishing unset values. |
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.projectmanagement.md
+++ b/docgen/markdown/firebase-admin.project-management.projectmanagement.md
@@ -1,0 +1,215 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ProjectManagement class{% endblock title %}
+{% block body %}
+The Firebase ProjectManagement service interface.
+
+Do not call this constructor directly. Instead, use \[`admin.projectManagement()`<!-- -->\](projectManagement\#projectManagement).
+
+<b>Signature:</b>
+
+```typescript
+export declare class ProjectManagement 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.project-management.projectmanagement.md#projectmanagementapp) |  | App |  |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [androidApp(appId)](./firebase-admin.project-management.projectmanagement.md#projectmanagementandroidapp) |  | Creates an <code>AndroidApp</code> object, referencing the specified Android app within this Firebase project.<!-- -->This method does not perform an RPC. |
+|  [createAndroidApp(packageName, displayName)](./firebase-admin.project-management.projectmanagement.md#projectmanagementcreateandroidapp) |  | Creates a new Firebase Android app associated with this Firebase project. |
+|  [createIosApp(bundleId, displayName)](./firebase-admin.project-management.projectmanagement.md#projectmanagementcreateiosapp) |  | Creates a new Firebase iOS app associated with this Firebase project. |
+|  [iosApp(appId)](./firebase-admin.project-management.projectmanagement.md#projectmanagementiosapp) |  | Creates an <code>iOSApp</code> object, referencing the specified iOS app within this Firebase project.<!-- -->This method does not perform an RPC. |
+|  [listAndroidApps()](./firebase-admin.project-management.projectmanagement.md#projectmanagementlistandroidapps) |  | Lists up to 100 Firebase Android apps associated with this Firebase project. The list of Android apps. |
+|  [listAppMetadata()](./firebase-admin.project-management.projectmanagement.md#projectmanagementlistappmetadata) |  | Lists up to 100 Firebase apps associated with this Firebase project. A promise that resolves to the metadata list of the apps. |
+|  [listIosApps()](./firebase-admin.project-management.projectmanagement.md#projectmanagementlistiosapps) |  | Lists up to 100 Firebase iOS apps associated with this Firebase project. The list of iOS apps. |
+|  [setDisplayName(newDisplayName)](./firebase-admin.project-management.projectmanagement.md#projectmanagementsetdisplayname) |  | Update the display name of this Firebase project. |
+|  [shaCertificate(shaHash)](./firebase-admin.project-management.projectmanagement.md#projectmanagementshacertificate) |  | Creates a <code>ShaCertificate</code> object.<!-- -->This method does not perform an RPC. |
+
+## ProjectManagement.app
+
+<b>Signature:</b>
+
+```typescript
+readonly app: App;
+```
+
+## ProjectManagement.androidApp()
+
+Creates an `AndroidApp` object, referencing the specified Android app within this Firebase project.
+
+This method does not perform an RPC.
+
+<b>Signature:</b>
+
+```typescript
+androidApp(appId: string): AndroidApp;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  appId | string | The <code>appId</code> of the Android app to reference. An <code>AndroidApp</code> object that references the specified Firebase Android app. |
+
+<b>Returns:</b>
+
+[AndroidApp](./firebase-admin.project-management.androidapp.md#androidapp_class)
+
+## ProjectManagement.createAndroidApp()
+
+Creates a new Firebase Android app associated with this Firebase project.
+
+<b>Signature:</b>
+
+```typescript
+createAndroidApp(packageName: string, displayName?: string): Promise<AndroidApp>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  packageName | string | The canonical package name of the Android App, as would appear in the Google Play Developer Console. |
+|  displayName | string | An optional user-assigned display name for this new app. A promise that resolves to the newly created Android app. |
+
+<b>Returns:</b>
+
+Promise&lt;[AndroidApp](./firebase-admin.project-management.androidapp.md#androidapp_class)<!-- -->&gt;
+
+## ProjectManagement.createIosApp()
+
+Creates a new Firebase iOS app associated with this Firebase project.
+
+<b>Signature:</b>
+
+```typescript
+createIosApp(bundleId: string, displayName?: string): Promise<IosApp>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  bundleId | string | The iOS app bundle ID to use for this new app. |
+|  displayName | string | An optional user-assigned display name for this new app. A promise that resolves to the newly created iOS app. |
+
+<b>Returns:</b>
+
+Promise&lt;[IosApp](./firebase-admin.project-management.iosapp.md#iosapp_class)<!-- -->&gt;
+
+## ProjectManagement.iosApp()
+
+Creates an `iOSApp` object, referencing the specified iOS app within this Firebase project.
+
+This method does not perform an RPC.
+
+<b>Signature:</b>
+
+```typescript
+iosApp(appId: string): IosApp;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  appId | string | The <code>appId</code> of the iOS app to reference. An <code>iOSApp</code> object that references the specified Firebase iOS app. |
+
+<b>Returns:</b>
+
+[IosApp](./firebase-admin.project-management.iosapp.md#iosapp_class)
+
+## ProjectManagement.listAndroidApps()
+
+Lists up to 100 Firebase Android apps associated with this Firebase project.
+
+ The list of Android apps.
+
+<b>Signature:</b>
+
+```typescript
+listAndroidApps(): Promise<AndroidApp[]>;
+```
+<b>Returns:</b>
+
+Promise&lt;[AndroidApp](./firebase-admin.project-management.androidapp.md#androidapp_class)<!-- -->\[\]&gt;
+
+## ProjectManagement.listAppMetadata()
+
+Lists up to 100 Firebase apps associated with this Firebase project.
+
+ A promise that resolves to the metadata list of the apps.
+
+<b>Signature:</b>
+
+```typescript
+listAppMetadata(): Promise<AppMetadata[]>;
+```
+<b>Returns:</b>
+
+Promise&lt;[AppMetadata](./firebase-admin.project-management.appmetadata.md#appmetadata_interface)<!-- -->\[\]&gt;
+
+## ProjectManagement.listIosApps()
+
+Lists up to 100 Firebase iOS apps associated with this Firebase project.
+
+ The list of iOS apps.
+
+<b>Signature:</b>
+
+```typescript
+listIosApps(): Promise<IosApp[]>;
+```
+<b>Returns:</b>
+
+Promise&lt;[IosApp](./firebase-admin.project-management.iosapp.md#iosapp_class)<!-- -->\[\]&gt;
+
+## ProjectManagement.setDisplayName()
+
+Update the display name of this Firebase project.
+
+<b>Signature:</b>
+
+```typescript
+setDisplayName(newDisplayName: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  newDisplayName | string | The new display name to be updated. A promise that resolves when the project display name has been updated. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## ProjectManagement.shaCertificate()
+
+Creates a `ShaCertificate` object.
+
+This method does not perform an RPC.
+
+<b>Signature:</b>
+
+```typescript
+shaCertificate(shaHash: string): ShaCertificate;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  shaHash | string | The SHA-1 or SHA-256 hash for this certificate. A <code>ShaCertificate</code> object contains the specified SHA hash. |
+
+<b>Returns:</b>
+
+[ShaCertificate](./firebase-admin.project-management.shacertificate.md#shacertificate_class)
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.project-management.shacertificate.md
+++ b/docgen/markdown/firebase-admin.project-management.shacertificate.md
@@ -1,0 +1,55 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ShaCertificate class{% endblock title %}
+{% block body %}
+A SHA-1 or SHA-256 certificate.
+
+Do not call this constructor directly. Instead, use \[`projectManagement.shaCertificate()`<!-- -->\](projectManagement.ProjectManagement\#shaCertificate).
+
+<b>Signature:</b>
+
+```typescript
+export declare class ShaCertificate 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [certType](./firebase-admin.project-management.shacertificate.md#shacertificatecerttype) |  | ('sha1' \| 'sha256') | The SHA certificate type. |
+|  [resourceName](./firebase-admin.project-management.shacertificate.md#shacertificateresourcename) |  | string \| undefined |  |
+|  [shaHash](./firebase-admin.project-management.shacertificate.md#shacertificateshahash) |  | string |  |
+
+## ShaCertificate.certType
+
+The SHA certificate type.
+
+<b>Signature:</b>
+
+```typescript
+readonly certType: ('sha1' | 'sha256');
+```
+
+### Example
+
+
+```javascript
+var certType = shaCertificate.certType;
+
+```
+
+## ShaCertificate.resourceName
+
+<b>Signature:</b>
+
+```typescript
+readonly resourceName?: string | undefined;
+```
+
+## ShaCertificate.shaHash
+
+<b>Signature:</b>
+
+```typescript
+readonly shaHash: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.explicitparametervalue.md
+++ b/docgen/markdown/firebase-admin.remote-config.explicitparametervalue.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ExplicitParameterValue interface{% endblock title %}
+{% block body %}
+Interface representing an explicit parameter value.
+
+<b>Signature:</b>
+
+```typescript
+export interface ExplicitParameterValue 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [value](./firebase-admin.remote-config.explicitparametervalue.md#explicitparametervaluevalue) | string | The <code>string</code> value that the parameter is set to. |
+
+## ExplicitParameterValue.value
+
+The `string` value that the parameter is set to.
+
+<b>Signature:</b>
+
+```typescript
+value: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.inappdefaultvalue.md
+++ b/docgen/markdown/firebase-admin.remote-config.inappdefaultvalue.md
@@ -1,0 +1,27 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}InAppDefaultValue interface{% endblock title %}
+{% block body %}
+Interface representing an in-app-default value.
+
+<b>Signature:</b>
+
+```typescript
+export interface InAppDefaultValue 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [useInAppDefault](./firebase-admin.remote-config.inappdefaultvalue.md#inappdefaultvalueuseinappdefault) | boolean | If <code>true</code>, the parameter is omitted from the parameter values returned to a client. |
+
+## InAppDefaultValue.useInAppDefault
+
+If `true`<!-- -->, the parameter is omitted from the parameter values returned to a client.
+
+<b>Signature:</b>
+
+```typescript
+useInAppDefault: boolean;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.listversionsoptions.md
+++ b/docgen/markdown/firebase-admin.remote-config.listversionsoptions.md
@@ -1,0 +1,71 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListVersionsOptions interface{% endblock title %}
+{% block body %}
+Interface representing options for Remote Config list versions operation.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListVersionsOptions 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [endTime](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptionsendtime) | Date \| string | Specifies the latest update time to include in the results. Any entries updated on or after this time are omitted. |
+|  [endVersionNumber](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptionsendversionnumber) | string \| number | Specifies the newest version number to include in the results. If specified, must be greater than zero. Defaults to the newest version. |
+|  [pageSize](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptionspagesize) | number | The maximum number of items to return per page. |
+|  [pageToken](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptionspagetoken) | string | The <code>nextPageToken</code> value returned from a previous list versions request, if any. |
+|  [startTime](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptionsstarttime) | Date \| string | Specifies the earliest update time to include in the results. Any entries updated before this time are omitted. |
+
+## ListVersionsOptions.endTime
+
+Specifies the latest update time to include in the results. Any entries updated on or after this time are omitted.
+
+<b>Signature:</b>
+
+```typescript
+endTime?: Date | string;
+```
+
+## ListVersionsOptions.endVersionNumber
+
+Specifies the newest version number to include in the results. If specified, must be greater than zero. Defaults to the newest version.
+
+<b>Signature:</b>
+
+```typescript
+endVersionNumber?: string | number;
+```
+
+## ListVersionsOptions.pageSize
+
+The maximum number of items to return per page.
+
+<b>Signature:</b>
+
+```typescript
+pageSize?: number;
+```
+
+## ListVersionsOptions.pageToken
+
+The `nextPageToken` value returned from a previous list versions request, if any.
+
+<b>Signature:</b>
+
+```typescript
+pageToken?: string;
+```
+
+## ListVersionsOptions.startTime
+
+Specifies the earliest update time to include in the results. Any entries updated before this time are omitted.
+
+<b>Signature:</b>
+
+```typescript
+startTime?: Date | string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.listversionsresult.md
+++ b/docgen/markdown/firebase-admin.remote-config.listversionsresult.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ListVersionsResult interface{% endblock title %}
+{% block body %}
+Interface representing a list of Remote Config template versions.
+
+<b>Signature:</b>
+
+```typescript
+export interface ListVersionsResult 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [nextPageToken](./firebase-admin.remote-config.listversionsresult.md#listversionsresultnextpagetoken) | string | Token to retrieve the next page of results, or empty if there are no more results in the list. |
+|  [versions](./firebase-admin.remote-config.listversionsresult.md#listversionsresultversions) | [Version](./firebase-admin.remote-config.version.md#version_interface)<!-- -->\[\] | A list of version metadata objects, sorted in reverse chronological order. |
+
+## ListVersionsResult.nextPageToken
+
+Token to retrieve the next page of results, or empty if there are no more results in the list.
+
+<b>Signature:</b>
+
+```typescript
+nextPageToken?: string;
+```
+
+## ListVersionsResult.versions
+
+A list of version metadata objects, sorted in reverse chronological order.
+
+<b>Signature:</b>
+
+```typescript
+versions: Version[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.md
+++ b/docgen/markdown/firebase-admin.remote-config.md
@@ -1,0 +1,98 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.remote-config package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [RemoteConfig](./firebase-admin.remote-config.remoteconfig.md#remoteconfig_class) | The Firebase <code>RemoteConfig</code> service interface. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getRemoteConfig(app)](./firebase-admin.remote-config.md#getremoteconfig) | Gets the  service for the default app or a given app.<code>getRemoteConfig()</code> can be called with no arguments to access the default app's  service or as <code>getRemoteConfig(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [ExplicitParameterValue](./firebase-admin.remote-config.explicitparametervalue.md#explicitparametervalue_interface) | Interface representing an explicit parameter value. |
+|  [InAppDefaultValue](./firebase-admin.remote-config.inappdefaultvalue.md#inappdefaultvalue_interface) | Interface representing an in-app-default value. |
+|  [ListVersionsOptions](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptions_interface) | Interface representing options for Remote Config list versions operation. |
+|  [ListVersionsResult](./firebase-admin.remote-config.listversionsresult.md#listversionsresult_interface) | Interface representing a list of Remote Config template versions. |
+|  [RemoteConfigCondition](./firebase-admin.remote-config.remoteconfigcondition.md#remoteconfigcondition_interface) | Interface representing a Remote Config condition. A condition targets a specific group of users. A list of these conditions make up part of a Remote Config template. |
+|  [RemoteConfigParameter](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameter_interface) | Interface representing a Remote Config parameter. At minimum, a <code>defaultValue</code> or a <code>conditionalValues</code> entry must be present for the parameter to have any effect. |
+|  [RemoteConfigParameterGroup](./firebase-admin.remote-config.remoteconfigparametergroup.md#remoteconfigparametergroup_interface) | Interface representing a Remote Config parameter group. Grouping parameters is only for management purposes and does not affect client-side fetching of parameter values. |
+|  [RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface) | Interface representing a Remote Config template. |
+|  [RemoteConfigUser](./firebase-admin.remote-config.remoteconfiguser.md#remoteconfiguser_interface) | Interface representing a Remote Config user. |
+|  [Version](./firebase-admin.remote-config.version.md#version_interface) | Interface representing a Remote Config template version. Output only, except for the version description. Contains metadata about a particular version of the Remote Config template. All fields are set at the time the specified Remote Config template is published. A version's description field may be specified in <code>publishTemplate</code> calls. |
+
+## Type Aliases
+
+|  Type Alias | Description |
+|  --- | --- |
+|  [RemoteConfigParameterValue](./firebase-admin.remote-config.md#remoteconfigparametervalue) | Type representing a Remote Config parameter value. A <code>RemoteConfigParameterValue</code> could be either an <code>ExplicitParameterValue</code> or an <code>InAppDefaultValue</code>. |
+|  [TagColor](./firebase-admin.remote-config.md#tagcolor) | Colors that are associated with conditions for display purposes. |
+
+## getRemoteConfig()
+
+Gets the  service for the default app or a given app.
+
+`getRemoteConfig()` can be called with no arguments to access the default app's  service or as `getRemoteConfig(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getRemoteConfig(app?: App): RemoteConfig;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app for which to return the <code>RemoteConfig</code> service. If not provided, the default <code>RemoteConfig</code> service is returned. The default <code>RemoteConfig</code> service if no app is provided, or the <code>RemoteConfig</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[RemoteConfig](./firebase-admin.remote-config.remoteconfig.md#remoteconfig_class)
+
+### Example 1
+
+
+```javascript
+// Get the `RemoteConfig` service for the default app
+const defaultRemoteConfig = getRemoteConfig();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the `RemoteConfig` service for a given app
+const otherRemoteConfig = getRemoteConfig(otherApp);
+
+```
+
+## RemoteConfigParameterValue
+
+Type representing a Remote Config parameter value. A `RemoteConfigParameterValue` could be either an `ExplicitParameterValue` or an `InAppDefaultValue`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+export declare type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue;
+```
+
+## TagColor
+
+Colors that are associated with conditions for display purposes.
+
+<b>Signature:</b>
+
+```typescript
+export declare type TagColor = 'BLUE' | 'BROWN' | 'CYAN' | 'DEEP_ORANGE' | 'GREEN' | 'INDIGO' | 'LIME' | 'ORANGE' | 'PINK' | 'PURPLE' | 'TEAL';
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfig.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfig.md
@@ -1,0 +1,178 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfig class{% endblock title %}
+{% block body %}
+The Firebase `RemoteConfig` service interface.
+
+<b>Signature:</b>
+
+```typescript
+export declare class RemoteConfig 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.remote-config.remoteconfig.md#remoteconfigapp) |  | App |  |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [createTemplateFromJSON(json)](./firebase-admin.remote-config.remoteconfig.md#remoteconfigcreatetemplatefromjson) |  | Creates and returns a new Remote Config template from a JSON string. |
+|  [getTemplate()](./firebase-admin.remote-config.remoteconfig.md#remoteconfiggettemplate) |  | Gets the current active version of the  of the project. A promise that fulfills with a <code>RemoteConfigTemplate</code>. |
+|  [getTemplateAtVersion(versionNumber)](./firebase-admin.remote-config.remoteconfig.md#remoteconfiggettemplateatversion) |  | Gets the requested version of the  of the project. |
+|  [listVersions(options)](./firebase-admin.remote-config.remoteconfig.md#remoteconfiglistversions) |  | Gets a list of Remote Config template versions that have been published, sorted in reverse chronological order. Only the last 300 versions are stored. All versions that correspond to non-active Remote Config templates (i.e., all except the template that is being fetched by clients) are also deleted if they are older than 90 days. |
+|  [publishTemplate(template, options)](./firebase-admin.remote-config.remoteconfig.md#remoteconfigpublishtemplate) |  | Publishes a Remote Config template. |
+|  [rollback(versionNumber)](./firebase-admin.remote-config.remoteconfig.md#remoteconfigrollback) |  | Rolls back a project's published Remote Config template to the specified version. A rollback is equivalent to getting a previously published Remote Config template and re-publishing it using a force update. |
+|  [validateTemplate(template)](./firebase-admin.remote-config.remoteconfig.md#remoteconfigvalidatetemplate) |  | Validates a . |
+
+## RemoteConfig.app
+
+<b>Signature:</b>
+
+```typescript
+readonly app: App;
+```
+
+## RemoteConfig.createTemplateFromJSON()
+
+Creates and returns a new Remote Config template from a JSON string.
+
+<b>Signature:</b>
+
+```typescript
+createTemplateFromJSON(json: string): RemoteConfigTemplate;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  json | string | The JSON string to populate a Remote Config template. A new template instance. |
+
+<b>Returns:</b>
+
+[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)
+
+## RemoteConfig.getTemplate()
+
+Gets the current active version of the  of the project.
+
+ A promise that fulfills with a `RemoteConfigTemplate`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+getTemplate(): Promise<RemoteConfigTemplate>;
+```
+<b>Returns:</b>
+
+Promise&lt;[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)<!-- -->&gt;
+
+## RemoteConfig.getTemplateAtVersion()
+
+Gets the requested version of the  of the project.
+
+<b>Signature:</b>
+
+```typescript
+getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  versionNumber | number \| string | Version number of the Remote Config template to look up. A promise that fulfills with a <code>RemoteConfigTemplate</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)<!-- -->&gt;
+
+## RemoteConfig.listVersions()
+
+Gets a list of Remote Config template versions that have been published, sorted in reverse chronological order. Only the last 300 versions are stored. All versions that correspond to non-active Remote Config templates (i.e., all except the template that is being fetched by clients) are also deleted if they are older than 90 days.
+
+<b>Signature:</b>
+
+```typescript
+listVersions(options?: ListVersionsOptions): Promise<ListVersionsResult>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  options | [ListVersionsOptions](./firebase-admin.remote-config.listversionsoptions.md#listversionsoptions_interface) | Optional options object for getting a list of versions.  A promise that fulfills with a <code>ListVersionsResult</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[ListVersionsResult](./firebase-admin.remote-config.listversionsresult.md#listversionsresult_interface)<!-- -->&gt;
+
+## RemoteConfig.publishTemplate()
+
+Publishes a Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+publishTemplate(template: RemoteConfigTemplate, options?: {
+        force: boolean;
+    }): Promise<RemoteConfigTemplate>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  template | [RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface) | The Remote Config template to be published. |
+|  options | { force: boolean; } | Optional options object when publishing a Remote Config template: - {<!-- -->boolean<!-- -->} <code>force</code> Setting this to <code>true</code> forces the Remote Config template to be updated and circumvent the ETag. This approach is not recommended because it risks causing the loss of updates to your Remote Config template if multiple clients are updating the Remote Config template. See . A Promise that fulfills with the published <code>RemoteConfigTemplate</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)<!-- -->&gt;
+
+## RemoteConfig.rollback()
+
+Rolls back a project's published Remote Config template to the specified version. A rollback is equivalent to getting a previously published Remote Config template and re-publishing it using a force update.
+
+<b>Signature:</b>
+
+```typescript
+rollback(versionNumber: number | string): Promise<RemoteConfigTemplate>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  versionNumber | number \| string | The version number of the Remote Config template to roll back to. The specified version number must be lower than the current version number, and not have been deleted due to staleness. Only the last 300 versions are stored. All versions that correspond to non-active Remote Config templates (that is, all except the template that is being fetched by clients) are also deleted if they are more than 90 days old.  A promise that fulfills with the published <code>RemoteConfigTemplate</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)<!-- -->&gt;
+
+## RemoteConfig.validateTemplate()
+
+Validates a .
+
+<b>Signature:</b>
+
+```typescript
+validateTemplate(template: RemoteConfigTemplate): Promise<RemoteConfigTemplate>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  template | [RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface) | The Remote Config template to be validated. |
+
+<b>Returns:</b>
+
+Promise&lt;[RemoteConfigTemplate](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplate_interface)<!-- -->&gt;
+
+A promise that fulfills with the validated `RemoteConfigTemplate`<!-- -->.
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfigcondition.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfigcondition.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfigCondition interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config condition. A condition targets a specific group of users. A list of these conditions make up part of a Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+export interface RemoteConfigCondition 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [expression](./firebase-admin.remote-config.remoteconfigcondition.md#remoteconfigconditionexpression) | string | The logic of this condition. See the documentation on  for the expected syntax of this field. |
+|  [name](./firebase-admin.remote-config.remoteconfigcondition.md#remoteconfigconditionname) | string | A non-empty and unique name of this condition. |
+|  [tagColor](./firebase-admin.remote-config.remoteconfigcondition.md#remoteconfigconditiontagcolor) | [TagColor](./firebase-admin.remote-config.md#tagcolor) | The color associated with this condition for display purposes in the Firebase Console. Not specifying this value results in the console picking an arbitrary color to associate with the condition. |
+
+## RemoteConfigCondition.expression
+
+The logic of this condition. See the documentation on  for the expected syntax of this field.
+
+<b>Signature:</b>
+
+```typescript
+expression: string;
+```
+
+## RemoteConfigCondition.name
+
+A non-empty and unique name of this condition.
+
+<b>Signature:</b>
+
+```typescript
+name: string;
+```
+
+## RemoteConfigCondition.tagColor
+
+The color associated with this condition for display purposes in the Firebase Console. Not specifying this value results in the console picking an arbitrary color to associate with the condition.
+
+<b>Signature:</b>
+
+```typescript
+tagColor?: TagColor;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfigparameter.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfigparameter.md
@@ -1,0 +1,51 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfigParameter interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config parameter. At minimum, a `defaultValue` or a `conditionalValues` entry must be present for the parameter to have any effect.
+
+<b>Signature:</b>
+
+```typescript
+export interface RemoteConfigParameter 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [conditionalValues](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameterconditionalvalues) | { \[key: string\]: [RemoteConfigParameterValue](./firebase-admin.remote-config.md#remoteconfigparametervalue)<!-- -->; } | A <code>(condition name, value)</code> map. The condition name of the highest priority (the one listed first in the Remote Config template's conditions list) determines the value of this parameter. |
+|  [defaultValue](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameterdefaultvalue) | [RemoteConfigParameterValue](./firebase-admin.remote-config.md#remoteconfigparametervalue) | The value to set the parameter to, when none of the named conditions evaluate to <code>true</code>. |
+|  [description](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameterdescription) | string | A description for this parameter. Should not be over 100 characters and may contain any Unicode characters. |
+
+## RemoteConfigParameter.conditionalValues
+
+A `(condition name, value)` map. The condition name of the highest priority (the one listed first in the Remote Config template's conditions list) determines the value of this parameter.
+
+<b>Signature:</b>
+
+```typescript
+conditionalValues?: {
+        [key: string]: RemoteConfigParameterValue;
+    };
+```
+
+## RemoteConfigParameter.defaultValue
+
+The value to set the parameter to, when none of the named conditions evaluate to `true`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+defaultValue?: RemoteConfigParameterValue;
+```
+
+## RemoteConfigParameter.description
+
+A description for this parameter. Should not be over 100 characters and may contain any Unicode characters.
+
+<b>Signature:</b>
+
+```typescript
+description?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfigparametergroup.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfigparametergroup.md
@@ -1,0 +1,40 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfigParameterGroup interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config parameter group. Grouping parameters is only for management purposes and does not affect client-side fetching of parameter values.
+
+<b>Signature:</b>
+
+```typescript
+export interface RemoteConfigParameterGroup 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [description](./firebase-admin.remote-config.remoteconfigparametergroup.md#remoteconfigparametergroupdescription) | string | A description for the group. Its length must be less than or equal to 256 characters. A description may contain any Unicode characters. |
+|  [parameters](./firebase-admin.remote-config.remoteconfigparametergroup.md#remoteconfigparametergroupparameters) | { \[key: string\]: [RemoteConfigParameter](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameter_interface)<!-- -->; } | Map of parameter keys to their optional default values and optional conditional values for parameters that belong to this group. A parameter only appears once per Remote Config template. An ungrouped parameter appears at the top level, whereas a parameter organized within a group appears within its group's map of parameters. |
+
+## RemoteConfigParameterGroup.description
+
+A description for the group. Its length must be less than or equal to 256 characters. A description may contain any Unicode characters.
+
+<b>Signature:</b>
+
+```typescript
+description?: string;
+```
+
+## RemoteConfigParameterGroup.parameters
+
+Map of parameter keys to their optional default values and optional conditional values for parameters that belong to this group. A parameter only appears once per Remote Config template. An ungrouped parameter appears at the top level, whereas a parameter organized within a group appears within its group's map of parameters.
+
+<b>Signature:</b>
+
+```typescript
+parameters: {
+        [key: string]: RemoteConfigParameter;
+    };
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfigtemplate.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfigtemplate.md
@@ -1,0 +1,75 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfigTemplate interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+export interface RemoteConfigTemplate 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [conditions](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplateconditions) | [RemoteConfigCondition](./firebase-admin.remote-config.remoteconfigcondition.md#remoteconfigcondition_interface)<!-- -->\[\] | A list of conditions in descending order by priority. |
+|  [etag](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplateetag) | string | ETag of the current Remote Config template (readonly). |
+|  [parameterGroups](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplateparametergroups) | { \[key: string\]: [RemoteConfigParameterGroup](./firebase-admin.remote-config.remoteconfigparametergroup.md#remoteconfigparametergroup_interface)<!-- -->; } | Map of parameter group names to their parameter group objects. A group's name is mutable but must be unique among groups in the Remote Config template. The name is limited to 256 characters and intended to be human-readable. Any Unicode characters are allowed. |
+|  [parameters](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplateparameters) | { \[key: string\]: [RemoteConfigParameter](./firebase-admin.remote-config.remoteconfigparameter.md#remoteconfigparameter_interface)<!-- -->; } | Map of parameter keys to their optional default values and optional conditional values. |
+|  [version](./firebase-admin.remote-config.remoteconfigtemplate.md#remoteconfigtemplateversion) | [Version](./firebase-admin.remote-config.version.md#version_interface) | Version information for the current Remote Config template. |
+
+## RemoteConfigTemplate.conditions
+
+A list of conditions in descending order by priority.
+
+<b>Signature:</b>
+
+```typescript
+conditions: RemoteConfigCondition[];
+```
+
+## RemoteConfigTemplate.etag
+
+ETag of the current Remote Config template (readonly).
+
+<b>Signature:</b>
+
+```typescript
+readonly etag: string;
+```
+
+## RemoteConfigTemplate.parameterGroups
+
+Map of parameter group names to their parameter group objects. A group's name is mutable but must be unique among groups in the Remote Config template. The name is limited to 256 characters and intended to be human-readable. Any Unicode characters are allowed.
+
+<b>Signature:</b>
+
+```typescript
+parameterGroups: {
+        [key: string]: RemoteConfigParameterGroup;
+    };
+```
+
+## RemoteConfigTemplate.parameters
+
+Map of parameter keys to their optional default values and optional conditional values.
+
+<b>Signature:</b>
+
+```typescript
+parameters: {
+        [key: string]: RemoteConfigParameter;
+    };
+```
+
+## RemoteConfigTemplate.version
+
+Version information for the current Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+version?: Version;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.remoteconfiguser.md
+++ b/docgen/markdown/firebase-admin.remote-config.remoteconfiguser.md
@@ -1,0 +1,49 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RemoteConfigUser interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config user.
+
+<b>Signature:</b>
+
+```typescript
+export interface RemoteConfigUser 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [email](./firebase-admin.remote-config.remoteconfiguser.md#remoteconfiguseremail) | string | Email address. Output only. |
+|  [imageUrl](./firebase-admin.remote-config.remoteconfiguser.md#remoteconfiguserimageurl) | string | Image URL. Output only. |
+|  [name](./firebase-admin.remote-config.remoteconfiguser.md#remoteconfigusername) | string | Display name. Output only. |
+
+## RemoteConfigUser.email
+
+Email address. Output only.
+
+<b>Signature:</b>
+
+```typescript
+email: string;
+```
+
+## RemoteConfigUser.imageUrl
+
+Image URL. Output only.
+
+<b>Signature:</b>
+
+```typescript
+imageUrl?: string;
+```
+
+## RemoteConfigUser.name
+
+Display name. Output only.
+
+<b>Signature:</b>
+
+```typescript
+name?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.remote-config.version.md
+++ b/docgen/markdown/firebase-admin.remote-config.version.md
@@ -1,0 +1,104 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Version interface{% endblock title %}
+{% block body %}
+Interface representing a Remote Config template version. Output only, except for the version description. Contains metadata about a particular version of the Remote Config template. All fields are set at the time the specified Remote Config template is published. A version's description field may be specified in `publishTemplate` calls.
+
+<b>Signature:</b>
+
+```typescript
+export interface Version 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [description](./firebase-admin.remote-config.version.md#versiondescription) | string | The user-provided description of the corresponding Remote Config template. |
+|  [isLegacy](./firebase-admin.remote-config.version.md#versionislegacy) | boolean | Indicates whether this Remote Config template was published before version history was supported. |
+|  [rollbackSource](./firebase-admin.remote-config.version.md#versionrollbacksource) | string | The version number of the Remote Config template that has become the current version due to a rollback. Only present if this version is the result of a rollback. |
+|  [updateOrigin](./firebase-admin.remote-config.version.md#versionupdateorigin) | ('REMOTE\_CONFIG\_UPDATE\_ORIGIN\_UNSPECIFIED' \| 'CONSOLE' \| 'REST\_API' \| 'ADMIN\_SDK\_NODE') | The origin of the template update action. |
+|  [updateTime](./firebase-admin.remote-config.version.md#versionupdatetime) | string | The timestamp of when this version of the Remote Config template was written to the Remote Config backend. |
+|  [updateType](./firebase-admin.remote-config.version.md#versionupdatetype) | ('REMOTE\_CONFIG\_UPDATE\_TYPE\_UNSPECIFIED' \| 'INCREMENTAL\_UPDATE' \| 'FORCED\_UPDATE' \| 'ROLLBACK') | The type of the template update action. |
+|  [updateUser](./firebase-admin.remote-config.version.md#versionupdateuser) | [RemoteConfigUser](./firebase-admin.remote-config.remoteconfiguser.md#remoteconfiguser_interface) | Aggregation of all metadata fields about the account that performed the update. |
+|  [versionNumber](./firebase-admin.remote-config.version.md#versionversionnumber) | string | The version number of a Remote Config template. |
+
+## Version.description
+
+The user-provided description of the corresponding Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+description?: string;
+```
+
+## Version.isLegacy
+
+Indicates whether this Remote Config template was published before version history was supported.
+
+<b>Signature:</b>
+
+```typescript
+isLegacy?: boolean;
+```
+
+## Version.rollbackSource
+
+The version number of the Remote Config template that has become the current version due to a rollback. Only present if this version is the result of a rollback.
+
+<b>Signature:</b>
+
+```typescript
+rollbackSource?: string;
+```
+
+## Version.updateOrigin
+
+The origin of the template update action.
+
+<b>Signature:</b>
+
+```typescript
+updateOrigin?: ('REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED' | 'CONSOLE' | 'REST_API' | 'ADMIN_SDK_NODE');
+```
+
+## Version.updateTime
+
+The timestamp of when this version of the Remote Config template was written to the Remote Config backend.
+
+<b>Signature:</b>
+
+```typescript
+updateTime?: string;
+```
+
+## Version.updateType
+
+The type of the template update action.
+
+<b>Signature:</b>
+
+```typescript
+updateType?: ('REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED' | 'INCREMENTAL_UPDATE' | 'FORCED_UPDATE' | 'ROLLBACK');
+```
+
+## Version.updateUser
+
+Aggregation of all metadata fields about the account that performed the update.
+
+<b>Signature:</b>
+
+```typescript
+updateUser?: RemoteConfigUser;
+```
+
+## Version.versionNumber
+
+The version number of a Remote Config template.
+
+<b>Signature:</b>
+
+```typescript
+versionNumber?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.md
+++ b/docgen/markdown/firebase-admin.security-rules.md
@@ -1,0 +1,61 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.security-rules package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class) | A set of Firebase security rules. |
+|  [RulesetMetadataList](./firebase-admin.security-rules.rulesetmetadatalist.md#rulesetmetadatalist_class) | A page of ruleset metadata. |
+|  [SecurityRules](./firebase-admin.security-rules.securityrules.md#securityrules_class) | The Firebase <code>SecurityRules</code> service interface. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getSecurityRules(app)](./firebase-admin.security-rules.md#getsecurityrules) | Gets the  service for the default app or a given app.<code>admin.securityRules()</code> can be called with no arguments to access the default app's  service, or as <code>admin.securityRules(app)</code> to access the  service associated with a specific app. |
+
+## Interfaces
+
+|  Interface | Description |
+|  --- | --- |
+|  [RulesetMetadata](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadata_interface) | Required metadata associated with a ruleset. |
+|  [RulesFile](./firebase-admin.security-rules.rulesfile.md#rulesfile_interface) | A source file containing some Firebase security rules. The content includes raw source code including text formatting, indentation and comments. Use the \[<code>securityRules.createRulesFileFromSource()</code>\](securityRules.SecurityRules\#createRulesFileFromSource) method to create new instances of this type. |
+
+## getSecurityRules()
+
+Gets the  service for the default app or a given app.
+
+`admin.securityRules()` can be called with no arguments to access the default app's  service, or as `admin.securityRules(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getSecurityRules(app?: App): SecurityRules;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App | Optional app to return the <code>SecurityRules</code> service for. If not provided, the default <code>SecurityRules</code> service is returned.  The default <code>SecurityRules</code> service if no app is provided, or the <code>SecurityRules</code> service associated with the provided app. |
+
+<b>Returns:</b>
+
+[SecurityRules](./firebase-admin.security-rules.securityrules.md#securityrules_class)
+
+### Example 1
+
+
+```javascript
+// Get the SecurityRules service for the default app
+const defaultSecurityRules = getSecurityRules();
+
+```
+
+### Example 2
+
+\`\`\`<!-- -->javascript // Get the SecurityRules service for a given app const otherSecurityRules = getSecurityRules(otherApp); \`\`\`
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.ruleset.md
+++ b/docgen/markdown/firebase-admin.security-rules.ruleset.md
@@ -1,0 +1,48 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Ruleset class{% endblock title %}
+{% block body %}
+A set of Firebase security rules.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Ruleset implements RulesetMetadata 
+```
+<b>Implements:</b> [RulesetMetadata](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadata_interface)
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [createTime](./firebase-admin.security-rules.ruleset.md#rulesetcreatetime) |  | string | Creation time of the <code>Ruleset</code> as a UTC timestamp string. |
+|  [name](./firebase-admin.security-rules.ruleset.md#rulesetname) |  | string | Name of the <code>Ruleset</code> as a short string. This can be directly passed into APIs like  and . |
+|  [source](./firebase-admin.security-rules.ruleset.md#rulesetsource) |  | [RulesFile](./firebase-admin.security-rules.rulesfile.md#rulesfile_interface)<!-- -->\[\] |  |
+
+## Ruleset.createTime
+
+Creation time of the `Ruleset` as a UTC timestamp string.
+
+<b>Signature:</b>
+
+```typescript
+readonly createTime: string;
+```
+
+## Ruleset.name
+
+Name of the `Ruleset` as a short string. This can be directly passed into APIs like  and .
+
+<b>Signature:</b>
+
+```typescript
+readonly name: string;
+```
+
+## Ruleset.source
+
+<b>Signature:</b>
+
+```typescript
+readonly source: RulesFile[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.rulesetmetadata.md
+++ b/docgen/markdown/firebase-admin.security-rules.rulesetmetadata.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RulesetMetadata interface{% endblock title %}
+{% block body %}
+Required metadata associated with a ruleset.
+
+<b>Signature:</b>
+
+```typescript
+export interface RulesetMetadata 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [createTime](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadatacreatetime) | string | Creation time of the <code>Ruleset</code> as a UTC timestamp string. |
+|  [name](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadataname) | string | Name of the <code>Ruleset</code> as a short string. This can be directly passed into APIs like  and . |
+
+## RulesetMetadata.createTime
+
+Creation time of the `Ruleset` as a UTC timestamp string.
+
+<b>Signature:</b>
+
+```typescript
+readonly createTime: string;
+```
+
+## RulesetMetadata.name
+
+Name of the `Ruleset` as a short string. This can be directly passed into APIs like  and .
+
+<b>Signature:</b>
+
+```typescript
+readonly name: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.rulesetmetadatalist.md
+++ b/docgen/markdown/firebase-admin.security-rules.rulesetmetadatalist.md
@@ -1,0 +1,38 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RulesetMetadataList class{% endblock title %}
+{% block body %}
+A page of ruleset metadata.
+
+<b>Signature:</b>
+
+```typescript
+export declare class RulesetMetadataList 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [nextPageToken](./firebase-admin.security-rules.rulesetmetadatalist.md#rulesetmetadatalistnextpagetoken) |  | string | The next page token if available. This is needed to retrieve the next batch. |
+|  [rulesets](./firebase-admin.security-rules.rulesetmetadatalist.md#rulesetmetadatalistrulesets) |  | [RulesetMetadata](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadata_interface)<!-- -->\[\] | A batch of ruleset metadata. |
+
+## RulesetMetadataList.nextPageToken
+
+The next page token if available. This is needed to retrieve the next batch.
+
+<b>Signature:</b>
+
+```typescript
+readonly nextPageToken?: string;
+```
+
+## RulesetMetadataList.rulesets
+
+A batch of ruleset metadata.
+
+<b>Signature:</b>
+
+```typescript
+readonly rulesets: RulesetMetadata[];
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.rulesfile.md
+++ b/docgen/markdown/firebase-admin.security-rules.rulesfile.md
@@ -1,0 +1,34 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}RulesFile interface{% endblock title %}
+{% block body %}
+A source file containing some Firebase security rules. The content includes raw source code including text formatting, indentation and comments. Use the \[`securityRules.createRulesFileFromSource()`<!-- -->\](securityRules.SecurityRules\#createRulesFileFromSource) method to create new instances of this type.
+
+<b>Signature:</b>
+
+```typescript
+export interface RulesFile 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [content](./firebase-admin.security-rules.rulesfile.md#rulesfilecontent) | string |  |
+|  [name](./firebase-admin.security-rules.rulesfile.md#rulesfilename) | string |  |
+
+## RulesFile.content
+
+<b>Signature:</b>
+
+```typescript
+readonly content: string;
+```
+
+## RulesFile.name
+
+<b>Signature:</b>
+
+```typescript
+readonly name: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.security-rules.securityrules.md
+++ b/docgen/markdown/firebase-admin.security-rules.securityrules.md
@@ -1,0 +1,273 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}SecurityRules class{% endblock title %}
+{% block body %}
+The Firebase `SecurityRules` service interface.
+
+<b>Signature:</b>
+
+```typescript
+export declare class SecurityRules 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.security-rules.securityrules.md#securityrulesapp) |  | App |  |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [createRuleset(file)](./firebase-admin.security-rules.securityrules.md#securityrulescreateruleset) |  | Creates a new  from the given . |
+|  [createRulesFileFromSource(name, source)](./firebase-admin.security-rules.securityrules.md#securityrulescreaterulesfilefromsource) |  | Creates a  with the given name and source. Throws an error if any of the arguments are invalid. This is a local operation, and does not involve any network API calls. |
+|  [deleteRuleset(name)](./firebase-admin.security-rules.securityrules.md#securityrulesdeleteruleset) |  | Deletes the  identified by the given name. The input name should be the short name string without the project ID prefix. For example, to delete the <code>projects/project-id/rulesets/my-ruleset</code>, pass the short name "my-ruleset". Rejects with a <code>not-found</code> error if the specified <code>Ruleset</code> cannot be found. |
+|  [getFirestoreRuleset()](./firebase-admin.security-rules.securityrules.md#securityrulesgetfirestoreruleset) |  | Gets the  currently applied to Cloud Firestore. Rejects with a <code>not-found</code> error if no ruleset is applied on Firestore. A promise that fulfills with the Firestore ruleset. |
+|  [getRuleset(name)](./firebase-admin.security-rules.securityrules.md#securityrulesgetruleset) |  | Gets the  identified by the given name. The input name should be the short name string without the project ID prefix. For example, to retrieve the <code>projects/project-id/rulesets/my-ruleset</code>, pass the short name "my-ruleset". Rejects with a <code>not-found</code> error if the specified <code>Ruleset</code> cannot be found. |
+|  [getStorageRuleset(bucket)](./firebase-admin.security-rules.securityrules.md#securityrulesgetstorageruleset) |  | Gets the  currently applied to a Cloud Storage bucket. Rejects with a <code>not-found</code> error if no ruleset is applied on the bucket. |
+|  [listRulesetMetadata(pageSize, nextPageToken)](./firebase-admin.security-rules.securityrules.md#securityruleslistrulesetmetadata) |  | Retrieves a page of ruleset metadata. |
+|  [releaseFirestoreRuleset(ruleset)](./firebase-admin.security-rules.securityrules.md#securityrulesreleasefirestoreruleset) |  | Applies the specified  ruleset to Cloud Firestore. |
+|  [releaseFirestoreRulesetFromSource(source)](./firebase-admin.security-rules.securityrules.md#securityrulesreleasefirestorerulesetfromsource) |  | Creates a new  from the given source, and applies it to Cloud Firestore. |
+|  [releaseStorageRuleset(ruleset, bucket)](./firebase-admin.security-rules.securityrules.md#securityrulesreleasestorageruleset) |  | Applies the specified  ruleset to a Cloud Storage bucket. |
+|  [releaseStorageRulesetFromSource(source, bucket)](./firebase-admin.security-rules.securityrules.md#securityrulesreleasestoragerulesetfromsource) |  | Creates a new  from the given source, and applies it to a Cloud Storage bucket. |
+
+## SecurityRules.app
+
+<b>Signature:</b>
+
+```typescript
+readonly app: App;
+```
+
+## SecurityRules.createRuleset()
+
+Creates a new  from the given .
+
+<b>Signature:</b>
+
+```typescript
+createRuleset(file: RulesFile): Promise<Ruleset>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  file | [RulesFile](./firebase-admin.security-rules.rulesfile.md#rulesfile_interface) | Rules file to include in the new <code>Ruleset</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+A promise that fulfills with the newly created `Ruleset`<!-- -->.
+
+## SecurityRules.createRulesFileFromSource()
+
+Creates a  with the given name and source. Throws an error if any of the arguments are invalid. This is a local operation, and does not involve any network API calls.
+
+<b>Signature:</b>
+
+```typescript
+createRulesFileFromSource(name: string, source: string | Buffer): RulesFile;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string | Name to assign to the rules file. This is usually a short file name that helps identify the file in a ruleset. |
+|  source | string \| Buffer | Contents of the rules file.  A new rules file instance. |
+
+<b>Returns:</b>
+
+[RulesFile](./firebase-admin.security-rules.rulesfile.md#rulesfile_interface)
+
+### Example
+
+
+```javascript
+const source = '// Some rules source';
+const rulesFile = admin.securityRules().createRulesFileFromSource(
+  'firestore.rules', source);
+
+```
+
+## SecurityRules.deleteRuleset()
+
+Deletes the  identified by the given name. The input name should be the short name string without the project ID prefix. For example, to delete the `projects/project-id/rulesets/my-ruleset`<!-- -->, pass the short name "my-ruleset". Rejects with a `not-found` error if the specified `Ruleset` cannot be found.
+
+<b>Signature:</b>
+
+```typescript
+deleteRuleset(name: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string | Name of the <code>Ruleset</code> to delete.  A promise that fulfills when the <code>Ruleset</code> is deleted. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## SecurityRules.getFirestoreRuleset()
+
+Gets the  currently applied to Cloud Firestore. Rejects with a `not-found` error if no ruleset is applied on Firestore.
+
+ A promise that fulfills with the Firestore ruleset.
+
+<b>Signature:</b>
+
+```typescript
+getFirestoreRuleset(): Promise<Ruleset>;
+```
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+## SecurityRules.getRuleset()
+
+Gets the  identified by the given name. The input name should be the short name string without the project ID prefix. For example, to retrieve the `projects/project-id/rulesets/my-ruleset`<!-- -->, pass the short name "my-ruleset". Rejects with a `not-found` error if the specified `Ruleset` cannot be found.
+
+<b>Signature:</b>
+
+```typescript
+getRuleset(name: string): Promise<Ruleset>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string | Name of the <code>Ruleset</code> to retrieve.  A promise that fulfills with the specified <code>Ruleset</code>. |
+
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+## SecurityRules.getStorageRuleset()
+
+Gets the  currently applied to a Cloud Storage bucket. Rejects with a `not-found` error if no ruleset is applied on the bucket.
+
+<b>Signature:</b>
+
+```typescript
+getStorageRuleset(bucket?: string): Promise<Ruleset>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  bucket | string | Optional name of the Cloud Storage bucket to be retrieved. If not specified, retrieves the ruleset applied on the default bucket configured via <code>AppOptions</code>.  A promise that fulfills with the Cloud Storage ruleset. |
+
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+## SecurityRules.listRulesetMetadata()
+
+Retrieves a page of ruleset metadata.
+
+<b>Signature:</b>
+
+```typescript
+listRulesetMetadata(pageSize?: number, nextPageToken?: string): Promise<RulesetMetadataList>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  pageSize | number | The page size, 100 if undefined. This is also the maximum allowed limit. |
+|  nextPageToken | string | The next page token. If not specified, returns rulesets starting without any offset.  A promise that fulfills with a page of rulesets. |
+
+<b>Returns:</b>
+
+Promise&lt;[RulesetMetadataList](./firebase-admin.security-rules.rulesetmetadatalist.md#rulesetmetadatalist_class)<!-- -->&gt;
+
+## SecurityRules.releaseFirestoreRuleset()
+
+Applies the specified  ruleset to Cloud Firestore.
+
+<b>Signature:</b>
+
+```typescript
+releaseFirestoreRuleset(ruleset: string | RulesetMetadata): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  ruleset | string \| [RulesetMetadata](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadata_interface) | Name of the ruleset to apply or a <code>RulesetMetadata</code> object containing the name.  A promise that fulfills when the ruleset is released. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## SecurityRules.releaseFirestoreRulesetFromSource()
+
+Creates a new  from the given source, and applies it to Cloud Firestore.
+
+<b>Signature:</b>
+
+```typescript
+releaseFirestoreRulesetFromSource(source: string | Buffer): Promise<Ruleset>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  source | string \| Buffer | Rules source to apply.  A promise that fulfills when the ruleset is created and released. |
+
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+## SecurityRules.releaseStorageRuleset()
+
+Applies the specified  ruleset to a Cloud Storage bucket.
+
+<b>Signature:</b>
+
+```typescript
+releaseStorageRuleset(ruleset: string | RulesetMetadata, bucket?: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  ruleset | string \| [RulesetMetadata](./firebase-admin.security-rules.rulesetmetadata.md#rulesetmetadata_interface) | Name of the ruleset to apply or a <code>RulesetMetadata</code> object containing the name. |
+|  bucket | string | Optional name of the Cloud Storage bucket to apply the rules on. If not specified, applies the ruleset on the default bucket configured via .  A promise that fulfills when the ruleset is released. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
+
+## SecurityRules.releaseStorageRulesetFromSource()
+
+Creates a new  from the given source, and applies it to a Cloud Storage bucket.
+
+<b>Signature:</b>
+
+```typescript
+releaseStorageRulesetFromSource(source: string | Buffer, bucket?: string): Promise<Ruleset>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  source | string \| Buffer | Rules source to apply. |
+|  bucket | string | Optional name of the Cloud Storage bucket to apply the rules on. If not specified, applies the ruleset on the default bucket configured via .  A promise that fulfills when the ruleset is created and released. |
+
+<b>Returns:</b>
+
+Promise&lt;[Ruleset](./firebase-admin.security-rules.ruleset.md#ruleset_class)<!-- -->&gt;
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.serviceaccount.md
+++ b/docgen/markdown/firebase-admin.serviceaccount.md
@@ -1,0 +1,41 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}ServiceAccount interface{% endblock title %}
+{% block body %}
+<b>Signature:</b>
+
+```typescript
+export interface ServiceAccount 
+```
+
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [clientEmail](./firebase-admin.serviceaccount.md#serviceaccountclientemail) | string |  |
+|  [privateKey](./firebase-admin.serviceaccount.md#serviceaccountprivatekey) | string |  |
+|  [projectId](./firebase-admin.serviceaccount.md#serviceaccountprojectid) | string |  |
+
+## ServiceAccount.clientEmail
+
+<b>Signature:</b>
+
+```typescript
+clientEmail?: string;
+```
+
+## ServiceAccount.privateKey
+
+<b>Signature:</b>
+
+```typescript
+privateKey?: string;
+```
+
+## ServiceAccount.projectId
+
+<b>Signature:</b>
+
+```typescript
+projectId?: string;
+```
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.storage.md
+++ b/docgen/markdown/firebase-admin.storage.md
@@ -1,0 +1,57 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}firebase-admin.storage package{% endblock title %}
+{% block body %}
+
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [Storage](./firebase-admin.storage.storage.md#storage_class) | The default <code>Storage</code> service if no app is provided or the <code>Storage</code> service associated with the provided app. |
+
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [getStorage(app)](./firebase-admin.storage.md#getstorage) | Gets the  service for the default app or a given app.<code>getStorage()</code> can be called with no arguments to access the default app's  service or as <code>getStorage(app)</code> to access the  service associated with a specific app. |
+
+## getStorage()
+
+Gets the  service for the default app or a given app.
+
+`getStorage()` can be called with no arguments to access the default app's  service or as `getStorage(app)` to access the  service associated with a specific app.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getStorage(app?: App): Storage;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | App |  |
+
+<b>Returns:</b>
+
+[Storage](./firebase-admin.storage.storage.md#storage_class)
+
+### Example 1
+
+
+```javascript
+// Get the Storage service for the default app
+const defaultStorage = getStorage();
+
+```
+
+### Example 2
+
+
+```javascript
+// Get the Storage service for a given app
+const otherStorage = getStorage(otherApp);
+
+```
+
+{% endblock body %}

--- a/docgen/markdown/firebase-admin.storage.storage.md
+++ b/docgen/markdown/firebase-admin.storage.storage.md
@@ -1,0 +1,56 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}Storage class{% endblock title %}
+{% block body %}
+The default `Storage` service if no app is provided or the `Storage` service associated with the provided app.
+
+<b>Signature:</b>
+
+```typescript
+export declare class Storage 
+```
+
+## Properties
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [app](./firebase-admin.storage.storage.md#storageapp) |  | App | Optional app whose <code>Storage</code> service to return. If not provided, the default <code>Storage</code> service will be returned. |
+
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [bucket(name)](./firebase-admin.storage.storage.md#storagebucket) |  | Gets a reference to a Cloud Storage bucket. |
+
+## Storage.app
+
+Optional app whose `Storage` service to return. If not provided, the default `Storage` service will be returned.
+
+<b>Signature:</b>
+
+```typescript
+get app(): App;
+```
+
+## Storage.bucket()
+
+Gets a reference to a Cloud Storage bucket.
+
+<b>Signature:</b>
+
+```typescript
+bucket(name?: string): Bucket;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  name | string | Optional name of the bucket to be retrieved. If name is not specified, retrieves a reference to the default bucket. |
+
+<b>Returns:</b>
+
+Bucket
+
+A \[Bucket\](https://cloud.google.com/nodejs/docs/reference/storage/latest/Bucket) instance as defined in the `@google-cloud/storage` package.
+
+{% endblock body %}

--- a/docgen/markdown/index.md
+++ b/docgen/markdown/index.md
@@ -1,0 +1,22 @@
+{% extends "_internal/templates/reference.html" %}
+{% block title %}API Reference{% endblock title %}
+{% block body %}
+
+## Packages
+
+|  Package | Description |
+|  --- | --- |
+|  [firebase-admin](./firebase-admin.md#firebase-admin_package) |  |
+|  [firebase-admin.app](./firebase-admin.app.md#firebase-adminapp_package) |  |
+|  [firebase-admin.auth](./firebase-admin.auth.md#firebase-adminauth_package) |  |
+|  [firebase-admin.database](./firebase-admin.database.md#firebase-admindatabase_package) |  |
+|  [firebase-admin.firestore](./firebase-admin.firestore.md#firebase-adminfirestore_package) |  |
+|  [firebase-admin.instance-id](./firebase-admin.instance-id.md#firebase-admininstance-id_package) |  |
+|  [firebase-admin.machine-learning](./firebase-admin.machine-learning.md#firebase-adminmachine-learning_package) |  |
+|  [firebase-admin.messaging](./firebase-admin.messaging.md#firebase-adminmessaging_package) |  |
+|  [firebase-admin.project-management](./firebase-admin.project-management.md#firebase-adminproject-management_package) |  |
+|  [firebase-admin.remote-config](./firebase-admin.remote-config.md#firebase-adminremote-config_package) |  |
+|  [firebase-admin.security-rules](./firebase-admin.security-rules.md#firebase-adminsecurity-rules_package) |  |
+|  [firebase-admin.storage](./firebase-admin.storage.md#firebase-adminstorage_package) |  |
+
+{% endblock body %}


### PR DESCRIPTION
Experimental markdown docs generated from the API Documenter.

Process followed:

### Admin SDK repo

```
git clone https://github.com/firebase/firebase-admin-node
cd firebase-admin-node
git checkout modular sdk
npm install
npm run api-extractor:local
```

### JS SDK repo

```
git clone https://github.com/firebase/firebase-js-sdk
yarn
npx ts-node-script repo-scripts/api-documenter/src/start.ts markdown --input path/to/admin/sdk/repo/temp --output adminsdk
```

Most of the generated markdown content looks ok. Open issues to be addressed:

A. The API Documenter doesn't correctly handle old namespaces. Specifically, cases like `admin.auth` being both a function and a namespace are not reflected correctly.
B. Exports from external packages like RTDB and Firestore are not listed.
C. Some invalid tsdoc annotations in the Admin SDK source resulting in some warnings.
