### PR TITLE
Update multi-tenancy integration tests to run against auth emulator

### DIFF
--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -1257,17 +1257,11 @@ describe('admin.auth', () => {
           expectedCreatedTenant.tenantId = createdTenantId;
           const actualTenantObj = actualTenant.toJSON();
           if (authEmulatorHost) {
-            expect(actualTenantObj).to.have.property('displayName')
-              .eql(expectedCreatedTenant.displayName);
-            expect(actualTenantObj).to.have.property('emailSignInConfig')
-              .eql(expectedCreatedTenant.emailSignInConfig);
-            expect(actualTenantObj).to.have.property('anonymousSignInEnabled')
-              .eql(expectedCreatedTenant.anonymousSignInEnabled);
-            expect(actualTenantObj).to.have.property('multiFactorConfig')
-              .eql(expectedCreatedTenant.multiFactorConfig);
-          } else {
-            expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
+            // Not supported in Auth Emulator
+            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete expectedCreatedTenant.testPhoneNumbers;
           }
+          expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
         });
     });
 
@@ -1621,17 +1615,11 @@ describe('admin.auth', () => {
         .then((actualTenant) => {
           const actualTenantObj = actualTenant.toJSON();
           if (authEmulatorHost) {
-            expect(actualTenantObj).to.have.property('displayName')
-              .eql(expectedCreatedTenant.displayName);
-            expect(actualTenantObj).to.have.property('emailSignInConfig')
-              .eql(expectedCreatedTenant.emailSignInConfig);
-            expect(actualTenantObj).to.have.property('anonymousSignInEnabled')
-              .eql(expectedCreatedTenant.anonymousSignInEnabled);
-            expect(actualTenantObj).to.have.property('multiFactorConfig')
-              .eql(expectedCreatedTenant.multiFactorConfig);
-          } else {
-            expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
+            // Not supported in Auth Emulator
+            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete expectedCreatedTenant.testPhoneNumbers;
           }
+          expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
         });
     });
 
@@ -1659,26 +1647,18 @@ describe('admin.auth', () => {
         return getAuth().tenantManager().updateTenant(createdTenantId, updatedOptions)
           .then((actualTenant) => {
             const actualTenantObj = actualTenant.toJSON();
-            expect(actualTenantObj).to.have.property('displayName')
-              .eql(expectedUpdatedTenant.displayName);
-            expect(actualTenantObj).to.have.property('emailSignInConfig')
-              .eql(expectedUpdatedTenant.emailSignInConfig);
-            expect(actualTenantObj).to.have.property('anonymousSignInEnabled')
-              .eql(expectedUpdatedTenant.anonymousSignInEnabled);
-            expect(actualTenantObj).to.have.property('multiFactorConfig')
-              .eql(expectedUpdatedTenant.multiFactorConfig);
+            // Not supported in Auth Emulator
+            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete expectedUpdatedTenant.testPhoneNumbers;
+            expect(actualTenantObj).to.deep.equal(expectedUpdatedTenant);
             return getAuth().tenantManager().updateTenant(createdTenantId, updatedOptions2);
           })
           .then((actualTenant) => {
             const actualTenantObj = actualTenant.toJSON();
-            expect(actualTenantObj).to.have.property('displayName')
-              .eql(expectedUpdatedTenant2.displayName);
-            expect(actualTenantObj).to.have.property('emailSignInConfig')
-              .eql(expectedUpdatedTenant2.emailSignInConfig);
-            expect(actualTenantObj).to.have.property('anonymousSignInEnabled')
-              .eql(expectedUpdatedTenant2.anonymousSignInEnabled);
-            expect(actualTenantObj).to.have.property('multiFactorConfig')
-              .eql(expectedUpdatedTenant2.multiFactorConfig);
+            // Not supported in Auth Emulator
+            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete expectedUpdatedTenant2.testPhoneNumbers;
+            expect(actualTenantObj).to.deep.equal(expectedUpdatedTenant2);
           });
       }
       return getAuth().tenantManager().updateTenant(createdTenantId, updatedOptions)


### PR DESCRIPTION
### Discussion

Update multi-tenancy integration tests to pass against auth emulator. Notable changes includes:
- Not checking test phone numbers on tenant config object
- Skipping tenant OIDC/SAML tests until it's supported in emulator

**DO NOT LAND UNTIL: https://github.com/firebase/firebase-tools/pull/3818 and https://github.com/firebase/firebase-tools/pull/3822 is merged to mainline**

Corresponding internal bug: b/192387245

### Testing

* `npm run build` in auth emulator, followed by `node /Users/lisajian/dev/firebase-tools/lib/bin/firebase emulators:exec --project fake-project-id --only auth,database,firestore     'npx mocha \"test/integration/auth.spec.ts\" --slow 5000 --timeout 20000 --require ts-node/register --testMultiTenancy'` passes in firebase-admin-node SDK

### API Changes

N/A
