### PR TITLE
chore: Add emulator tests to nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,12 @@ jobs:
 
     - name: Verify public API
       run: npm run api-extractor
+      
+    - name: Run emulator-based integration tests
+      run: |
+        npm install -g firebase-tools
+        firebase emulators:exec --project fake-project-id --only auth,database,firestore \
+          'npx mocha \"test/integration/{auth,database,firestore}.spec.ts\" --slow 5000 --timeout 20000 --require ts-node/register'
 
     - name: Run integration tests
       run: ./.github/scripts/run_integration_tests.sh


### PR DESCRIPTION
- Run emulator based integration tests as part of the nightly tests.

