### PR TITLE
chore: Added docstrings to type aliases in namespaces

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -62,24 +62,14 @@ export function auth(app?: App): auth.Auth;
 // @public (undocumented)
 export namespace auth {
     // Warning: (ae-forgotten-export) The symbol "ActionCodeSettings" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ActionCodeSettings = ActionCodeSettings;
     // Warning: (ae-forgotten-export) The symbol "Auth" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Auth = Auth;
     // Warning: (ae-forgotten-export) The symbol "AuthFactorType" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AuthFactorType = AuthFactorType;
     // Warning: (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AuthProviderConfig = AuthProviderConfig;
     // Warning: (ae-forgotten-export) The symbol "AuthProviderConfigFilter" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AuthProviderConfigFilter = AuthProviderConfigFilter;
     // Warning: (ae-forgotten-export) The symbol "BaseAuth" needs to be exported by the entry point default-namespace.d.ts
     //

--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -72,188 +72,96 @@ export namespace auth {
     // Warning: (ae-forgotten-export) The symbol "AuthProviderConfigFilter" needs to be exported by the entry point default-namespace.d.ts
     export type AuthProviderConfigFilter = AuthProviderConfigFilter;
     // Warning: (ae-forgotten-export) The symbol "BaseAuth" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type BaseAuth = BaseAuth;
     // Warning: (ae-forgotten-export) The symbol "CreateMultiFactorInfoRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type CreateMultiFactorInfoRequest = CreateMultiFactorInfoRequest;
     // Warning: (ae-forgotten-export) The symbol "CreatePhoneMultiFactorInfoRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type CreatePhoneMultiFactorInfoRequest = CreatePhoneMultiFactorInfoRequest;
     // Warning: (ae-forgotten-export) The symbol "CreateRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type CreateRequest = CreateRequest;
     // Warning: (ae-forgotten-export) The symbol "CreateTenantRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type CreateTenantRequest = CreateTenantRequest;
     // Warning: (ae-forgotten-export) The symbol "DecodedIdToken" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type DecodedIdToken = DecodedIdToken;
     // Warning: (ae-forgotten-export) The symbol "DeleteUsersResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type DeleteUsersResult = DeleteUsersResult;
     // Warning: (ae-forgotten-export) The symbol "EmailIdentifier" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type EmailIdentifier = EmailIdentifier;
     // Warning: (ae-forgotten-export) The symbol "EmailSignInProviderConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type EmailSignInProviderConfig = EmailSignInProviderConfig;
     // Warning: (ae-forgotten-export) The symbol "GetUsersResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type GetUsersResult = GetUsersResult;
     // Warning: (ae-forgotten-export) The symbol "HashAlgorithmType" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type HashAlgorithmType = HashAlgorithmType;
     // Warning: (ae-forgotten-export) The symbol "ListProviderConfigResults" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListProviderConfigResults = ListProviderConfigResults;
     // Warning: (ae-forgotten-export) The symbol "ListTenantsResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListTenantsResult = ListTenantsResult;
     // Warning: (ae-forgotten-export) The symbol "ListUsersResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListUsersResult = ListUsersResult;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorConfig = MultiFactorConfig;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorConfigState" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorConfigState = MultiFactorConfigState;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorCreateSettings" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorCreateSettings = MultiFactorCreateSettings;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorInfo" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorInfo = MultiFactorInfo;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorSettings" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorSettings = MultiFactorSettings;
     // Warning: (ae-forgotten-export) The symbol "MultiFactorUpdateSettings" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MultiFactorUpdateSettings = MultiFactorUpdateSettings;
     // Warning: (ae-forgotten-export) The symbol "OIDCAuthProviderConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type OIDCAuthProviderConfig = OIDCAuthProviderConfig;
     // Warning: (ae-forgotten-export) The symbol "OIDCUpdateAuthProviderRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type OIDCUpdateAuthProviderRequest = OIDCUpdateAuthProviderRequest;
     // Warning: (ae-forgotten-export) The symbol "PhoneIdentifier" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type PhoneIdentifier = PhoneIdentifier;
     // Warning: (ae-forgotten-export) The symbol "PhoneMultiFactorInfo" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type PhoneMultiFactorInfo = PhoneMultiFactorInfo;
     // Warning: (ae-forgotten-export) The symbol "ProviderIdentifier" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ProviderIdentifier = ProviderIdentifier;
     // Warning: (ae-forgotten-export) The symbol "SAMLAuthProviderConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type SAMLAuthProviderConfig = SAMLAuthProviderConfig;
     // Warning: (ae-forgotten-export) The symbol "SAMLUpdateAuthProviderRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type SAMLUpdateAuthProviderRequest = SAMLUpdateAuthProviderRequest;
     // Warning: (ae-forgotten-export) The symbol "SessionCookieOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type SessionCookieOptions = SessionCookieOptions;
     // Warning: (ae-forgotten-export) The symbol "Tenant" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Tenant = Tenant;
     // Warning: (ae-forgotten-export) The symbol "TenantAwareAuth" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TenantAwareAuth = TenantAwareAuth;
     // Warning: (ae-forgotten-export) The symbol "TenantManager" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TenantManager = TenantManager;
     // Warning: (ae-forgotten-export) The symbol "UidIdentifier" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UidIdentifier = UidIdentifier;
     // Warning: (ae-forgotten-export) The symbol "UpdateAuthProviderRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UpdateAuthProviderRequest = UpdateAuthProviderRequest;
     // Warning: (ae-forgotten-export) The symbol "UpdateMultiFactorInfoRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UpdateMultiFactorInfoRequest = UpdateMultiFactorInfoRequest;
     // Warning: (ae-forgotten-export) The symbol "UpdatePhoneMultiFactorInfoRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UpdatePhoneMultiFactorInfoRequest = UpdatePhoneMultiFactorInfoRequest;
     // Warning: (ae-forgotten-export) The symbol "UpdateRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UpdateRequest = UpdateRequest;
     // Warning: (ae-forgotten-export) The symbol "UpdateTenantRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UpdateTenantRequest = UpdateTenantRequest;
     // Warning: (ae-forgotten-export) The symbol "UserIdentifier" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserIdentifier = UserIdentifier;
     // Warning: (ae-forgotten-export) The symbol "UserImportOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserImportOptions = UserImportOptions;
     // Warning: (ae-forgotten-export) The symbol "UserImportRecord" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserImportRecord = UserImportRecord;
     // Warning: (ae-forgotten-export) The symbol "UserImportResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserImportResult = UserImportResult;
     // Warning: (ae-forgotten-export) The symbol "UserInfo" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserInfo = UserInfo;
     // Warning: (ae-forgotten-export) The symbol "UserMetadata" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserMetadata = UserMetadata;
     // Warning: (ae-forgotten-export) The symbol "UserMetadataRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserMetadataRequest = UserMetadataRequest;
     // Warning: (ae-forgotten-export) The symbol "UserProviderRequest" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserProviderRequest = UserProviderRequest;
     // Warning: (ae-forgotten-export) The symbol "UserRecord" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type UserRecord = UserRecord;
 }
 
@@ -274,8 +182,6 @@ export function database(app?: App): database.Database;
 // @public (undocumented)
 export namespace database {
     // Warning: (ae-forgotten-export) The symbol "Database" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Database = Database;
     // (undocumented)
     export type DataSnapshot = rtdb.DataSnapshot;
@@ -289,8 +195,7 @@ export namespace database {
     export type Reference = rtdb.Reference;
     // (undocumented)
     export type ThenableReference = rtdb.ThenableReference;
-    const // (undocumented)
-    enableLogging: typeof rtdb.enableLogging;
+    const enableLogging: typeof rtdb.enableLogging;
     const ServerValue: rtdb.ServerValue;
 }
 

--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -183,17 +183,11 @@ export function database(app?: App): database.Database;
 export namespace database {
     // Warning: (ae-forgotten-export) The symbol "Database" needs to be exported by the entry point default-namespace.d.ts
     export type Database = Database;
-    // (undocumented)
     export type DataSnapshot = rtdb.DataSnapshot;
-    // (undocumented)
     export type EventType = rtdb.EventType;
-    // (undocumented)
     export type OnDisconnect = rtdb.OnDisconnect;
-    // (undocumented)
     export type Query = rtdb.Query;
-    // (undocumented)
     export type Reference = rtdb.Reference;
-    // (undocumented)
     export type ThenableReference = rtdb.ThenableReference;
     const enableLogging: typeof rtdb.enableLogging;
     const ServerValue: rtdb.ServerValue;
@@ -266,8 +260,6 @@ export function instanceId(app?: App): instanceId.InstanceId;
 // @public (undocumented)
 export namespace instanceId {
     // Warning: (ae-forgotten-export) The symbol "InstanceId" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type InstanceId = InstanceId;
 }
 
@@ -277,40 +269,22 @@ export function machineLearning(app?: App): machineLearning.MachineLearning;
 // @public (undocumented)
 export namespace machineLearning {
     // Warning: (ae-forgotten-export) The symbol "AutoMLTfliteModelOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AutoMLTfliteModelOptions = AutoMLTfliteModelOptions;
     // Warning: (ae-forgotten-export) The symbol "GcsTfliteModelOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type GcsTfliteModelOptions = GcsTfliteModelOptions;
     // Warning: (ae-forgotten-export) The symbol "ListModelsOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListModelsOptions = ListModelsOptions;
     // Warning: (ae-forgotten-export) The symbol "ListModelsResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListModelsResult = ListModelsResult;
     // Warning: (ae-forgotten-export) The symbol "MachineLearning" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MachineLearning = MachineLearning;
     // Warning: (ae-forgotten-export) The symbol "Model" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Model = Model;
     // Warning: (ae-forgotten-export) The symbol "ModelOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ModelOptions = ModelOptions;
     // Warning: (ae-forgotten-export) The symbol "ModelOptionsBase" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ModelOptionsBase = ModelOptionsBase;
     // Warning: (ae-forgotten-export) The symbol "TFLiteModel" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TFLiteModel = TFLiteModel;
 }
 
@@ -320,136 +294,70 @@ export function messaging(app?: App): messaging.Messaging;
 // @public (undocumented)
 export namespace messaging {
     // Warning: (ae-forgotten-export) The symbol "AndroidConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AndroidConfig = AndroidConfig;
     // Warning: (ae-forgotten-export) The symbol "AndroidFcmOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AndroidFcmOptions = AndroidFcmOptions;
     // Warning: (ae-forgotten-export) The symbol "AndroidNotification" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AndroidNotification = AndroidNotification;
     // Warning: (ae-forgotten-export) The symbol "ApnsConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ApnsConfig = ApnsConfig;
     // Warning: (ae-forgotten-export) The symbol "ApnsFcmOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ApnsFcmOptions = ApnsFcmOptions;
     // Warning: (ae-forgotten-export) The symbol "ApnsPayload" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ApnsPayload = ApnsPayload;
     // Warning: (ae-forgotten-export) The symbol "Aps" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Aps = Aps;
     // Warning: (ae-forgotten-export) The symbol "ApsAlert" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ApsAlert = ApsAlert;
     // Warning: (ae-forgotten-export) The symbol "BatchResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type BatchResponse = BatchResponse;
     // Warning: (ae-forgotten-export) The symbol "ConditionMessage" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ConditionMessage = ConditionMessage;
     // Warning: (ae-forgotten-export) The symbol "CriticalSound" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type CriticalSound = CriticalSound;
     // Warning: (ae-forgotten-export) The symbol "DataMessagePayload" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type DataMessagePayload = DataMessagePayload;
     // Warning: (ae-forgotten-export) The symbol "FcmOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type FcmOptions = FcmOptions;
     // Warning: (ae-forgotten-export) The symbol "LightSettings" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type LightSettings = LightSettings;
     // Warning: (ae-forgotten-export) The symbol "Message" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Message = Message;
     // Warning: (ae-forgotten-export) The symbol "Messaging" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Messaging = Messaging;
     // Warning: (ae-forgotten-export) The symbol "MessagingConditionResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingConditionResponse = MessagingConditionResponse;
     // Warning: (ae-forgotten-export) The symbol "MessagingDeviceGroupResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingDeviceGroupResponse = MessagingDeviceGroupResponse;
     // Warning: (ae-forgotten-export) The symbol "MessagingDeviceResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingDeviceResult = MessagingDeviceResult;
     // Warning: (ae-forgotten-export) The symbol "MessagingDevicesResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingDevicesResponse = MessagingDevicesResponse;
     // Warning: (ae-forgotten-export) The symbol "MessagingOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingOptions = MessagingOptions;
     // Warning: (ae-forgotten-export) The symbol "MessagingPayload" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingPayload = MessagingPayload;
     // Warning: (ae-forgotten-export) The symbol "MessagingTopicManagementResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingTopicManagementResponse = MessagingTopicManagementResponse;
     // Warning: (ae-forgotten-export) The symbol "MessagingTopicResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MessagingTopicResponse = MessagingTopicResponse;
     // Warning: (ae-forgotten-export) The symbol "MulticastMessage" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type MulticastMessage = MulticastMessage;
     // Warning: (ae-forgotten-export) The symbol "Notification" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Notification = Notification;
     // Warning: (ae-forgotten-export) The symbol "NotificationMessagePayload" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type NotificationMessagePayload = NotificationMessagePayload;
     // Warning: (ae-forgotten-export) The symbol "SendResponse" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type SendResponse = SendResponse;
     // Warning: (ae-forgotten-export) The symbol "TokenMessage" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TokenMessage = TokenMessage;
     // Warning: (ae-forgotten-export) The symbol "TopicMessage" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TopicMessage = TopicMessage;
     // Warning: (ae-forgotten-export) The symbol "WebpushConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type WebpushConfig = WebpushConfig;
     // Warning: (ae-forgotten-export) The symbol "WebpushFcmOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type WebpushFcmOptions = WebpushFcmOptions;
     // Warning: (ae-forgotten-export) The symbol "WebpushNotification" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type WebpushNotification = WebpushNotification;
 }
 
@@ -459,36 +367,20 @@ export function projectManagement(app?: App): projectManagement.ProjectManagemen
 // @public (undocumented)
 export namespace projectManagement {
     // Warning: (ae-forgotten-export) The symbol "AndroidApp" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AndroidApp = AndroidApp;
     // Warning: (ae-forgotten-export) The symbol "AndroidAppMetadata" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AndroidAppMetadata = AndroidAppMetadata;
     // Warning: (ae-forgotten-export) The symbol "AppMetadata" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AppMetadata = AppMetadata;
     // Warning: (ae-forgotten-export) The symbol "AppPlatform" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type AppPlatform = AppPlatform;
     // Warning: (ae-forgotten-export) The symbol "IosApp" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type IosApp = IosApp;
     // Warning: (ae-forgotten-export) The symbol "IosAppMetadata" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type IosAppMetadata = IosAppMetadata;
     // Warning: (ae-forgotten-export) The symbol "ProjectManagement" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ProjectManagement = ProjectManagement;
     // Warning: (ae-forgotten-export) The symbol "ShaCertificate" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ShaCertificate = ShaCertificate;
 }
 
@@ -498,56 +390,30 @@ export function remoteConfig(app?: App): remoteConfig.RemoteConfig;
 // @public (undocumented)
 export namespace remoteConfig {
     // Warning: (ae-forgotten-export) The symbol "ExplicitParameterValue" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ExplicitParameterValue = ExplicitParameterValue;
     // Warning: (ae-forgotten-export) The symbol "InAppDefaultValue" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type InAppDefaultValue = InAppDefaultValue;
     // Warning: (ae-forgotten-export) The symbol "ListVersionsOptions" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListVersionsOptions = ListVersionsOptions;
     // Warning: (ae-forgotten-export) The symbol "ListVersionsResult" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type ListVersionsResult = ListVersionsResult;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfig" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfig = RemoteConfig;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigCondition" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigCondition = RemoteConfigCondition;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigParameter" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigParameter = RemoteConfigParameter;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigParameterGroup" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigParameterGroup = RemoteConfigParameterGroup;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigParameterValue" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigParameterValue = RemoteConfigParameterValue;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigTemplate" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigTemplate = RemoteConfigTemplate;
     // Warning: (ae-forgotten-export) The symbol "RemoteConfigUser" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RemoteConfigUser = RemoteConfigUser;
     // Warning: (ae-forgotten-export) The symbol "TagColor" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type TagColor = TagColor;
     // Warning: (ae-forgotten-export) The symbol "Version" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Version = Version;
 }
 
@@ -560,24 +426,14 @@ export function securityRules(app?: App): securityRules.SecurityRules;
 // @public (undocumented)
 export namespace securityRules {
     // Warning: (ae-forgotten-export) The symbol "Ruleset" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Ruleset = Ruleset;
     // Warning: (ae-forgotten-export) The symbol "RulesetMetadata" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RulesetMetadata = RulesetMetadata;
     // Warning: (ae-forgotten-export) The symbol "RulesetMetadataList" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RulesetMetadataList = RulesetMetadataList;
     // Warning: (ae-forgotten-export) The symbol "RulesFile" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type RulesFile = RulesFile;
     // Warning: (ae-forgotten-export) The symbol "SecurityRules" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type SecurityRules = SecurityRules;
 }
 
@@ -597,8 +453,6 @@ export function storage(app?: App): storage.Storage;
 // @public (undocumented)
 export namespace storage {
     // Warning: (ae-forgotten-export) The symbol "Storage" needs to be exported by the entry point default-namespace.d.ts
-    //
-    // (undocumented)
     export type Storage = Storage;
 }
 

--- a/etc/firebase-admin.database.api.md
+++ b/etc/firebase-admin.database.api.md
@@ -14,7 +14,7 @@ import { Reference } from '@firebase/database-types';
 import * as rtdb from '@firebase/database-types';
 import { ThenableReference } from '@firebase/database-types';
 
-// @public (undocumented)
+// @public
 export interface Database extends FirebaseDatabase {
     getRules(): Promise<string>;
     getRulesJSON(): Promise<object>;

--- a/etc/firebase-admin.firestore.api.md
+++ b/etc/firebase-admin.firestore.api.md
@@ -16,7 +16,6 @@ import { DocumentSnapshot } from '@google-cloud/firestore';
 import { FieldPath } from '@google-cloud/firestore';
 import { FieldValue } from '@google-cloud/firestore';
 import { Firestore } from '@google-cloud/firestore';
-import * as _firestore from '@google-cloud/firestore';
 import { FirestoreDataConverter } from '@google-cloud/firestore';
 import { GeoPoint } from '@google-cloud/firestore';
 import { GrpcStatus } from '@google-cloud/firestore';
@@ -64,7 +63,7 @@ export { GeoPoint }
 // Warning: (ae-forgotten-export) The symbol "App" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function getFirestore(app?: App): _firestore.Firestore;
+export function getFirestore(app?: App): Firestore;
 
 export { GrpcStatus }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "9.4.2",
+  "version": "9.100.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,17 +57,39 @@
   "types": "./lib/index.d.ts",
   "typesVersions": {
     "*": {
-      "app": ["lib/app"],
-      "auth": ["lib/auth"],
-      "database": ["lib/database"],
-      "firestore": ["lib/firestore"],
-      "instance-id": ["lib/instance-id"],
-      "machine-learning": ["lib/machine-learning"],
-      "messaging": ["lib/messaging"],
-      "project-management": ["lib/project-management"],
-      "remote-config": ["lib/remote-config"],
-      "security-rules": ["lib/security-rules"],
-      "storage": ["lib/storage"]
+      "app": [
+        "lib/app"
+      ],
+      "auth": [
+        "lib/auth"
+      ],
+      "database": [
+        "lib/database"
+      ],
+      "firestore": [
+        "lib/firestore"
+      ],
+      "instance-id": [
+        "lib/instance-id"
+      ],
+      "machine-learning": [
+        "lib/machine-learning"
+      ],
+      "messaging": [
+        "lib/messaging"
+      ],
+      "project-management": [
+        "lib/project-management"
+      ],
+      "remote-config": [
+        "lib/remote-config"
+      ],
+      "security-rules": [
+        "lib/security-rules"
+      ],
+      "storage": [
+        "lib/storage"
+      ]
     }
   },
   "exports": {

--- a/src/auth/auth-namespace.ts
+++ b/src/auth/auth-namespace.ts
@@ -142,50 +142,234 @@ export namespace auth {
    * Type alias to {@link firebase-admin.auth#AuthProviderConfigFilter}.
    */
   export type AuthProviderConfigFilter = TAuthProviderConfigFilter;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#BaseAuth}.
+   */
   export type BaseAuth = TBaseAuth;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#CreateMultiFactorInfoRequest}.
+   */
   export type CreateMultiFactorInfoRequest = TCreateMultiFactorInfoRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#CreatePhoneMultiFactorInfoRequest}.
+   */
   export type CreatePhoneMultiFactorInfoRequest = TCreatePhoneMultiFactorInfoRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#CreateRequest}.
+   */
   export type CreateRequest = TCreateRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#CreateTenantRequest}.
+   */
   export type CreateTenantRequest = TCreateTenantRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#DecodedIdToken}.
+   */
   export type DecodedIdToken = TDecodedIdToken;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#DeleteUsersResult}.
+   */
   export type DeleteUsersResult = TDeleteUsersResult;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#EmailIdentifier}.
+   */
   export type EmailIdentifier = TEmailIdentifier;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#EmailSignInProviderConfig}.
+   */
   export type EmailSignInProviderConfig = TEmailSignInProviderConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#GetUsersResult}.
+   */
   export type GetUsersResult = TGetUsersResult;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#HashAlgorithmType}.
+   */
   export type HashAlgorithmType = THashAlgorithmType;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#ListProviderConfigResults}.
+   */
   export type ListProviderConfigResults = TListProviderConfigResults;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#ListTenantsResult}.
+   */
   export type ListTenantsResult = TListTenantsResult;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#ListUsersResult}.
+   */
   export type ListUsersResult = TListUsersResult;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorCreateSettings}.
+   */
   export type MultiFactorCreateSettings = TMultiFactorCreateSettings;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorConfig}.
+   */
   export type MultiFactorConfig = TMultiFactorConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorConfigState}.
+   */
   export type MultiFactorConfigState = TMultiFactorConfigState;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorInfo}.
+   */
   export type MultiFactorInfo = TMultiFactorInfo;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorUpdateSettings}.
+   */
   export type MultiFactorUpdateSettings = TMultiFactorUpdateSettings;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#MultiFactorSettings}.
+   */
   export type MultiFactorSettings = TMultiFactorSettings;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#OIDCAuthProviderConfig}.
+   */
   export type OIDCAuthProviderConfig = TOIDCAuthProviderConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#OIDCUpdateAuthProviderRequest}.
+   */
   export type OIDCUpdateAuthProviderRequest = TOIDCUpdateAuthProviderRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#PhoneIdentifier}.
+   */
   export type PhoneIdentifier = TPhoneIdentifier;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#PhoneMultiFactorInfo}.
+   */
   export type PhoneMultiFactorInfo = TPhoneMultiFactorInfo;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#ProviderIdentifier}.
+   */
   export type ProviderIdentifier = TProviderIdentifier;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#SAMLAuthProviderConfig}.
+   */
   export type SAMLAuthProviderConfig = TSAMLAuthProviderConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#SAMLUpdateAuthProviderRequest}.
+   */
   export type SAMLUpdateAuthProviderRequest = TSAMLUpdateAuthProviderRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#SessionCookieOptions}.
+   */
   export type SessionCookieOptions = TSessionCookieOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#Tenant}.
+   */
   export type Tenant = TTenant;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#TenantAwareAuth}.
+   */
   export type TenantAwareAuth = TTenantAwareAuth;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#TenantManager}.
+   */
   export type TenantManager = TTenantManager;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UidIdentifier}.
+   */
   export type UidIdentifier = TUidIdentifier;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UpdateAuthProviderRequest}.
