### PR TITLE
Add support for a service account credential file at the GCLOUD_CREDENTIAL_PATH

### DIFF
--- a/src/credential/credential-internal.ts
+++ b/src/credential/credential-internal.ts
@@ -354,9 +354,13 @@ export function getApplicationDefault(httpAgent?: Agent): Credential {
 
   // It is OK to not have this file. If it is present, it must be valid.
   if (GCLOUD_CREDENTIAL_PATH) {
-    const refreshToken = readCredentialFile(GCLOUD_CREDENTIAL_PATH, true);
-    if (refreshToken) {
-      return new RefreshTokenCredential(refreshToken, httpAgent, true);
+    const credentialFile = readCredentialFile(GCLOUD_CREDENTIAL_PATH, true);
+    if (credentialFile) {
+      if (credentialFile.type === 'service_account') {
+        return new ServiceAccountCredential(credentialFile, httpAgent, true);
+      }
+
+      return new RefreshTokenCredential(credentialFile, httpAgent, true);
     }
   }
 

--- a/test/unit/credential/credential.spec.ts
+++ b/test/unit/credential/credential.spec.ts
@@ -535,6 +535,13 @@ describe('Credential', () => {
       const c = getApplicationDefault();
       expect(c).to.be.an.instanceof(RefreshTokenCredential);
       expect(isApplicationDefault(c)).to.be.true;
+    })
+    
+    it('should return true for ServiceAccountCredential loaded from GCLOUD_CREDENTIAL_PATH', () => {
+      process.env.GCLOUD_CREDENTIAL_PATH = path.resolve(__dirname, '../../resources/mock.key.json');
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(ServiceAccountCredential);
+      expect(isApplicationDefault(c)).to.be.true;
     });
 
     it('should return true for ComputeEngineCredential', () => {


### PR DESCRIPTION
I noticed that the SDK would fail to detect the Application Default Credentials when I set the `GCLOUD_CREDENTIAL_PATH` environment variable the path of a service account key file. Since the same is working perfectly fine in the C# SDK, I assumed that this is a bug.

Please let me know if I should do anything different here or if this is the expected behavior, since I'm not familiar with the internals of the Node SDK at all!