### PR TITLE
chore: Temporarily disabling sendToDeviceGroup integration test

### DIFF
--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -172,7 +172,7 @@ describe('admin.messaging', () => {
       });
   });
 
-  it('sendToDeviceGroup() returns a response with success count', () => {
+  xit('sendToDeviceGroup() returns a response with success count', () => {
     return admin.messaging().sendToDeviceGroup(notificationKey, payload, options)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');


### PR DESCRIPTION
The backend server has implemented a behavior change that is causing this test to fail. Temporarily disabling the test as we work with the FCM team to understand the new behavior, and incorporate it into our implementation correctly.