### PR TITLE
chore: Remove gulp-replace dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -971,7 +971,7 @@
     },
     "@types/firebase-token-generator": {
       "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@types/firebase-token-generator/-/firebase-token-generator-2.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/firebase-token-generator/-/firebase-token-generator-2.0.28.tgz",
       "integrity": "sha1-Z1VIHZMk4mt6XItFXWgUg3aCw5Y=",
       "dev": true
     },
@@ -1726,12 +1726,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true
-    },
-    "binaryextensions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
-      "integrity": "sha1-HmN0iLNbWL2l9HdL+WpSEqjJB1U=",
       "dev": true
     },
     "bindings": {
@@ -3433,7 +3427,7 @@
     },
     "firebase-token-generator": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/firebase-token-generator/-/firebase-token-generator-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/firebase-token-generator/-/firebase-token-generator-2.0.0.tgz",
       "integrity": "sha1-l2fXWewTq9yZuhFf1eqZ2Lk9EgY=",
       "dev": true
     },
@@ -3854,7 +3848,7 @@
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -4094,17 +4088,6 @@
             "xtend": "~4.0.1"
           }
         }
-      }
-    },
-    "gulp-replace": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.4.tgz",
-      "integrity": "sha1-aaZ5FLvRPFYr/xT1BKQDeWqg2qk=",
-      "dev": true,
-      "requires": {
-        "istextorbinary": "1.0.2",
-        "readable-stream": "^2.0.1",
-        "replacestream": "^4.0.0"
       }
     },
     "gulp-typescript": {
@@ -5103,16 +5086,6 @@
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0"
-      }
-    },
-    "istextorbinary": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
-      "integrity": "sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=",
-      "dev": true,
-      "requires": {
-        "binaryextensions": "~1.0.0",
-        "textextensions": "~1.0.0"
       }
     },
     "jju": {
@@ -7279,7 +7252,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -7441,7 +7414,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -7742,17 +7715,6 @@
         "remove-trailing-separator": "^1.1.0"
       }
     },
-    "replacestream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.3",
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -7984,7 +7946,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -8804,12 +8766,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "textextensions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
-      "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
       "dev": true
     },
     "thenify": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "gulp": "^4.0.2",
     "gulp-filter": "^6.0.0",
     "gulp-header": "^1.8.8",
-    "gulp-replace": "^0.5.4",
     "gulp-typescript": "^5.0.1",
     "http-message-parser": "^0.0.34",
     "jsdom": "^15.0.0",


### PR DESCRIPTION
We no longer seem to use this dependency. Likely because we switched to reading the package version from the `package.json` file, as opposed to writing it to source files during build time.