### PR TITLE
feat(rc): Add Remote Config Parameter Value Type Support

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -1014,6 +1014,7 @@ export namespace remoteConfig {
         nextPageToken?: string;
         versions: Version[];
     }
+    export type ParameterValueType = 'STRING' | 'BOOLEAN' | 'NUMBER' | 'JSON';
     export interface RemoteConfig {
         // (undocumented)
         app: app.App;
@@ -1038,6 +1039,7 @@ export namespace remoteConfig {
         };
         defaultValue?: RemoteConfigParameterValue;
         description?: string;
+        valueType?: ParameterValueType;
     }
     export interface RemoteConfigParameterGroup {
         description?: string;

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -150,6 +150,12 @@ export namespace remoteConfig {
      * Unicode characters.
      */
     description?: string;
+
+    /**
+     * The data type for all values of this parameter in the current version of the template.
+     * Defaults to `ParameterValueType.STRING` if unspecified.
+     */
+    valueType?: ParameterValueType;
   }
 
   /**
@@ -258,6 +264,12 @@ export namespace remoteConfig {
    */
   export type TagColor = 'BLUE' | 'BROWN' | 'CYAN' | 'DEEP_ORANGE' | 'GREEN' |
     'INDIGO' | 'LIME' | 'ORANGE' | 'PINK' | 'PURPLE' | 'TEAL';
+
+  /**
+   * Type representing a Remote Config parameter value data type.
+   * Defaults to `STRING` if unspecified.
+   */
+  export type ParameterValueType = 'STRING' | 'BOOLEAN' | 'NUMBER' | 'JSON'
 
   /**
    * Interface representing a Remote Config template version.

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -28,11 +28,13 @@ const VALID_PARAMETERS = {
   // eslint-disable-next-line @typescript-eslint/camelcase
   holiday_promo_enabled: {
     defaultValue: { useInAppDefault: true },
-    description: 'promo indicator'
+    description: 'promo indicator',
+    valueType: 'STRING' as admin.remoteConfig.ParameterValueType,
   },
   // eslint-disable-next-line @typescript-eslint/camelcase
   welcome_message: {
     defaultValue: { value: `welcome text ${Date.now()}` },
+    valueType: 'STRING' as admin.remoteConfig.ParameterValueType,
     conditionalValues: {
       ios: { value: 'welcome ios text' },
       android: { value: 'welcome android text' },
@@ -52,6 +54,7 @@ const VALID_PARAMETER_GROUPS = {
           'android': { value: 'A Droid must love a pumpkin spice latte.' },
         },
         description: 'Description of the parameter.',
+        valueType: 'STRING' as admin.remoteConfig.ParameterValueType,
       },
     },
   },

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -73,7 +73,7 @@ describe('RemoteConfigApiClient', () => {
 
   const TEST_RESPONSE = {
     conditions: [{ name: 'ios', expression: 'exp' }],
-    parameters: { param: { defaultValue: { value: 'true' } } },
+    parameters: { param: { defaultValue: { value: 'true' }, valueType: 'BOOLEAN' } },
     parameterGroups: { group: { parameters: { paramabc: { defaultValue: { value: 'true' } } }, } },
     version: VERSION_INFO,
   };
@@ -132,6 +132,7 @@ describe('RemoteConfigApiClient', () => {
         defaultValue: { value: 'true' },
         conditionalValues: { ios: { useInAppDefault: true } },
         description: 'this is a promo',
+        valueType: 'BOOLEAN'
       },
     },
     parameterGroups: {
@@ -429,7 +430,7 @@ describe('RemoteConfigApiClient', () => {
     });
 
     VALIDATION_ERROR_MESSAGES.forEach((message) => {
-      it('should reject with failed-precondition when a validation error occurres', () => {
+      it('should reject with failed-precondition when a validation error occurs', () => {
         const stub = sinon
           .stub(HttpClient.prototype, 'send')
           .rejects(utils.errorFrom({

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -51,6 +51,7 @@ describe('RemoteConfig', () => {
             'android_en': { value: 'A Droid must love a pumpkin spice latte.' },
           },
           description: 'Description of the parameter.',
+          valueType: 'STRING' as remoteConfig.ParameterValueType,
         },
       },
     },
@@ -91,6 +92,7 @@ describe('RemoteConfig', () => {
         defaultValue: { value: 'true' },
         conditionalValues: { ios: { useInAppDefault: true } },
         description: 'this is a promo',
+        valueType: 'BOOLEAN',
       },
     },
     parameterGroups: PARAMETER_GROUPS,
@@ -110,6 +112,7 @@ describe('RemoteConfig', () => {
         defaultValue: { value: 'true' },
         conditionalValues: { ios: { useInAppDefault: true } },
         description: 'this is a promo',
+        valueType: 'BOOLEAN',
       },
     },
     parameterGroups: PARAMETER_GROUPS,
@@ -383,7 +386,7 @@ describe('RemoteConfig', () => {
       });
     });
 
-    it('should resolve with an empty versions list if the no results are availble for requested list options', () => {
+    it('should resolve with an empty versions list if no results are available for requested list options', () => {
       const stub = sinon
         .stub(RemoteConfigApiClient.prototype, 'listVersions')
         .resolves({} as any);
@@ -498,6 +501,7 @@ describe('RemoteConfig', () => {
       expect(p1.defaultValue).deep.equals({ value: 'true' });
       expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
       expect(p1.description).equals('this is a promo');
+      expect(p1.valueType).equals('BOOLEAN');
 
       expect(newTemplate.parameterGroups).deep.equals(PARAMETER_GROUPS);
 
@@ -662,6 +666,7 @@ describe('RemoteConfig', () => {
           expect(p1.defaultValue).deep.equals({ value: 'true' });
           expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
           expect(p1.description).equals('this is a promo');
+          expect(p1.valueType).equals('BOOLEAN');
 
           expect(template.parameterGroups).deep.equals(PARAMETER_GROUPS);
 


### PR DESCRIPTION
go/admin-sdk-rc-parameter-value-types

- Add RC Parameter Value Type.
- Update unit tests.
~- Integration tests will be added following the REST API launch.~
- Added `release:stage` to trigger existing integration tests (to test backward compatibility).
~- `Do not merge` until the BE is updated.~

Update:
- Integration tests are updated.

RELEASE NOTE: Added Remote Config Parameter Value Type Support.