### PR TITLE
Fix markdown lists in reference docs

### DIFF
--- a/src/eventarc/eventarc.ts
+++ b/src/eventarc/eventarc.ts
@@ -70,12 +70,15 @@ export class Eventarc {
   /**
    * Creates a reference to the Eventarc channel using the provided channel resource name.
    * The channel resource name can be either:
-   *   * A fully qualified channel resource name:
+   * 
+   * - A fully qualified channel resource name:
    *     `projects/{project}/locations/{location}/channels/{channel-id}`
-   *   * A partial resource name with location and channel ID, in which case
+   * 
+   * - A partial resource name with location and channel ID, in which case
    *     the runtime project ID of the function is used:
    *     `locations/{location}/channels/{channel-id}`
-   *   * A partial channel ID, in which case the runtime project ID of the
+   * 
+   * - A partial channel ID, in which case the runtime project ID of the
    *     function and `us-central1` as location is used:
    *     `{channel-id}`
    * 

--- a/src/functions/functions-api.ts
+++ b/src/functions/functions-api.ts
@@ -42,6 +42,7 @@ export interface AbsoluteDelivery {
 
 /**
  * Type representing delivery schedule options.
+ * `DeliverySchedule` is a union type of {@link DelayDelivery} and {@link AbsoluteDelivery} types.
  */
 export type DeliverySchedule = DelayDelivery | AbsoluteDelivery
 

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -39,12 +39,15 @@ export class Functions {
   /**
    * Creates a reference to a {@link TaskQueue} for a given function name.
    * The function name can be either:
-   *   * A fully qualified function resource name:
+   *
+   * 1) A fully qualified function resource name:
    *     `projects/{project}/locations/{location}/functions/{functionName}`
-   *   * A partial resource name with location and function name, in which case
+   *
+   * 2) A partial resource name with location and function name, in which case
    *     the runtime project ID is used:
    *     `locations/{location}/functions/{functionName}`
-   *   * A partial function name, in which case the runtime project ID and the default location,
+   *
+   * 3) A partial function name, in which case the runtime project ID and the default location,
    *     `us-central1`, is used:
    *     `{functionName}`
    * 


### PR DESCRIPTION
Fix markdown lists in reference docs.
Note: It appears that TSDoc can't parse markdown lists in the description yet.