### PR TITLE
Fix types for Create / Update MultifactorRequest

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -339,7 +339,7 @@ export namespace auth {
    * Interface representing common properties of a user enrolled second factor
    * for an `UpdateRequest`.
    */
-  export interface UpdateMultiFactorInfoRequest {
+  export interface BaseUpdateMultiFactorInfoRequest {
 
     /**
      * The ID of the enrolled second factor. This ID is unique to the user. When not provided,
@@ -367,13 +367,21 @@ export namespace auth {
    * Interface representing a phone specific user enrolled second factor
    * for an `UpdateRequest`.
    */
-  export interface UpdatePhoneMultiFactorInfoRequest extends UpdateMultiFactorInfoRequest {
+  export interface UpdatePhoneMultiFactorInfoRequest extends BaseUpdateMultiFactorInfoRequest {
 
     /**
      * The phone number associated with a phone second factor.
      */
     phoneNumber: string;
   }
+  
+  /**
+   * Interface representing properties of a user enrolled second factor
+   * for an `UpdateRequest`.
+   */
+  export type UpdateMultiFactorInfoRequest = 
+    | UpdatePhoneMultiFactorInfoRequest;
+
 
   /**
    * Interface representing the properties to update on the provided user.
@@ -446,7 +454,7 @@ export namespace auth {
    * Interface representing base properties of a user enrolled second factor for a
    * `CreateRequest`.
    */
-  export interface CreateMultiFactorInfoRequest {
+  export interface BaseCreateMultiFactorInfoRequest {
 
     /**
      * The optional display name for an enrolled second factor.
@@ -463,13 +471,21 @@ export namespace auth {
    * Interface representing a phone specific user enrolled second factor for a
    * `CreateRequest`.
    */
-  export interface CreatePhoneMultiFactorInfoRequest extends CreateMultiFactorInfoRequest {
+  export interface CreatePhoneMultiFactorInfoRequest extends BaseCreateMultiFactorInfoRequest {
 
     /**
      * The phone number associated with a phone second factor.
      */
     phoneNumber: string;
   }
+  
+  /**
+   * Interface representing properties of a user enrolled second factor for a
+   * `CreateRequest`.
+   */
+  export type CreateMultiFactorInfoRequest = 
+    | CreatePhoneMultiFactorInfoRequest;
+
 
   /**
    * Interface representing the properties to set on a new user record to be


### PR DESCRIPTION
Fixes #1267.

Derived classes are not interchangeable with Base classes as types. Rather than making the request take a generic `<T extends CreateMultifactorInfoRequest>`, this assigns a union of the (one currently allowed) type.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
