### PR TITLE
fix(rtdb): Fixing a token refresh livelock in Cloud Functions

### DIFF
--- a/src/database/database-internal.ts
+++ b/src/database/database-internal.ts
@@ -116,18 +116,15 @@ export class DatabaseService {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private onTokenChange(_: string): void {
-    this.appInternal.INTERNAL.getToken()
-      .then((token) => {
-        const delayMillis = token.expirationTime - TOKEN_REFRESH_THRESHOLD_MILLIS - Date.now();
-        // If the new token is set to expire soon (unlikely), do nothing. Somebody will eventually
-        // notice and refresh the token, at which point this callback will fire again.
-        if (delayMillis > 0) {
-          this.scheduleTokenRefresh(delayMillis);
-        }
-      })
-      .catch((err) => {
-        console.error('Unexpected error while attempting to schedule a token refresh:', err);
-      });
+    const token = this.appInternal.INTERNAL.getCachedToken();
+    if (token) {
+      const delayMillis = token.expirationTime - TOKEN_REFRESH_THRESHOLD_MILLIS - Date.now();
+      // If the new token is set to expire soon (unlikely), do nothing. Somebody will eventually
+      // notice and refresh the token, at which point this callback will fire again.
+      if (delayMillis > 0) {
+        this.scheduleTokenRefresh(delayMillis);
+      }
+    }
   }
 
   private scheduleTokenRefresh(delayMillis: number): void {

--- a/src/firebase-app.ts
+++ b/src/firebase-app.ts
@@ -74,6 +74,10 @@ export class FirebaseAppInternals {
     return Promise.resolve(this.cachedToken_);
   }
 
+  public getCachedToken(): FirebaseAccessToken | null {
+    return this.cachedToken_ || null;
+  }
+
   private refreshToken(): Promise<FirebaseAccessToken> {
     return Promise.resolve(this.credential_.getAccessToken())
       .then((result) => {
@@ -97,6 +101,8 @@ export class FirebaseAppInternals {
         if (!this.cachedToken_
           || this.cachedToken_.accessToken !== token.accessToken
           || this.cachedToken_.expirationTime !== token.expirationTime) {
+          // Update the cache before firing listeners. Listeners may directly query the
+          // cached token state.
           this.cachedToken_ = token;
           this.tokenListeners_.forEach((listener) => {
             listener(token.accessToken);

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -211,9 +211,7 @@ describe('Database', () => {
         });
     });
 
-    // Currently doesn't work as expected since onTokenChange() can force a token refresh
-    // by calling getToken(). Skipping for now.
-    xit('should not reschedule when the token is about to expire in 5 minutes', () => {
+    it('should not reschedule when the token is about to expire in 5 minutes', () => {
       database.getDatabase();
       return mockApp.INTERNAL.getToken()
         .then((token1) => {


### PR DESCRIPTION
Resolves #1231 and #1233

We originally assumed that a credential would never issue tokens with a TTL shorter than 5 minutes. But turns out this assumption does not hold in the latest GCF runtime, where the metadata server can issue tokens with TTLs as short as 2 minutes. In such situations the SDK ends up in a livelock resulting in high CPU/memory usage, and other normal operations timing out.

Livelock event sequence:

1. Attempt to fetch a new token: the metadata server sends a token with a TTL less than 5 minutes.
2. Fire token change listeners.
3. RTDB token change listener calls `FirebaseApp.INTERNAL.getToken()` to access the last fetched token.
4. But the last fetched token has a TTL less than 5 minutes (i.e. eligible for refresh). Back to step 1.

In order to break the above cycle, I'm introducing a new `getCachedToken()` method to `FirebaseAppInternals`. This method simply returns the last fetched/cached token without ever attempting to refresh it. In step 3, we call this method instead of `getToken()`.

We already had implemented a test case for this scenario but had skipped it in the past. We can enable it now.