### PR TITLE
Fix storage emulator env formatting

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -49,7 +49,16 @@ export class Storage implements StorageInterface {
     }
 
     if (!process.env.STORAGE_EMULATOR_HOST && process.env.FIREBASE_STORAGE_EMULATOR_HOST) {
-      process.env.STORAGE_EMULATOR_HOST = process.env.FIREBASE_STORAGE_EMULATOR_HOST;
+      const firebaseStorageEmulatorHost = process.env.FIREBASE_STORAGE_EMULATOR_HOST;
+
+      if (firebaseStorageEmulatorHost.match(/https?:\/\//)) {
+        throw new FirebaseError({
+          code: 'storage/invalid-emulator-host',
+          message: 'FIREBASE_STORAGE_EMULATOR_HOST should not contain a protocol (http or https).',
+        });
+      }
+
+      process.env.STORAGE_EMULATOR_HOST = `http://${process.env.FIREBASE_STORAGE_EMULATOR_HOST}`;
     }
     
     let storage: typeof StorageClient;

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -127,7 +127,7 @@ describe('Storage', () => {
       expect(process.env.STORAGE_EMULATOR_HOST).to.equal(`http://${EMULATOR_HOST}`);
     });
 
-    it('sets STORAGE_EMULATOR_HOST if FIREBASE_STORAGE_EMULATOR_HOST is set', () => {
+    it('throws if FIREBASE_STORAGE_EMULATOR_HOST has a protocol', () => {
       expect(() => new Storage(mockApp)).to.throw;
     });
   

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -123,6 +123,7 @@ describe('Storage', () => {
     });
 
     it('sets STORAGE_EMULATOR_HOST if FIREBASE_STORAGE_EMULATOR_HOST is set', () => {
+      new Storage(mockApp)
       expect(process.env.STORAGE_EMULATOR_HOST).to.equal(`http://${EMULATOR_HOST}`);
     });
 

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -128,7 +128,10 @@ describe('Storage', () => {
     });
 
     it('throws if FIREBASE_STORAGE_EMULATOR_HOST has a protocol', () => {
-      expect(() => new Storage(mockApp)).to.throw;
+      process.env.FIREBASE_STORAGE_EMULATOR_HOST = `https://${EMULATOR_HOST}`;
+
+      expect(() => new Storage(mockApp)).to.throw(
+        'FIREBASE_STORAGE_EMULATOR_HOST should not contain a protocol');
     });
   
     after(() => {

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -115,7 +115,7 @@ describe('Storage', () => {
   });
 
   describe('Emulator mode', () => {
-    const EMULATOR_HOST = 'http://localhost:9199';
+    const EMULATOR_HOST = 'localhost:9199';
 
     before(() => {
       delete process.env.STORAGE_EMULATOR_HOST;

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -123,9 +123,11 @@ describe('Storage', () => {
     });
 
     it('sets STORAGE_EMULATOR_HOST if FIREBASE_STORAGE_EMULATOR_HOST is set', () => {
-      new Storage(mockApp);
-      
-      expect(process.env.STORAGE_EMULATOR_HOST).to.equal(EMULATOR_HOST);
+      expect(process.env.STORAGE_EMULATOR_HOST).to.equal(`http://${EMULATOR_HOST}`);
+    });
+
+    it('sets STORAGE_EMULATOR_HOST if FIREBASE_STORAGE_EMULATOR_HOST is set', () => {
+      expect(() => new Storage(mockApp)).to.throw;
     });
   
     after(() => {

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -114,21 +114,24 @@ describe('Storage', () => {
     });
   });
 
-  describe('Emulator mode', () => {
-    const EMULATOR_HOST = 'localhost:9199';
+  describe.only('Emulator mode', () => {
+    const VALID_EMULATOR_HOST = 'localhost:9199';
+    const INVALID_EMULATOR_HOST = 'https://localhost:9199';
 
-    before(() => {
+    beforeEach(() => {
       delete process.env.STORAGE_EMULATOR_HOST;
-      process.env.FIREBASE_STORAGE_EMULATOR_HOST = EMULATOR_HOST;
+      delete process.env.FIREBASE_STORAGE_EMULATOR_HOST;
     });
 
     it('sets STORAGE_EMULATOR_HOST if FIREBASE_STORAGE_EMULATOR_HOST is set', () => {
+      process.env.FIREBASE_STORAGE_EMULATOR_HOST = VALID_EMULATOR_HOST;
+
       new Storage(mockApp)
-      expect(process.env.STORAGE_EMULATOR_HOST).to.equal(`http://${EMULATOR_HOST}`);
+      expect(process.env.STORAGE_EMULATOR_HOST).to.equal(`http://${VALID_EMULATOR_HOST}`);
     });
 
     it('throws if FIREBASE_STORAGE_EMULATOR_HOST has a protocol', () => {
-      process.env.FIREBASE_STORAGE_EMULATOR_HOST = `https://${EMULATOR_HOST}`;
+      process.env.FIREBASE_STORAGE_EMULATOR_HOST = INVALID_EMULATOR_HOST;
 
       expect(() => new Storage(mockApp)).to.throw(
         'FIREBASE_STORAGE_EMULATOR_HOST should not contain a protocol');


### PR DESCRIPTION
The Firebase style env var for storage emulator can't have protocol and the Cloud version *must* have a protocol.