### PR TITLE
Version bumped to alpha0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "9.4.2",
+  "version": "9.100.0-alpha.0",
   "description": "Firebase admin SDK for Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Setting the version on the modular-sdk branch to 9.100.0-alpha.0. These artifacts will be published to a separate NPM tag, so will not conflict with our official releases.