### PR TITLE
fix(auth): Fixing some public API signatures to be consistent with the current API

### DIFF
--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -195,7 +195,7 @@ export abstract class MultiFactorInfo {
 // @public
 export class MultiFactorSettings {
     enrolledFactors: MultiFactorInfo[];
-    toJSON(): any;
+    toJSON(): object;
 }
 
 // @public

--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -394,7 +394,7 @@ export class UserInfo {
 // @public
 export class UserMetadata {
     readonly creationTime: string;
-    readonly lastRefreshTime: string | null;
+    readonly lastRefreshTime?: string | null;
     readonly lastSignInTime: string;
     toJSON(): object;
 }

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -78,6 +78,7 @@ export interface GetAccountInfoUserResponse {
   mfaInfo?: MultiFactorInfoResponse[];
   createdAt?: string;
   lastLoginAt?: string;
+  lastRefreshAt?: string;
   [key: string]: any;
 }
 
@@ -277,7 +278,7 @@ export class MultiFactorSettings {
   /**
    * @return A JSON-serializable representation of this multi-factor object.
    */
-  public toJSON(): any {
+  public toJSON(): object {
     return {
       enrolledFactors: this.enrolledFactors.map((info) => info.toJSON()),
     };

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -304,7 +304,7 @@ export class UserMetadata {
    * formatted as a UTC Date string (eg 'Sat, 03 Feb 2001 04:05:06 GMT').
    * Returns null if the user was never active.
    */
-  public readonly lastRefreshTime: string | null;
+  public readonly lastRefreshTime?: string | null;
 
   /**
    * @param response The server side response returned from the getAccountInfo

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -685,6 +685,15 @@ describe('UserMetadata', () => {
     it('should return expected lastRefreshTime', () => {
       expect(actualMetadata.lastRefreshTime).to.equal(new Date(expectedLastRefreshAt).toUTCString())
     });
+
+    it('should return null when lastRefreshTime is not available', () => {
+      const metadata: UserMetadata = new UserMetadata({
+        localId: 'uid123',
+        lastLoginAt: expectedLastLoginAt.toString(),
+        createdAt: expectedCreatedAt.toString(),
+      });
+      expect(metadata.lastRefreshTime).to.be.null;
+    });
   });
 
   describe('toJSON', () => {


### PR DESCRIPTION
Discovered a couple of deviations in the new API when compared to the existing API surface.

* `UserMetadata.lastRefreshTime` should be optional
https://github.com/firebase/firebase-admin-node/blob/d961c3f705a8259762a796ac4f4d6a6dd0992eb1/src/auth/index.ts#L64

* `MultiFactorSettings.toJSON` should return `object`
https://github.com/firebase/firebase-admin-node/blob/d961c3f705a8259762a796ac4f4d6a6dd0992eb1/src/auth/index.ts#L311