### PR TITLE
Fixed storage ignoring projectId issue

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -45,6 +45,9 @@ export class Storage {
       });
     }
 
+    // make sure to pass along `projectId` from when the user calls `initializeApp`
+    if (app.options.projectId) process.env.GCLOUD_PROJECT = app.options.projectId;
+
     if (!process.env.STORAGE_EMULATOR_HOST && process.env.FIREBASE_STORAGE_EMULATOR_HOST) {
       const firebaseStorageEmulatorHost = process.env.FIREBASE_STORAGE_EMULATOR_HOST;
 


### PR DESCRIPTION
### Discussion

In the following piece of code:
```
initializeApp({ projectId: 'my-project-id` })
```

The library should initialize the app with the specified project id. However, when using the storage library, such as with this example:
```
getStorage().bucket().upload(filePath)
```
The application throws the following error:
```
Error: Unable to detect a Project Id in the current environment. 
To learn more about authentication and Google APIs, visit: 
https://cloud.google.com/docs/authentication/getting-started
```

This issue has been mentioned in https://github.com/firebase/firebase-admin-node/issues/1466.

This PR fixes the issue by setting the `process.env.GCLOUD_PROJECT` variable to the value passed in to `initializeApp`.

### Testing

All unit tests pass after making the changes in this PR.
Integration tests were not performed.
