### PR TITLE
Revert "[chore] Release 10.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "10.1.0",
+  "version": "10.0.1",
   "description": "Firebase admin SDK for Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts firebase/firebase-admin-node#1553

It appears that the TS4 upgrade (required for Firestore upgrade) breaks backwards compatibility with `tsc 3.x` (caught during the release process). Reverting this until we investigate the best path forward.