### PR TITLE
chore: Update Typescript to 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9288,9 +9288,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "sinon": "^9.0.0",
     "sinon-chai": "^3.0.0",
     "ts-node": "^10.2.0",
-    "typescript": "^3.7.3",
+    "typescript": "^4.4.3",
     "yargs": "^17.0.1"
   }
 }

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -1259,7 +1259,7 @@ describe('admin.auth', () => {
           const actualTenantObj = actualTenant.toJSON();
           if (authEmulatorHost) {
             // Not supported in Auth Emulator
-            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete (actualTenantObj as {testPhoneNumbers?: Record<string, string>}).testPhoneNumbers;
             delete expectedCreatedTenant.testPhoneNumbers;
           }
           expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
@@ -1617,7 +1617,7 @@ describe('admin.auth', () => {
           const actualTenantObj = actualTenant.toJSON();
           if (authEmulatorHost) {
             // Not supported in Auth Emulator
-            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete (actualTenantObj as {testPhoneNumbers?: Record<string, string>}).testPhoneNumbers;
             delete expectedCreatedTenant.testPhoneNumbers;
           }
           expect(actualTenantObj).to.deep.equal(expectedCreatedTenant);
@@ -1649,7 +1649,7 @@ describe('admin.auth', () => {
           .then((actualTenant) => {
             const actualTenantObj = actualTenant.toJSON();
             // Not supported in Auth Emulator
-            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete (actualTenantObj as {testPhoneNumbers?: Record<string, string>}).testPhoneNumbers;
             delete expectedUpdatedTenant.testPhoneNumbers;
             expect(actualTenantObj).to.deep.equal(expectedUpdatedTenant);
             return getAuth().tenantManager().updateTenant(createdTenantId, updatedOptions2);
@@ -1657,7 +1657,7 @@ describe('admin.auth', () => {
           .then((actualTenant) => {
             const actualTenantObj = actualTenant.toJSON();
             // Not supported in Auth Emulator
-            delete (actualTenantObj as {testPhoneNumbers: Record<string, string>}).testPhoneNumbers;
+            delete (actualTenantObj as {testPhoneNumbers?: Record<string, string>}).testPhoneNumbers;
             delete expectedUpdatedTenant2.testPhoneNumbers;
             expect(actualTenantObj).to.deep.equal(expectedUpdatedTenant2);
           });
@@ -2150,8 +2150,8 @@ describe('admin.auth', () => {
           // Not supported in ID token,
           delete decodedIdToken.nonce;
           // exp and iat may vary depending on network connection latency.
-          delete decodedIdToken.exp;
-          delete decodedIdToken.iat;
+          delete (decodedIdToken as any).exp;
+          delete (decodedIdToken as any).iat;
           expect(decodedIdToken).to.deep.equal(payloadClaims);
         });
     });

--- a/test/unit/auth/tenant.spec.ts
+++ b/test/unit/auth/tenant.spec.ts
@@ -86,7 +86,7 @@ describe('Tenant', () => {
       it('should return the expected server request without multi-factor and phone config', () => {
         const tenantOptionsClientRequest = deepCopy(clientRequestWithoutMfa);
         const tenantOptionsServerRequest = deepCopy(serverRequestWithoutMfa);
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest))
           .to.deep.equal(tenantOptionsServerRequest);
       });
@@ -94,7 +94,7 @@ describe('Tenant', () => {
       it('should return the expected server request with multi-factor and phone config', () => {
         const tenantOptionsClientRequest = deepCopy(clientRequest);
         const tenantOptionsServerRequest = deepCopy(serverRequest);
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest))
           .to.deep.equal(tenantOptionsServerRequest);
       });
@@ -134,7 +134,7 @@ describe('Tenant', () => {
         const tenantOptionsClientRequest = deepCopy(clientRequest);
         const tenantOptionsServerRequest = deepCopy(serverRequest);
         tenantOptionsClientRequest.testPhoneNumbers = null;
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
         tenantOptionsServerRequest.testPhoneNumbers = {};
 
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest))
@@ -181,7 +181,7 @@ describe('Tenant', () => {
       it('should return the expected server request without multi-factor and phone config', () => {
         const tenantOptionsClientRequest: CreateTenantRequest = deepCopy(clientRequestWithoutMfa);
         const tenantOptionsServerRequest: TenantServerResponse = deepCopy(serverRequestWithoutMfa);
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
 
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
           .to.deep.equal(tenantOptionsServerRequest);
@@ -190,7 +190,7 @@ describe('Tenant', () => {
       it('should return the expected server request with multi-factor and phone config', () => {
         const tenantOptionsClientRequest: CreateTenantRequest = deepCopy(clientRequest);
         const tenantOptionsServerRequest: TenantServerResponse = deepCopy(serverRequest);
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
 
         expect(Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest))
           .to.deep.equal(tenantOptionsServerRequest);
@@ -224,7 +224,7 @@ describe('Tenant', () => {
         const tenantOptionsClientRequest = deepCopy(clientRequest);
         const tenantOptionsServerRequest = deepCopy(serverRequest);
         tenantOptionsClientRequest.testPhoneNumbers = null;
-        delete tenantOptionsServerRequest.name;
+        delete (tenantOptionsServerRequest as any).name;
         tenantOptionsServerRequest.testPhoneNumbers = {};
 
         expect(() => {

--- a/test/unit/security-rules/security-rules.spec.ts
+++ b/test/unit/security-rules/security-rules.spec.ts
@@ -825,7 +825,7 @@ describe('SecurityRules', () => {
 
     it('should resolve with RulesetMetadataList when the response contains no page token', () => {
       const response = deepCopy(LIST_RULESETS_RESPONSE);
-      delete response.nextPageToken;
+      delete (response as any).nextPageToken;
       const stub = sinon
         .stub(SecurityRulesApiClient.prototype, 'listRulesets')
         .resolves(response);


### PR DESCRIPTION
This is the second PR of a series of changes to update @google-cloud/firestore dependency to 5.x. This is a follow-up to #1540 

- Upgraded Typescript from ~3.7.3 to ~4.4.3
- Fixed `TS2790: The operand of a 'delete' operator must be optional` errors

**Note:** Manually tested for backwards compatibility on TS 3.7.x to 4.5.x. We will add TS compatibility tests to CIs in the future.
