### PR TITLE
fix(auth): make MFA uid optional for updateUser operations

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -274,8 +274,8 @@ function validateAuthFactorInfo(request: AuthFactorInfo): void {
   // No enrollment ID is available for signupNewUser. Use another identifier.
   const authFactorInfoIdentifier =
       request.mfaEnrollmentId || request.phoneInfo || JSON.stringify(request);
-  // Enrollment uid can be specified for update operations.
-  if ((typeof request.mfaEnrollmentId !== 'undefined') &&
+  // Enrollment uid may or may not be specified for update operations.
+  if (typeof request.mfaEnrollmentId !== 'undefined' &&
       !validator.isNonEmptyString(request.mfaEnrollmentId)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_UID,

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -257,9 +257,8 @@ class AuthHttpClient extends AuthorizedHttpClient {
  * an error is thrown.
  *
  * @param request The AuthFactorInfo request object.
- * @param writeOperationType The write operation type.
  */
-function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: WriteOperationType): void {
+function validateAuthFactorInfo(request: AuthFactorInfo): void {
   const validKeys = {
     mfaEnrollmentId: true,
     displayName: true,
@@ -275,8 +274,8 @@ function validateAuthFactorInfo(request: AuthFactorInfo, writeOperationType: Wri
   // No enrollment ID is available for signupNewUser. Use another identifier.
   const authFactorInfoIdentifier =
       request.mfaEnrollmentId || request.phoneInfo || JSON.stringify(request);
-  const uidRequired = writeOperationType !== WriteOperationType.Create;
-  if ((typeof request.mfaEnrollmentId !== 'undefined' || uidRequired) &&
+  // Enrollment uid can be specified for update operations.
+  if ((typeof request.mfaEnrollmentId !== 'undefined') &&
       !validator.isNonEmptyString(request.mfaEnrollmentId)) {
     throw new FirebaseAuthError(
       AuthClientErrorCode.INVALID_UID,
@@ -573,7 +572,7 @@ function validateCreateEditRequest(request: any, writeOperationType: WriteOperat
       throw new FirebaseAuthError(AuthClientErrorCode.INVALID_ENROLLED_FACTORS);
     }
     enrollments.forEach((authFactorInfoEntry: AuthFactorInfo) => {
-      validateAuthFactorInfo(authFactorInfoEntry, writeOperationType);
+      validateAuthFactorInfo(authFactorInfoEntry);
     });
   }
 }

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -2071,6 +2071,11 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               phoneNumber: '+16505551000',
               factorId: 'phone',
             } as UpdateMultiFactorInfoRequest,
+            {
+              // No error should be thrown when no uid is specified.
+              phoneNumber: '+16505551234',
+              factorId: 'phone',
+            } as UpdateMultiFactorInfoRequest,
           ],
         },
       };
@@ -2095,6 +2100,9 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             {
               mfaEnrollmentId: 'enrolledSecondFactor2',
               phoneInfo: '+16505551000',
+            },
+            {
+              phoneInfo: '+16505551234',
             },
           ],
         },


### PR DESCRIPTION
MFA `uid` should be optional for `updateUser` operations.
When not specified, the backend will provision a `uid` for the
enrolled second factor.

Fixes https://github.com/firebase/firebase-admin-node/issues/1276