### PR TITLE
More integration test for account defender

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1890,7 +1890,6 @@ export abstract class AbstractAuthRequestHandler {
     requestData: object | undefined, additionalResourceParams?: object): Promise<object> {
     return urlBuilder.getUrl(apiSettings.getEndpoint(), additionalResourceParams)
       .then((url) => {
-        console.log(url);
         // Validate request.
         if (requestData) {
           const requestValidator = apiSettings.getRequestValidator();

--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1890,6 +1890,7 @@ export abstract class AbstractAuthRequestHandler {
     requestData: object | undefined, additionalResourceParams?: object): Promise<object> {
     return urlBuilder.getUrl(apiSettings.getEndpoint(), additionalResourceParams)
       .then((url) => {
+        console.log(url);
         // Validate request.
         if (requestData) {
           const requestValidator = apiSettings.getRequestValidator();


### PR DESCRIPTION
Added more integration test for account defender -
Case 1 - Trying to disable recaptcha after account defender is enabled should return invalid-config error.  This is tested by this PR.
Case 2 - Trying to enable account defender when recaptcha is not enabled should return recaptcha-not-enabled error.  This is tested by a previous approved change.

This PR is in draft mode because test needs to be verified after RestAPI is ready.

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