+   */
   export type UpdateAuthProviderRequest = TUpdateAuthProviderRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UpdateMultiFactorInfoRequest}.
+   */
   export type UpdateMultiFactorInfoRequest = TUpdateMultiFactorInfoRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UpdatePhoneMultiFactorInfoRequest}.
+   */
   export type UpdatePhoneMultiFactorInfoRequest = TUpdatePhoneMultiFactorInfoRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UpdateRequest}.
+   */
   export type UpdateRequest = TUpdateRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UpdateTenantRequest}.
+   */
   export type UpdateTenantRequest = TUpdateTenantRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserIdentifier}.
+   */
   export type UserIdentifier = TUserIdentifier;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserImportOptions}.
+   */
   export type UserImportOptions = TUserImportOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserImportRecord}.
+   */
   export type UserImportRecord = TUserImportRecord;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserImportResult}.
+   */
   export type UserImportResult = TUserImportResult;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserInfo}.
+   */
   export type UserInfo = TUserInfo;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserMetadata}.
+   */
   export type UserMetadata = TUserMetadata;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserMetadataRequest}.
+   */
   export type UserMetadataRequest = TUserMetadataRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserProviderRequest}.
+   */
   export type UserProviderRequest = TUserProviderRequest;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#UserRecord}.
+   */
   export type UserRecord = TUserRecord;
 }

