### PR TITLE
chore: Updating node-forge to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "dicer": "^0.3.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.2",
-    "node-forge": "^1.0.0"
+    "node-forge": "^1.3.1"
   },
   "optionalDependencies": {
     "@google-cloud/firestore": "^4.15.1",


### PR DESCRIPTION
- Bumped the `node-forge` version to `1.3.1`

