### PR TITLE
Update Gulpfile to copy files required for generated client to properly run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,6 @@ gulp.task('copyTypings', function() {
 
 gulp.task('copyJSON', function() {
   return gulp.src([
-    'src/**/protos/*.json',
     // This isn't ideal, but doing something like
     // 'src/generated/**/*.json' results in incorrect paths in the /lib dir
     'src/**/*.json'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('compile', function() {
  */
 gulp.task('compile_test', function() {
   return gulp.src(paths.test)
-    // Compile Typescript ianto .js and .d.ts files
+    // Compile Typescript into .js and .d.ts files
     .pipe(buildTest())
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,18 +101,33 @@ gulp.task('compile', function() {
  */
 gulp.task('compile_test', function() {
   return gulp.src(paths.test)
-    // Compile Typescript into .js and .d.ts files
+    // Compile Typescript ianto .js and .d.ts files
     .pipe(buildTest())
 });
 
 gulp.task('copyTypings', function() {
-  return gulp.src(['src/index.d.ts', 'src/firebase-namespace.d.ts'])
+  return gulp.src([
+    'src/index.d.ts',
+    'src/firebase-namespace.d.ts',
+    'src/**/protos/*.d.ts',
+  ])
     // Add header
     .pipe(header(banner))
     .pipe(gulp.dest(paths.build))
 });
 
-gulp.task('compile_all', gulp.series('compile', 'copyTypings', 'compile_test'));
+gulp.task('copyJSON', function() {
+  return gulp.src([
+    'src/**/protos/*.json',
+    // This isn't ideal, but doing something like
+    // 'src/generated/**/*.json' results in incorrect paths in the /lib dir
+    'src/**/*.json'
+  ])
+    .pipe(gulp.dest(paths.build))
+});
+
+gulp.task('compile_all', gulp.series('compile', 'copyTypings',
+  'copyJSON', 'compile_test'));
 
 // Regenerates js every time a source file changes
 gulp.task('watch', function() {
@@ -120,7 +135,7 @@ gulp.task('watch', function() {
 });
 
 // Build task
-gulp.task('build', gulp.series('cleanup', 'compile', 'copyTypings'));
+gulp.task('build', gulp.series('cleanup', 'compile', 'copyTypings', 'copyJSON'));
 
 // Default task
 gulp.task('default', gulp.series('build'));


### PR DESCRIPTION
`npm run build` etc. will now copy over the the `.d.ts` and `.json` files found in `generated/messaging`. Before, this didn't happen, and the generated client would error on runtime.