--- a/src/auth/auth-namespace.ts
+++ b/src/auth/auth-namespace.ts
@@ -118,10 +118,29 @@ export declare function auth(app?: App): auth.Auth;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace auth {
+  /**
+   * Type alias to {@link firebase-admin.auth#ActionCodeSettings}.
+   */
   export type ActionCodeSettings = TActionCodeSettings;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#Auth}.
+   */
   export type Auth = TAuth;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#AuthFactorType}.
+   */
   export type AuthFactorType = TAuthFactorType;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#AuthProviderConfig}.
+   */
   export type AuthProviderConfig = TAuthProviderConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.auth#AuthProviderConfigFilter}.
+   */
   export type AuthProviderConfigFilter = TAuthProviderConfigFilter;
   export type BaseAuth = TBaseAuth;
   export type CreateMultiFactorInfoRequest = TCreateMultiFactorInfoRequest;

--- a/src/database/database-namespace.ts
+++ b/src/database/database-namespace.ts
@@ -51,6 +51,9 @@ export declare function database(app?: App): database.Database;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace database {
+  /**
+   * Type alias to {@link firebase-admin.database#Database}.
+   */
   export type Database = TDatabase;
   export type DataSnapshot = rtdb.DataSnapshot;
   export type EventType = rtdb.EventType;
@@ -59,11 +62,15 @@ export namespace database {
   export type Reference = rtdb.Reference;
   export type ThenableReference = rtdb.ThenableReference;
 
+  /**
+   * {@link https://firebase.google.com/docs/reference/js/firebase.database#enablelogging | enableLogging}
+   * function from the `@firebase/database` package.
+   */
   export declare const enableLogging: typeof rtdb.enableLogging;
 
   /**
    * {@link https://firebase.google.com/docs/reference/js/firebase.database.ServerValue | ServerValue}
-   * module from the `@firebase/database` package.
+   * constant from the `@firebase/database` package.
    */
   export declare const ServerValue: rtdb.ServerValue;
 }

--- a/src/database/database-namespace.ts
+++ b/src/database/database-namespace.ts
@@ -55,11 +55,41 @@ export namespace database {
    * Type alias to {@link firebase-admin.database#Database}.
    */
   export type Database = TDatabase;
+
+  /**
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.DataSnapshot | DataSnapshot}
+   * type from the `@firebase/database` package.
+   */
   export type DataSnapshot = rtdb.DataSnapshot;
+
+  /**
+   * Type alias to the {@link https://firebase.google.com/docs/reference/js/firebase.database#eventtype | EventType}
+   * type from the `@firebase/database` package.
+   */
   export type EventType = rtdb.EventType;
+
+  /**
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.OnDisconnect | OnDisconnect}
+   * type from the `@firebase/database` package.
+   */
   export type OnDisconnect = rtdb.OnDisconnect;
+
+  /**
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.Query | Query}
+   * type from the `@firebase/database` package.
+   */
   export type Query = rtdb.Query;
+
+  /**
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.Reference | Reference}
+   * type from the `@firebase/database` package.
+   */
   export type Reference = rtdb.Reference;
+
+  /**
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.ThenableReference |
+   * ThenableReference} type from the `@firebase/database` package.
+   */
   export type ThenableReference = rtdb.ThenableReference;
 
   /**

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -27,6 +27,11 @@ import * as validator from '../utils/validator';
 import { AuthorizedHttpClient, HttpRequestConfig, HttpError } from '../utils/api-request';
 import { getSdkVersion } from '../utils/index';
 
+/**
+ * The Firebase Database service interface. Extends the
+ * {@link https://firebase.google.com/docs/reference/js/firebase.database.Database | Database}
+ * interface provided by the `@firebase/database` package.
+ */
 export interface Database extends FirebaseDatabase {
   /**
    * Gets the currently applied security rules as a string. The return value consists of

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -42,7 +42,7 @@ export const enableLogging: typeof rtdb.enableLogging = enableLoggingFunc;
 
 /**
  * {@link https://firebase.google.com/docs/reference/js/firebase.database.ServerValue | ServerValue}
- * module from the `@firebase/database` package.
+ * constant from the `@firebase/database` package.
  */
 export const ServerValue: rtdb.ServerValue = serverValueConst;
 

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as _firestore from '@google-cloud/firestore';
+import { Firestore } from '@google-cloud/firestore';
 import { App, getApp } from '../app';
 import { FirebaseApp } from '../app/firebase-app';
 import { FirestoreService } from './firestore-internal';
@@ -50,7 +50,7 @@ export {
   setLogFunction,
 } from '@google-cloud/firestore';
 
-export function getFirestore(app?: App): _firestore.Firestore {
+export function getFirestore(app?: App): Firestore {
   if (typeof app === 'undefined') {
     app = getApp();
   }

--- a/src/instance-id/instance-id-namespace.ts
+++ b/src/instance-id/instance-id-namespace.ts
@@ -33,5 +33,8 @@ export declare function instanceId(app?: App): instanceId.InstanceId;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace instanceId {
+  /**
+   * Type alias to {@link firebase-admin.instance-id#InstanceId}.
+   */
   export type InstanceId = TInstanceId;
 }

--- a/src/machine-learning/machine-learning-namespace.ts
+++ b/src/machine-learning/machine-learning-namespace.ts
@@ -60,14 +60,48 @@ export declare function machineLearning(app?: App): machineLearning.MachineLearn
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace machineLearning {
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#ListModelsResult}.
+   */
   export type ListModelsResult = TListModelsResult;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#MachineLearning}.
+   */
   export type MachineLearning = TMachineLearning;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#Model}.
+   */
   export type Model = TModel;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#TFLiteModel}.
+   */
   export type TFLiteModel = TTFLiteModel;
 
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#AutoMLTfliteModelOptions}.
+   */
   export type AutoMLTfliteModelOptions = TAutoMLTfliteModelOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#GcsTfliteModelOptions}.
+   */
   export type GcsTfliteModelOptions = TGcsTfliteModelOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#ListModelsOptions}.
+   */
   export type ListModelsOptions = TListModelsOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#ModelOptions}.
+   */
   export type ModelOptions = TModelOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.machine-learning#ModelOptionsBase}.
+   */
   export type ModelOptionsBase = TModelOptionsBase;
 }

--- a/src/messaging/messaging-namespace.ts
+++ b/src/messaging/messaging-namespace.ts
@@ -84,40 +84,170 @@ export declare function messaging(app?: App): messaging.Messaging;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace messaging {
+  /**
+   * Type alias to {@link firebase-admin.messaging#Messaging}.
+   */
   export type Messaging = TMessaging;
 
+  /**
+   * Type alias to {@link firebase-admin.messaging#AndroidConfig}.
+   */
   export type AndroidConfig = TAndroidConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#AndroidFcmOptions}.
+   */
   export type AndroidFcmOptions = TAndroidFcmOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#AndroidNotification}.
+   */
   export type AndroidNotification = TAndroidNotification;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#ApnsConfig}.
+   */
   export type ApnsConfig = TApnsConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#ApnsFcmOptions}.
+   */
   export type ApnsFcmOptions = TApnsFcmOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#ApnsPayload}.
+   */
   export type ApnsPayload = TApnsPayload;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#Aps}.
+   */
   export type Aps = TAps;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#ApsAlert}.
+   */
   export type ApsAlert = TApsAlert;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#BatchResponse}.
+   */
   export type BatchResponse = TBatchResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#CriticalSound}.
+   */
   export type CriticalSound = TCriticalSound;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#ConditionMessage}.
+   */
   export type ConditionMessage = TConditionMessage;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#FcmOptions}.
+   */
   export type FcmOptions = TFcmOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#LightSettings}.
+   */
   export type LightSettings = TLightSettings;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#Message}.
+   */
   export type Message = TMessage;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingTopicManagementResponse}.
+   */
   export type MessagingTopicManagementResponse = TMessagingTopicManagementResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MulticastMessage}.
+   */
   export type MulticastMessage = TMulticastMessage;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#Notification}.
+   */
   export type Notification = TNotification;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#SendResponse}.
+   */
   export type SendResponse = TSendResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#TokenMessage}.
+   */
   export type TokenMessage = TTokenMessage;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#TopicMessage}.
+   */
   export type TopicMessage = TTopicMessage;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#WebpushConfig}.
+   */
   export type WebpushConfig = TWebpushConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#WebpushFcmOptions}.
+   */
   export type WebpushFcmOptions = TWebpushFcmOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#WebpushNotification}.
+   */
   export type WebpushNotification = TWebpushNotification;
 
   // Legacy APIs
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#DataMessagePayload}.
+   */
   export type DataMessagePayload = TDataMessagePayload;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingConditionResponse}.
+   */
   export type MessagingConditionResponse = TMessagingConditionResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingDeviceGroupResponse}.
+   */
   export type MessagingDeviceGroupResponse = TMessagingDeviceGroupResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingDeviceResult}.
+   */
   export type MessagingDeviceResult = TMessagingDeviceResult;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingDevicesResponse}.
+   */
   export type MessagingDevicesResponse = TMessagingDevicesResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingOptions}.
+   */
   export type MessagingOptions = TMessagingOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingPayload}.
