### PR TITLE
fix: Removed App from the top-level admin namespace

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -10,17 +10,12 @@ import { FirebaseDatabase } from '@firebase/database-types';
 import * as _firestore from '@google-cloud/firestore';
 import * as rtdb from '@firebase/database-types';
 
-// @public
-export interface App {
-    name: string;
-    options: AppOptions;
-}
-
 // @public (undocumented)
 export function app(name?: string): app.App;
 
 // @public (undocumented)
 export namespace app {
+    // Warning: (ae-forgotten-export) The symbol "App" needs to be exported by the entry point default-namespace.d.ts
     export interface App extends App {
         // (undocumented)
         auth(): auth.Auth;

--- a/src/firebase-namespace-api.ts
+++ b/src/firebase-namespace-api.ts
@@ -27,7 +27,7 @@ import { storage } from './storage/storage-namespace';
 
 import { App as AppCore, AppOptions } from './app/index';
 
-export { App, AppOptions, FirebaseError, FirebaseArrayIndexError } from './app/index';
+export { AppOptions, FirebaseError, FirebaseArrayIndexError } from './app/index';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace app {


### PR DESCRIPTION
`App` is exposed via the `admin.app` namespace. Not necessary to expose it on the `admin` namespace too.