### PR TITLE
fix(auth): cannot delete property 'uid' of #<UserInfo>

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -42,6 +42,7 @@ import {
   OIDCAuthProviderConfig, SAMLAuthProviderConfig, OIDCUpdateAuthProviderRequest,
   SAMLUpdateAuthProviderRequest
 } from './auth-config';
+import { UserInfo } from './user-record';
 
 /** Firebase Auth request header. */
 const FIREBASE_AUTH_HEADER = {
@@ -1439,8 +1440,12 @@ export abstract class AbstractAuthRequestHandler {
       delete request.phoneNumber;
     }
 
-    if (typeof(request.providerToLink) !== 'undefined') {
-      request.linkProviderUserInfo = deepCopy(request.providerToLink);
+    if (typeof request.providerToLink !== 'undefined') {
+      request.linkProviderUserInfo = deepCopy(
+        request.providerToLink instanceof UserInfo
+          ? request.providerToLink.toJSON()
+          : request.providerToLink,
+      );
       delete request.providerToLink;
 
       request.linkProviderUserInfo.rawId = request.linkProviderUserInfo.uid;


### PR DESCRIPTION
Hi. This error (*Cannot delete property 'uid' of #<UserInfo>*) occurs when we do something like below:

```ts
await auth.updateUser(uid, {
  providerToLink: {
    providerId: 'google.com',
    uid: 'google_uid',
  },
});
const user = await auth.getUser(uid);
const provider = user.providerData.find(v => v.providerId === 'google.com');
// previously this will throw an error: Cannot delete property 'uid' of #<UserInfo>
const updated = await auth.updateUser(uid, {
  providerToLink: provider,
});
```

The use case is I want to unlink a given provider from `user A` and then link that same provider to `user B`.