+   */
   export type MessagingPayload = TMessagingPayload;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#MessagingTopicResponse}.
+   */
   export type MessagingTopicResponse = TMessagingTopicResponse;
+
+  /**
+   * Type alias to {@link firebase-admin.messaging#NotificationMessagePayload}.
+   */
   export type NotificationMessagePayload = TNotificationMessagePayload;
 }

--- a/src/project-management/project-management-namespace.ts
+++ b/src/project-management/project-management-namespace.ts
@@ -60,12 +60,43 @@ export declare function projectManagement(app?: App): projectManagement.ProjectM
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace projectManagement {
+  /**
+   * Type alias to {@link firebase-admin.project-management#AppMetadata}.
+   */
   export type AppMetadata = TAppMetadata;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#AppPlatform}.
+   */
   export type AppPlatform = TAppPlatform;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#ProjectManagement}.
+   */
   export type ProjectManagement = TProjectManagement;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#IosApp}.
+   */
   export type IosApp = TIosApp;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#IosAppMetadata}.
+   */
   export type IosAppMetadata = TIosAppMetadata;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#AndroidApp}.
+   */
   export type AndroidApp = TAndroidApp;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#AndroidAppMetadata}.
+   */
   export type AndroidAppMetadata = TAndroidAppMetadata;
+
+  /**
+   * Type alias to {@link firebase-admin.project-management#ShaCertificate}.
+   */
   export type ShaCertificate = TShaCertificate;
 }

