### PR TITLE
Remove request body for deleteTenant

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1827,12 +1827,14 @@ export abstract class AbstractAuthRequestHandler {
    */
   protected invokeRequestHandler(
     urlBuilder: AuthResourceUrlBuilder, apiSettings: ApiSettings,
-    requestData: object, additionalResourceParams?: object): Promise<object> {
+    requestData: object | undefined, additionalResourceParams?: object): Promise<object> {
     return urlBuilder.getUrl(apiSettings.getEndpoint(), additionalResourceParams)
       .then((url) => {
         // Validate request.
-        const requestValidator = apiSettings.getRequestValidator();
-        requestValidator(requestData);
+        if (requestData != null) {
+          const requestValidator = apiSettings.getRequestValidator();
+          requestValidator(requestData);
+        }
         // Process request.
         const req: HttpRequestConfig = {
           method: apiSettings.getHttpMethod(),
@@ -2060,7 +2062,7 @@ export class AuthRequestHandler extends AbstractAuthRequestHandler {
     if (!validator.isNonEmptyString(tenantId)) {
       return Promise.reject(new FirebaseAuthError(AuthClientErrorCode.INVALID_TENANT_ID));
     }
-    return this.invokeRequestHandler(this.tenantMgmtResourceBuilder, DELETE_TENANT, {}, { tenantId })
+    return this.invokeRequestHandler(this.tenantMgmtResourceBuilder, DELETE_TENANT, undefined, { tenantId })
       .then(() => {
         // Return nothing.
       });

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -4554,7 +4554,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
           return requestHandler.deleteTenant(tenantId)
             .then((result) => {
               expect(result).to.be.undefined;
-              expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, method, {}));
+              expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, method, undefined));
             });
         });
 
@@ -4589,7 +4589,7 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
               throw new Error('Unexpected success');
             }, (error) => {
               expect(error).to.deep.include(expectedError);
-              expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, method, {}));
+              expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, method, undefined));
             });
         });
       });


### PR DESCRIPTION
### Discussion

Delete endpoints should not have a body in the request (see https://google.aip.dev/135). Currently running into issues with running `deleteTenant()` integration test against the emulator because a body is passed into the request. This issue will also be present for other delete endpoints but is not addressed in this PR.

https://github.com/firebase/firebase-tools/pull/3818 also addresses the issue from the emulator side, but Admin SDK should not pass in body to delete endpoints in general.

Corresponding internal bug: b/192387245

### Testing

`npm test` passes

### API Changes

N/A
