### PR TITLE
fix(auth): Add user disabled error code.

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -982,6 +982,8 @@ const AUTH_SERVER_TO_CLIENT_CODE: ServerToClientCode = {
   UNVERIFIED_EMAIL: 'UNVERIFIED_EMAIL',
   // User on which action is to be performed is not found.
   USER_NOT_FOUND: 'USER_NOT_FOUND',
+  // User record is disabled.
+  USER_DISABLED: 'USER_DISABLED',
   // Password provided is too weak.
   WEAK_PASSWORD: 'INVALID_PASSWORD',
 };


### PR DESCRIPTION
Add disabled error code, to avoid unparsed internal error in createSessionCookie(). see [issue](https://github.com/firebase/firebase-admin-node/issues/1503)