### PR TITLE
fix: Decoupled FirebaseNamespace from new module entry points

### DIFF
--- a/etc/firebase-admin.app.api.md
+++ b/etc/firebase-admin.app.api.md
@@ -54,7 +54,7 @@ export interface FirebaseError {
 }
 
 // @public (undocumented)
-export function getApp(name?: string): App;
+export function getApp(appName?: string): App;
 
 // @public (undocumented)
 export function getApps(): App[];
@@ -68,7 +68,7 @@ export interface GoogleOAuthAccessToken {
 }
 
 // @public (undocumented)
-export function initializeApp(options?: AppOptions, name?: string): App;
+export function initializeApp(options?: AppOptions, appName?: string): App;
 
 // @public
 export function refreshToken(refreshTokenPathOrObject: string | object, httpAgent?: Agent): Credential;

--- a/src/app/lifecycle.ts
+++ b/src/app/lifecycle.ts
@@ -95,7 +95,8 @@ export class AppStore {
     // Make sure the given app already exists.
     const existingApp = getApp(app.name);
 
-    // Delegate delete operation to the App instance itself.
+    // Delegate delete operation to the App instance itself. That will also remove the App
+    // instance from the AppStore.
     return (existingApp as FirebaseApp).delete();
   }
 
@@ -108,6 +109,11 @@ export class AppStore {
     return Promise.all(promises).then();
   }
 
+  /**
+   * Removes the specified App instance from the store. This is currently called by the
+   * {@link FirebaseApp.delete} method. Can be removed once the app deletion is handled
+   * entirely by the {@link deleteApp} top-level function.
+   */
   public removeApp(appName: string): void {
     this.appStore.delete(appName);
   }

--- a/src/default-namespace.ts
+++ b/src/default-namespace.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { defaultNamespace as firebaseAdmin } from './app/lifecycle';
+import { defaultNamespace as firebaseAdmin } from './app/firebase-namespace';
 
 // Inject a circular default export to allow users to use both:
 //

--- a/src/instance-id/instance-id.ts
+++ b/src/instance-id/instance-id.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp } from '../app/firebase-app';
+import { getInstallations } from '../installations';
 import { App } from '../app/index';
 import {
   FirebaseInstallationsError, FirebaseInstanceIdError,
@@ -63,7 +63,7 @@ export class InstanceId {
    * @returns A promise fulfilled when the instance ID is deleted.
    */
   public deleteInstanceId(instanceId: string): Promise<void> {
-    return (this.app as FirebaseApp).installations().deleteInstallation(instanceId)
+    return getInstallations(this.app).deleteInstallation(instanceId)
       .catch((err) => {
         if (err instanceof FirebaseInstallationsError) {
           let code = err.code.replace('installations/', '');

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -26,7 +26,6 @@ import * as _ from 'lodash';
 import * as jwt from 'jsonwebtoken';
 
 import { AppOptions } from '../../src/firebase-namespace-api';
-import { FirebaseNamespace } from '../../src/app/firebase-namespace';
 import { FirebaseApp } from '../../src/app/firebase-app';
 import { Credential, GoogleOAuthAccessToken, cert } from '../../src/app/index';
 
@@ -91,22 +90,18 @@ export class MockCredential implements Credential {
 }
 
 export function app(): FirebaseApp {
-  const namespaceInternals = new FirebaseNamespace().INTERNAL;
-  namespaceInternals.removeApp = _.noop;
-  return new FirebaseApp(appOptions, appName, namespaceInternals);
+  return new FirebaseApp(appOptions, appName);
 }
 
 export function mockCredentialApp(): FirebaseApp {
   return new FirebaseApp({
     credential: new MockCredential(),
     databaseURL,
-  }, appName, new FirebaseNamespace().INTERNAL);
+  }, appName);
 }
 
 export function appWithOptions(options: AppOptions): FirebaseApp {
-  const namespaceInternals = new FirebaseNamespace().INTERNAL;
-  namespaceInternals.removeApp = _.noop;
-  return new FirebaseApp(options, appName, namespaceInternals);
+  return new FirebaseApp(options, appName);
 }
 
 export function appReturningNullAccessToken(): FirebaseApp {
@@ -117,7 +112,7 @@ export function appReturningNullAccessToken(): FirebaseApp {
     } as any,
     databaseURL,
     projectId,
-  }, appName, new FirebaseNamespace().INTERNAL);
+  }, appName);
 }
 
 export function appReturningMalformedAccessToken(): FirebaseApp {
@@ -127,7 +122,7 @@ export function appReturningMalformedAccessToken(): FirebaseApp {
     } as any,
     databaseURL,
     projectId,
-  }, appName, new FirebaseNamespace().INTERNAL);
+  }, appName);
 }
 
 export function appRejectedWhileFetchingAccessToken(): FirebaseApp {
@@ -137,7 +132,7 @@ export function appRejectedWhileFetchingAccessToken(): FirebaseApp {
     } as any,
     databaseURL,
     projectId,
-  }, appName, new FirebaseNamespace().INTERNAL);
+  }, appName);
 }
 
 export const refreshToken = {

--- a/test/unit/app/firebase-namespace.spec.ts
+++ b/test/unit/app/firebase-namespace.spec.ts
@@ -260,66 +260,6 @@ describe('FirebaseNamespace', () => {
     });
   });
 
