### PR TITLE
chore: Added support for generating a toc file for docs

### DIFF
--- a/docgen/post-process.js
+++ b/docgen/post-process.js
@@ -63,6 +63,9 @@ async function fixTitles() {
   for (const file of files) {
     await fixTitleOf(path.join(markdownDir, file));
   }
+
+  const tocFile = path.join(markdownDir, 'toc.yaml');
+  await fixTocTitles(tocFile);
 }
 
 async function fixTitleOf(file) {
@@ -90,6 +93,25 @@ async function fixTitleOf(file) {
     const content = Buffer.from(buffer.join('\r\n'));
     await fs.writeFile(file, content);
   }
+}
+
+async function fixTocTitles(file) {
+  const reader = readline.createInterface({
+    input: fs.createReadStream(file),
+  });
+
+  const buffer = [];
+  for await (let line of reader) {
+    if (line.includes('- title: firebase-admin.')) {
+      line = line.replace(/firebase-admin\./, 'firebase-admin/');
+    }
+
+    buffer.push(line);
+  }
+
+  console.log(`Updating titles in ${file}`);
+  const content = Buffer.from(buffer.join('\r\n'));
+  await fs.writeFile(file, content);
 }
 
 async function getExtraFiles() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,9 +156,9 @@
       }
     },
     "@firebase/api-documenter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/api-documenter/-/api-documenter-0.1.1.tgz",
-      "integrity": "sha512-/8EtiyrWquuv6Byy9JYlYrclxAfPIwzUPCAzhOb14shGZW/YWANm8WRHbNSVOFXbZMGd89s3WZX3gVw2zWjZxA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/api-documenter/-/api-documenter-0.1.2.tgz",
+      "integrity": "sha512-aDofRZebqbMzrbo5WAi9f21qUTzhIub7yOszirik3AwujqOzcUr1F7lIFrI41686JD1Zw56lLL/B5EWZTwvVjA==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.12.24",
@@ -166,6 +166,7 @@
         "@rushstack/ts-command-line": "4.7.8",
         "api-extractor-model-me": "0.1.1",
         "colors": "~1.2.1",
+        "js-yaml": "4.0.0",
         "resolve": "~1.17.0",
         "tslib": "^2.1.0"
       },
@@ -211,15 +212,21 @@
           "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
           "dev": true
         },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "argparse": "^2.0.1"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+              "dev": true
+            }
           }
         },
         "lru-cache": {
@@ -1323,17 +1330,6 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
           "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
           "dev": true
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -3491,6 +3487,17 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     "test:coverage": "nyc npm run test:unit",
     "lint:src": "eslint src/ --ext .ts",
     "lint:test": "eslint test/ --ext .ts",
-    "apidocs": "run-s api-extractor:local api-documenter api-documenter:post",
+    "apidocs": "run-s api-extractor:local api-documenter api-documenter:toc api-documenter:post",
     "api-extractor": "node generate-reports.js",
     "api-extractor:local": "npm run build && node generate-reports.js --local",
     "esm-wrap": "node generate-esm-wrapper.js",
     "api-documenter": "api-documenter-fire markdown --input temp --output docgen/markdown -s",
+    "api-documenter:toc": "api-documenter-fire toc --input temp --output docgen/markdown -p /docs/reference/admin/node -s",
     "api-documenter:post": "node docgen/post-process.js"
   },
   "nyc": {
@@ -155,7 +156,7 @@
     "@google-cloud/storage": "^5.3.0"
   },
   "devDependencies": {
-    "@firebase/api-documenter": "^0.1.1",
+    "@firebase/api-documenter": "^0.1.2",
     "@firebase/app": "^0.6.13",
     "@firebase/auth": "^0.16.2",
     "@firebase/auth-types": "^0.10.1",


### PR DESCRIPTION
Generating a TOC using the latest API Documenter fork shipped by the JS SDK team.

Sample output: https://github.com/firebase/firebase-admin-node/blob/modular-sdk-docs/docgen/markdown/toc.yaml