### PR TITLE
[chore] Release 10.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 12 and higher.
+We support Node.js 12 and higher. However, Node.js 12 support is deprecated. We strongly encourage
+you to use Node.js 14 or higher as we will drop support for Node.js 12 in the next major version.
 
 Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Firebase admin SDK for Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Includes fixes for #1512, #1718, and #1726
- Node.js 12 support is deprecated. We strongly encourage you to use Node.js 14 or higher as we will drop support for Node.js 12 in the next major version. We will also upgrade Typescript to 4.x in the next major version.