-  describe('#INTERNAL.removeApp()', () => {
-    const invalidAppNames = [null, NaN, 0, 1, true, false, [], ['a'], {}, { a: 1 }, _.noop];
-    invalidAppNames.forEach((invalidAppName) => {
-      it('should throw given non-string app name: ' + JSON.stringify(invalidAppName), () => {
-        expect(() => {
-          firebaseNamespace.INTERNAL.removeApp(invalidAppName as any);
-        }).to.throw(`Invalid Firebase app name "${invalidAppName}" provided. App name must be a non-empty string.`);
-      });
-    });
-
-    it('should throw given empty string app name', () => {
-      expect(() => {
-        firebaseNamespace.INTERNAL.removeApp('');
-      }).to.throw('Invalid Firebase app name "" provided. App name must be a non-empty string.');
-    });
-
-    it('should throw given an app name which does not correspond to an existing app', () => {
-      expect(() => {
-        firebaseNamespace.INTERNAL.removeApp(mocks.appName);
-      }).to.throw(`Firebase app named "${mocks.appName}" does not exist.`);
-    });
-
-    it('should throw given no app name if the default app does not exist', () => {
-      expect(() => {
-        (firebaseNamespace as any).INTERNAL.removeApp();
-      }).to.throw('No Firebase app name provided. App name must be a non-empty string.');
-    });
-
-    it('should throw given no app name even if the default app exists', () => {
-      firebaseNamespace.initializeApp(mocks.appOptions);
-      expect(() => {
-        (firebaseNamespace as any).INTERNAL.removeApp();
-      }).to.throw('No Firebase app name provided. App name must be a non-empty string.');
-    });
-
-    it('should remove the app corresponding to the provided app name from the namespace\'s app list', () => {
-      firebaseNamespace.initializeApp(mocks.appOptions, mocks.appName);
-      firebaseNamespace.INTERNAL.removeApp(mocks.appName);
-      expect(() => {
-        return firebaseNamespace.app(mocks.appName);
-      }).to.throw(`Firebase app named "${mocks.appName}" does not exist.`);
-    });
-
-    it('should remove the default app from the namespace\'s app list if the default app name is provided', () => {
-      firebaseNamespace.initializeApp(mocks.appOptions);
-      firebaseNamespace.INTERNAL.removeApp(DEFAULT_APP_NAME);
-      expect(() => {
-        return firebaseNamespace.app();
-      }).to.throw('The default Firebase app does not exist.');
-    });
-
-    it('should not be idempotent', () => {
-      firebaseNamespace.initializeApp(mocks.appOptions, mocks.appName);
-      firebaseNamespace.INTERNAL.removeApp(mocks.appName);
-      expect(() => {
-        firebaseNamespace.INTERNAL.removeApp(mocks.appName);
-      }).to.throw(`Firebase app named "${mocks.appName}" does not exist.`);
-    });
-  });
-
   describe('#auth()', () => {
     it('should throw when called before initializing an app', () => {
       expect(() => {

--- a/test/unit/app/index.spec.ts
+++ b/test/unit/app/index.spec.ts
@@ -30,6 +30,7 @@ import {
   Credential, applicationDefault, cert, refreshToken,
 } from '../../../src/app/index';
 import { clearGlobalAppDefaultCred } from '../../../src/app/credential-factory';
+import { defaultAppStore } from '../../../src/app/lifecycle';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -39,12 +40,7 @@ const expect = chai.expect;
 
 describe('firebase-admin/app', () => {
   afterEach(() => {
-    const deletePromises: Array<Promise<void>> = [];
-    getApps().forEach((app) => {
-      deletePromises.push(deleteApp(app));
-    });
-
-    return Promise.all(deletePromises);
+    return defaultAppStore.clearAllApps();
   });
 
   describe('#initializeApp()', () => {
@@ -94,6 +90,12 @@ describe('firebase-admin/app', () => {
           },
         } as any);
       }).to.throw('Invalid Firebase app options');
+    });
+
+    it('should initialize App instance without extended service methods', () => {
+      const app = initializeApp(mocks.appOptions);
+      expect((app as any).__extended).to.be.undefined;
+      expect((app as any).auth).to.be.undefined;
     });
   });
 

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -32,6 +32,7 @@ import { FirebaseApp, FirebaseAppInternals } from '../../src/app/firebase-app';
 import {
   RefreshTokenCredential, ServiceAccountCredential, isApplicationDefault
 } from '../../src/app/credential-internal';
+import { defaultAppStore, initializeApp } from '../../src/app/lifecycle';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -54,12 +55,7 @@ describe('Firebase', () => {
   });
 
   afterEach(() => {
-    const deletePromises: Array<Promise<void>> = [];
-    firebaseAdmin.apps.forEach((app) => {
-      deletePromises.push(app.delete());
-    });
-
-    return Promise.all(deletePromises);
+    return defaultAppStore.clearAllApps();
   });
 
   describe('#initializeApp()', () => {
@@ -165,6 +161,23 @@ describe('Firebase', () => {
       return getAppInternals().getToken()
         .should.eventually.have.keys(['accessToken', 'expirationTime']);
     });
+
+    it('should initialize App instance with extended service methods', () => {
+      const app = firebaseAdmin.initializeApp(mocks.appOptions);
+      expect((app as any).__extended).to.be.true;
+      expect(app.auth).to.be.not.undefined;
+    });
+
+    it('should add extended service methods when retrieved via namespace', () => {
+      const app = initializeApp(mocks.appOptions);
+      expect((app as any).__extended).to.be.undefined;
+      expect((app as any).auth).to.be.undefined;
+
+      const extendedApp = firebaseAdmin.app();
+      expect(app).to.equal(extendedApp);
+      expect((app as any).__extended).to.be.true;
+      expect((app as any).auth).to.be.not.undefined;
+    });
   });
 
   describe('#database()', () => {
@@ -266,6 +279,6 @@ describe('Firebase', () => {
   });
 
   function getAppInternals(): FirebaseAppInternals {
-    return (firebaseAdmin.app() as FirebaseApp).INTERNAL;
+    return (firebaseAdmin.app() as unknown as FirebaseApp).INTERNAL;
   }
 });

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -17,10 +17,7 @@
 
 import * as _ from 'lodash';
 import * as sinon from 'sinon';
-
 import * as mocks from '../resources/mocks';
-
-import { FirebaseNamespace } from '../../src/app/firebase-namespace';
 import { AppOptions } from '../../src/firebase-namespace-api';
 import { FirebaseApp, FirebaseAppInternals, FirebaseAccessToken } from '../../src/app/firebase-app';
 import { HttpError, HttpResponse } from '../../src/utils/api-request';
@@ -32,8 +29,7 @@ import { HttpError, HttpResponse } from '../../src/utils/api-request';
  * @return A new FirebaseApp instance with the provided options.
  */
 export function createAppWithOptions(options: object): FirebaseApp {
-  const mockFirebaseNamespaceInternals = new FirebaseNamespace().INTERNAL;
-  return new FirebaseApp(options as AppOptions, mocks.appName, mockFirebaseNamespaceInternals);
+  return new FirebaseApp(options as AppOptions, mocks.appName);
 }
 
 


### PR DESCRIPTION
# Problem 

Currently, the `firebase-admin/app` entry point is implemented on top of a `FirebaseNamespace` instance. Top-level functions like `initializeApp()` simply delegate to the `FirebaseNamespace.initializeApp()` method. Since `FirebaseNamespace` has dependencies on all other services exposed within the SDK, importing `firebase-admin/app` can pull in other services as well. This is quite evident when we try to bundle the SDK using a tool like webpack:

**webpack.js**
```
const path = require('path');

module.exports = {
  target: "node",
  entry: {
    app: ["./src/index.js"]
  },
  output: {
    path: path.resolve(__dirname, "dist"),
    filename: "index.js"
  },
};
```

**src/index.js**
```
import { initializeApp } from "firebase-admin/app";

initializeApp();
```

Bundling the above source file with webpack yields the following output:
```
% npx webpack --config webpack.js 
asset index.js 2.68 MiB [emitted] [minimized] (name: app) 1 related asset
orphan modules 219 KiB [orphan] 22 modules
runtime modules 1.37 KiB 6 modules
javascript modules 8.31 MiB
  modules by path ./node_modules/ 8.31 MiB 546 modules
  24 modules
json modules 350 KiB
  modules by path ./node_modules/google-gax/ 53.7 KiB 9 modules
  modules by path ./node_modules/@google-cloud/ 79.8 KiB
    modules by path ./node_modules/@google-cloud/firestore/build/ 73 KiB 4 modules
    2 modules
  modules by path ./node_modules/protobufjs/ 10 KiB 4 modules
  modules by path ./node_modules/ent/ 54 KiB
    ./node_modules/ent/reversed.json 22.3 KiB [built] [code generated]
    ./node_modules/ent/entities.json 31.7 KiB [built] [code generated]

WARNING in ./node_modules/@firebase/database/dist/index.esm.js 15327:17-25
export 'default' (imported as 'firebase') was not found in '@firebase/app' (possible exports: FirebaseError, SDK_VERSION, _DEFAULT_ENTRY_NAME, _addComponent, _addOrOverwriteComponent, _apps, _clearComponents, _components, _getProvider, _registerComponent, _removeServiceInstance, deleteApp, getApp, getApps, initializeApp, onLog, registerVersion, setLogLevel)
 @ ./node_modules/firebase-admin/lib/app/firebase-namespace.js
 @ ./node_modules/firebase-admin/lib/app/lifecycle.js 22:27-58
 @ ./node_modules/firebase-admin/lib/app/index.js 22:18-40
 @ ./node_modules/firebase-admin/lib/esm/app/index.js 1:0-37 3:27-42 4:34-56 5:20-28 6:25-38 7:22-32 8:23-34 9:29-46 10:28-44
 @ ./src/index.js 1:0-51 3:0-13

WARNING in ./node_modules/hash-stream-validation/index.js 5:8-30
Module not found: Error: Can't resolve 'fast-crc32c' in '/Users/hkj/Projects/firebase-admin-node/adminuser/node_modules/hash-stream-validation'
 @ ./node_modules/@google-cloud/storage/build/src/file.js 26:29-62
 @ ./node_modules/@google-cloud/storage/build/src/index.js 20:13-30
 @ ./node_modules/firebase-admin/lib/storage/storage.js 55:22-62
 @ ./node_modules/firebase-admin/lib/app/firebase-namespace.js 225:26-63
 @ ./node_modules/firebase-admin/lib/app/lifecycle.js 22:27-58
 @ ./node_modules/firebase-admin/lib/app/index.js 22:18-40
 @ ./node_modules/firebase-admin/lib/esm/app/index.js 1:0-37 3:27-42 4:34-56 5:20-28 6:25-38 7:22-32 8:23-34 9:29-46 10:28-44
 @ ./src/index.js 1:0-51 3:0-13

WARNING in ./node_modules/retry-request/index.js 74:21-39
Module not found: Error: Can't resolve 'request' in '/Users/hkj/Projects/firebase-admin-node/adminuser/node_modules/retry-request'
 @ ./node_modules/google-gax/build/src/streamingCalls/streaming.js 22:21-45
 @ ./node_modules/google-gax/build/src/index.js 64:18-55
 @ ./node_modules/@google-cloud/firestore/build/src/index.js 428:95-121 1084:37-71 1373:15-43
 @ ./node_modules/firebase-admin/lib/app/firebase-namespace.js 242:28-62
 @ ./node_modules/firebase-admin/lib/app/lifecycle.js 22:27-58
 @ ./node_modules/firebase-admin/lib/app/index.js 22:18-40
 @ ./node_modules/firebase-admin/lib/esm/app/index.js 1:0-37 3:27-42 4:34-56 5:20-28 6:25-38 7:22-32 8:23-34 9:29-46 10:28-44
 @ ./src/index.js 1:0-51 3:0-13

WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/

2 warnings have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.52.0 compiled with 4 warnings in 22754 ms
~/Projects/firebase-admin-node/adminuser % ls -lh dist/index.js
-rw-r--r--  1 hkj  primarygroup   2.7M Sep  7 20:21 dist/index.js
```

Notice how webpack is pulling in dependencies like Firestore, Storage and RTDB even when the source file only contains a single `initializeApp()` call. The resulting bundle is 2.7MB in size.

# Possible Solution

As a potential fix, we can try to decouple `FirebaseNamespace` from the `firebase-admin/app` entry point. I've implemented all the App lifecycle management logic in a new independent class named `AppStore`. I'm also using a bit of prototype hacking in the `FirebaseNamespace` class to modify `App` instances on the fly. This means `initializeApp()` can create a `FirebaseApp` instance with no references to the `FirebaseNamespace`. Calling `FirebaseNamespace.initializeApp()` would first call `initializeApp()`, and then do some prototype hacking to add the old methods like `FirebaseApp.auth()` and `FirebaseApp.database()` dynamically.

With this change in place, we can now webpack bundle the above code with no warnings:
```
npx webpack --config webpack.js                         
asset index.js 382 KiB [emitted] [minimized] (name: app) 1 related asset
orphan modules 375 bytes [orphan] 1 module
modules by path ./node_modules/ 1.1 MiB
  modules by path ./node_modules/node-forge/lib/*.js 851 KiB 44 modules
  modules by path ./node_modules/jsonwebtoken/ 67.7 KiB 16 modules
  modules by path ./node_modules/firebase-admin/ 145 KiB 11 modules
  modules by path ./node_modules/dicer/lib/*.js 9.35 KiB 3 modules
  modules by path ./node_modules/ecdsa-sig-formatter/src/*.js 5.34 KiB
    ./node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js 4.89 KiB [built] [code generated]
    ./node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js 456 bytes [built] [code generated]
13 modules

WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/

webpack 5.52.0 compiled with 1 warning in 3898 ms
~/Projects/firebase-admin-node/adminuser % ls -lh dist/index.js
-rw-r--r--  1 hkj  primarygroup   382K Sep  7 20:24 dist/index.js
```

The resulting bundle is only 382KB -- **nearly 80% smaller**.

My testing also indicates that bundling app+auth is about 632KB and app+firestore is about 1.8MB.