### PR TITLE
fix typo in jsdoc of auth.DecodedIdToken

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -572,7 +572,7 @@ export namespace auth {
        * The ID of the provider used to sign in the user.
        * One of `"anonymous"`, `"password"`, `"facebook.com"`, `"github.com"`,
        * `"google.com"`, `"twitter.com"`, `"apple.com"`, `"microsoft.com"`,
-       * "yahoo.com"`, `"phone"`, `"playgames.google.com"`, `"gc.apple.com"`,
+       * `"yahoo.com"`, `"phone"`, `"playgames.google.com"`, `"gc.apple.com"`,
        * or `"custom"`.
        *
        * Additional Identity Platform provider IDs include `"linkedin.com"`,


### PR DESCRIPTION
I found a problem with displaying the documentation. I fixed the jsdoc.

![image](https://user-images.githubusercontent.com/522932/131120147-a08eab16-3ea4-490f-8cbd-642f7eadfa76.png)

Link to the documentation: https://firebase.google.com/docs/reference/admin/node/admin.auth.DecodedIdToken#sign_in_provider:-string
