### PR TITLE
fix(fac): Change the jwks cache duration from 1 day to 6 hours

### DIFF
--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -31,7 +31,7 @@ const JWT_CALLBACK_ERROR_PREFIX = 'error in secret or public key callback: ';
 const NO_MATCHING_KID_ERROR_MESSAGE = 'no-matching-kid-error';
 const NO_KID_IN_HEADER_ERROR_MESSAGE = 'no-kid-in-header-error';
 
-const ONE_DAY_IN_SECONDS = 24 * 3600;
+const HOUR_IN_SECONDS = 3600;
 
 export type Dictionary = { [key: string]: any }
 
@@ -60,7 +60,7 @@ export class JwksFetcher implements KeyFetcher {
 
     this.client = jwks({
       jwksUri: jwksUrl,
-      cache: false, // disable jwks-rsa LRU cache as the keys are always cahced for 24 hours.
+      cache: false, // disable jwks-rsa LRU cache as the keys are always cached for 6 hours.
     });
   }
 
@@ -84,7 +84,7 @@ export class JwksFetcher implements KeyFetcher {
           map[signingKey.kid] = signingKey.getPublicKey();
           return map;
         }, {});
-        this.publicKeysExpireAt = Date.now() + (ONE_DAY_IN_SECONDS * 1000);
+        this.publicKeysExpireAt = Date.now() + (HOUR_IN_SECONDS * 6 * 1000);
         this.publicKeys = newKeys;
         return newKeys;
       }).catch((err) => {

--- a/test/unit/utils/jwt.spec.ts
+++ b/test/unit/utils/jwt.spec.ts
@@ -33,7 +33,7 @@ import {
 const expect = chai.expect;
 
 const ONE_HOUR_IN_SECONDS = 60 * 60;
-const ONE_DAY_IN_SECONDS = 86400;
+const SIX_HOURS_IN_SECONDS = ONE_HOUR_IN_SECONDS * 6;
 const publicCertPath = '/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 const jwksPath = '/v1alpha/jwks';
 
@@ -709,24 +709,24 @@ describe('JwksFetcher', () => {
 
       return keyFetcher.fetchPublicKeys().then(() => {
         expect(https.request).to.have.been.calledOnce;
-        clock!.tick((ONE_DAY_IN_SECONDS - 1) * 1000);
+        clock!.tick((SIX_HOURS_IN_SECONDS - 1) * 1000);
         return keyFetcher.fetchPublicKeys();
       }).then(() => {
         expect(https.request).to.have.been.calledOnce;
-        clock!.tick(ONE_DAY_IN_SECONDS * 1000); // 24 hours in milliseconds
+        clock!.tick(SIX_HOURS_IN_SECONDS * 1000); // 6 hours in milliseconds
         return keyFetcher.fetchPublicKeys();
       }).then(() => {
-        // App check keys do not contain cache headers so we cache the keys for 24 hours.
-        // 24 hours has passed
+        // App check keys do not contain cache headers so we cache the keys for 6 hours.
+        // 6 hours has passed
         expect(https.request).to.have.been.calledTwice;
-        clock!.tick((ONE_DAY_IN_SECONDS - 1) * 1000);
+        clock!.tick((SIX_HOURS_IN_SECONDS - 1) * 1000);
         return keyFetcher.fetchPublicKeys();
       }).then(() => {
         expect(https.request).to.have.been.calledTwice;
-        clock!.tick(ONE_DAY_IN_SECONDS * 1000);
+        clock!.tick(SIX_HOURS_IN_SECONDS * 1000);
         return keyFetcher.fetchPublicKeys();
       }).then(() => {
-        // 48 hours have passed
+        // 12 hours have passed
         expect(https.request).to.have.been.calledThrice;
       });
     });


### PR DESCRIPTION
- Change the jwks cache duration (used by the verify token API) from 1 day to 6 hours.
- b/200973487