--- a/src/remote-config/remote-config-namespace.ts
+++ b/src/remote-config/remote-config-namespace.ts
@@ -62,17 +62,68 @@ export declare function remoteConfig(app?: App): remoteConfig.RemoteConfig;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace remoteConfig {
+  /**
+   * Type alias to {@link firebase-admin.remote-config#ExplicitParameterValue}.
+   */
   export type ExplicitParameterValue = TExplicitParameterValue;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#InAppDefaultValue}.
+   */
   export type InAppDefaultValue = TInAppDefaultValue;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#ListVersionsOptions}.
+   */
   export type ListVersionsOptions = TListVersionsOptions;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#ListVersionsResult}.
+   */
   export type ListVersionsResult = TListVersionsResult;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfig}.
+   */
   export type RemoteConfig = TRemoteConfig;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigCondition}.
+   */
   export type RemoteConfigCondition = TRemoteConfigCondition;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigParameter}.
+   */
   export type RemoteConfigParameter = TRemoteConfigParameter;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigParameterGroup}.
+   */
   export type RemoteConfigParameterGroup = TRemoteConfigParameterGroup;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigParameterValue}.
+   */
   export type RemoteConfigParameterValue = TRemoteConfigParameterValue;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigTemplate}.
+   */
   export type RemoteConfigTemplate = TRemoteConfigTemplate;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#RemoteConfigUser}.
