### PR TITLE
[chore] Release 11.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -27,7 +27,6 @@ jobs:
     - name: Run api-extractor
       run: npm run api-extractor
     - name: Run emulator-based integration tests
-      if: matrix.node-version == '14.x'
       run: |
         npm install -g firebase-tools
         firebase emulators:exec --project fake-project-id --only auth,database,firestore \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "10.3.0",
+  "version": "11.0.0",
   "description": "Firebase admin SDK for Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",

--- a/test/unit/machine-learning/machine-learning.spec.ts
+++ b/test/unit/machine-learning/machine-learning.spec.ts
@@ -581,8 +581,7 @@ describe('MachineLearning', () => {
         .resolves(null as any);
       stubs.push(stub);
       return machineLearning.createModel(MODEL_OPTIONS_WITH_GCS)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Cannot read property \'done\' of null');
+        .should.eventually.be.rejected;
     });
 
     it('should reject when API response does not contain a name', () => {
@@ -698,8 +697,7 @@ describe('MachineLearning', () => {
         .resolves(null as any);
       stubs.push(stub);
       return machineLearning.updateModel(MODEL_ID, MODEL_OPTIONS_WITH_GCS)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Cannot read property \'done\' of null');
+        .should.eventually.be.rejected;
     });
 
     it('should reject when API response does not contain a name', () => {
@@ -802,8 +800,7 @@ describe('MachineLearning', () => {
         .resolves(null as any);
       stubs.push(stub);
       return machineLearning.publishModel(MODEL_ID)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Cannot read property \'done\' of null');
+        .should.eventually.be.rejected;
     });
 
     it('should reject when API response does not contain a name', () => {
@@ -906,8 +903,7 @@ describe('MachineLearning', () => {
         .resolves(null as any);
       stubs.push(stub);
       return machineLearning.unpublishModel(MODEL_ID)
-        .should.eventually.be.rejected.and.have.property(
-          'message', 'Cannot read property \'done\' of null');
+        .should.eventually.be.rejected;
     });
 
     it('should reject when API response does not contain a name', () => {


### PR DESCRIPTION
- Bumped version to 11.0.0
- Fixed ML unit tests to pass on Node 16.
  - The error message is different on Node 14 vs 16 `Cannot read properties of null (reading 'done')` vs  `Cannot read property 'done' of null`
  - Updated to only check for rejection instead of checking for an exact error string.
- Added Node 16 to CI

Breaking change: Dropped support for Node.js 12. Developers should use Node.js 14 or higher when deploying the Admin SDK.

Breaking change: Upgraded TypeScript to [v4.6.4](https://github.com/microsoft/TypeScript/releases/tag/v4.6.4).

Breaking change: Upgraded the @google-cloud/firestore package to v5. This contains breaking changes. Refer to the Cloud Firestore [release notes](https://github.com/googleapis/nodejs-firestore/releases/tag/v5.0.0) for more details.

Breaking change: Upgraded the @google-cloud/storage package to v6. This contains breaking changes. Refer to the Cloud Storage [release notes](https://github.com/googleapis/nodejs-storage/releases/tag/v6.0.0) for more details.