### PR TITLE
chore: Run nightly builds on Node 14

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Install and build
       run: |


### PR DESCRIPTION
- Node 12 reached EoL in April 2022.
- `firebase-tools` has dropped support for Node 12 this breaks our nightly workflows.
- Updating the nightly workflow to run on Node 14 (we will also deprecate and drop support for Node 12 in Admin SDK in the upcoming releases).