+   */
   export type RemoteConfigUser = TRemoteConfigUser;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#TagColor}.
+   */
   export type TagColor = TTagColor;
+
+  /**
+   * Type alias to {@link firebase-admin.remote-config#Version}.
+   */
   export type Version = TVersion;
 }

--- a/src/security-rules/security-rules-namespace.ts
+++ b/src/security-rules/security-rules-namespace.ts
@@ -55,9 +55,28 @@ export declare function securityRules(app?: App): securityRules.SecurityRules;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace securityRules {
+  /**
+   * Type alias to {@link firebase-admin.security-rules#RulesFile}.
+   */
   export type RulesFile = TRulesFile;
+
+  /**
+   * Type alias to {@link firebase-admin.security-rules#Ruleset}.
+   */
   export type Ruleset = TRuleset;
+
+  /**
+   * Type alias to {@link firebase-admin.security-rules#RulesetMetadata}.
+   */
   export type RulesetMetadata = TRulesetMetadata;
+
+  /**
+   * Type alias to {@link firebase-admin.security-rules#RulesetMetadataList}.
+   */
   export type RulesetMetadataList = TRulesetMetadataList;
+
+  /**
+   * Type alias to {@link firebase-admin.security-rules#SecurityRules}.
+   */
   export type SecurityRules = TSecurityRules;
 }

--- a/src/storage/storage-namespace.ts
+++ b/src/storage/storage-namespace.ts
@@ -41,5 +41,8 @@ export declare function storage(app?: App): storage.Storage;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace storage {
+  /**
+   * Type alias to {@link firebase-admin.storage#Storage}.
+   */
   export type Storage = TStorage;
 }


### PR DESCRIPTION
Added docstrings referencing the source of truth definitions in new module entrypoints. For example, the `admin.auth.UserRecord` type alias gets a docstring with a reference to the `UserRecord` export in the `firebase-admin/auth` module entry point. These references are correctly converted into hyperlinkg by API Documenter.

<img width="826" alt="Screen Shot 2021-05-03 at 2 08 32 PM" src="https://user-images.githubusercontent.com/2375201/116933944-1d42a980-ac19-11eb-87d4-77bd326eac71.png">


