### PR TITLE
enable esModuleInterop in tsconfig to fix import issue

### DIFF
--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -17,7 +17,7 @@
 
 import fs = require('fs');
 import os = require('os');
-import path = require('path');
+import path from 'path';
 
 import { Agent } from 'http';
 import { Credential, GoogleOAuthAccessToken } from './credential';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -15,8 +15,8 @@
  */
 
 import * as validator from './validator';
-import * as jwt from 'jsonwebtoken';
-import * as jwks from 'jwks-rsa';
+import jwt from 'jsonwebtoken';
+import jwks from 'jwks-rsa';
 import { HttpClient, HttpRequestConfig, HttpError } from '../utils/api-request';
 import { Agent } from 'http';
 

--- a/test/integration/app-check.spec.ts
+++ b/test/integration/app-check.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as admin from '../../lib/index';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-import fs = require('fs');
-import path = require('path');
+import _ from 'lodash';
+import admin from '../../lib/index';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import fs from 'fs';
+import path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const chalk = require('chalk');

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import url = require('url');
-import * as crypto from 'crypto';
-import * as bcrypt from 'bcrypt';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import url from 'url';
+import crypto from 'crypto';
+import bcrypt from 'bcrypt';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import firebase from '@firebase/app-compat';
 import '@firebase/auth-compat';
 import { clone } from 'lodash';
@@ -551,7 +551,7 @@ describe('admin.auth', () => {
             // each attempt). Occassionally, this call retrieves the user data
             // without the lastLoginTime/lastRefreshTime set; possibly because
             // it's hitting a different server than the login request uses.
-            let userRecord = null;
+            let userRecord:UserRecord|null = null;
 
             for (let i = 0; i < 3; i++) {
               userRecord = await getAuth().getUser('lastRefreshTimeUser');

--- a/test/integration/database.spec.ts
+++ b/test/integration/database.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import * as admin from '../../lib/index';
 import {
   Database, DataSnapshot, EventType, Reference, ServerValue, getDatabase, getDatabaseWithUrl,

--- a/test/integration/firestore.spec.ts
+++ b/test/integration/firestore.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { clone } from 'lodash';
 import * as admin from '../../lib/index';
 import {
@@ -169,7 +169,7 @@ describe('admin.firestore', () => {
         const data = snapshot.data();
         expect(data).to.exist;
         expect(data!.sisterCity.path).to.deep.equal(source.path);
-        const promises = [];
+        const promises:Promise<admin.firestore.WriteResult>[] = [];
         promises.push(source.delete());
         promises.push(target.delete());
         return Promise.all(promises);

--- a/test/integration/functions.spec.ts
+++ b/test/integration/functions.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { getFunctions } from '../../lib/functions/index';
 
 chai.should();

--- a/test/integration/installations.spec.ts
+++ b/test/integration/installations.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import { getInstallations } from '../../lib/installations/index';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/test/integration/instance-id.spec.ts
+++ b/test/integration/instance-id.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { getInstanceId } from '../../lib/instance-id/index';
 
 chai.should();

--- a/test/integration/machine-learning.spec.ts
+++ b/test/integration/machine-learning.spec.ts
@@ -15,8 +15,8 @@
  */
 
 
-import path = require('path');
-import * as chai from 'chai';
+import path from 'path';
+import chai from 'chai';
 import { projectId } from './setup';
 import { Bucket } from '@google-cloud/storage';
 import { getStorage } from '../../lib/storage/index';

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { Message, MulticastMessage, getMessaging } from '../../lib/messaging/index';
 
 chai.should();

--- a/test/integration/project-management.spec.ts
+++ b/test/integration/project-management.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { projectId } from './setup';
 import {
   AndroidApp, IosApp, ShaCertificate, getProjectManagement,

--- a/test/integration/remote-config.spec.ts
+++ b/test/integration/remote-config.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { deepCopy } from '../../src/utils/deep-copy';
 import {
   getRemoteConfig,

--- a/test/integration/security-rules.spec.ts
+++ b/test/integration/security-rules.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
+import chai from 'chai';
 import { Ruleset, RulesetMetadata, getSecurityRules } from '../../lib/security-rules/index';
 
 const expect = chai.expect;

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import fs = require('fs');
-import minimist = require('minimist');
-import path = require('path');
+import fs from 'fs';
+import minimist from 'minimist';
+import path from 'path';
 import { random } from 'lodash';
 import {
   App, Credential, GoogleOAuthAccessToken, cert, deleteApp, initializeApp,

--- a/test/integration/storage.spec.ts
+++ b/test/integration/storage.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { Bucket, File } from '@google-cloud/storage';
 
 import { projectId } from './setup';

--- a/test/resources/mocks.ts
+++ b/test/resources/mocks.ts
@@ -18,11 +18,11 @@
 'use strict';
 
 // Use untyped import syntax for Node built-ins.
-import path = require('path');
-import events = require('events');
-import stream = require('stream');
+import path from 'path';
+import events from 'events';
+import stream from 'stream';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import * as jwt from 'jsonwebtoken';
 
 import { AppOptions } from '../../src/firebase-namespace-api';

--- a/test/unit/app-check/app-check-api-client-internal.spec.ts
+++ b/test/unit/app-check/app-check-api-client-internal.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/app-check/app-check.spec.ts
+++ b/test/unit/app-check/app-check.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import * as mocks from '../../resources/mocks';
 
 import { FirebaseApp } from '../../../src/app/firebase-app';

--- a/test/unit/app-check/token-generator.spec.ts
+++ b/test/unit/app-check/token-generator.spec.ts
@@ -17,12 +17,12 @@
 
 'use strict';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import * as jwt from 'jsonwebtoken';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../../resources/mocks';
 
 import {

--- a/test/unit/app-check/token-verifier.spec.ts
+++ b/test/unit/app-check/token-verifier.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import * as mocks from '../../resources/mocks';
-import * as nock from 'nock';
+import nock from 'nock';
 
 import { AppCheckTokenVerifier } from '../../../src/app-check/token-verifier';
 import { JwtError, JwtErrorCode, PublicKeySignatureVerifier } from '../../../src/utils/jwt';

--- a/test/unit/app/credential-internal.spec.ts
+++ b/test/unit/app/credential-internal.spec.ts
@@ -18,15 +18,15 @@
 'use strict';
 
 // Use untyped import syntax for Node built-ins
-import fs = require('fs');
-import path = require('path');
+import fs from 'fs';
+import path from 'path';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import nock from 'nock';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/app/firebase-app.spec.ts
+++ b/test/unit/app/firebase-app.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/app/firebase-namespace.spec.ts
+++ b/test/unit/app/firebase-namespace.spec.ts
@@ -17,12 +17,12 @@
 
 'use strict';
 
-import path = require('path');
+import path from 'path';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 

--- a/test/unit/app/index.spec.ts
+++ b/test/unit/app/index.spec.ts
@@ -17,13 +17,13 @@
 
 'use strict';
 
-import path = require('path');
+import path from 'path';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import * as mocks from '../../resources/mocks';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import {
   initializeApp, getApp, getApps, deleteApp, SDK_VERSION,

--- a/test/unit/auth/action-code-settings-builder.spec.ts
+++ b/test/unit/auth/action-code-settings-builder.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { ActionCodeSettingsBuilder } from '../../../src/auth/action-code-settings-builder';
 import { AuthClientErrorCode } from '../../../src/utils/error';

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/auth/auth-config.spec.ts
+++ b/test/unit/auth/auth-config.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { deepCopy } from '../../../src/utils/deep-copy';
 import {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -18,11 +18,11 @@
 'use strict';
 
 import * as jwt from 'jsonwebtoken';
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/auth/index.spec.ts
+++ b/test/unit/auth/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/auth/tenant-manager.spec.ts
+++ b/test/unit/auth/tenant-manager.spec.ts
@@ -16,11 +16,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/app/firebase-app';

--- a/test/unit/auth/tenant.spec.ts
+++ b/test/unit/auth/tenant.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { deepCopy } from '../../../src/utils/deep-copy';
 import { EmailSignInConfig, MultiFactorAuthConfig } from '../../../src/auth/auth-config';

--- a/test/unit/auth/token-generator.spec.ts
+++ b/test/unit/auth/token-generator.spec.ts
@@ -17,12 +17,12 @@
 
 'use strict';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import * as jwt from 'jsonwebtoken';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import {

--- a/test/unit/auth/token-verifier.spec.ts
+++ b/test/unit/auth/token-verifier.spec.ts
@@ -16,12 +16,12 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import nock from 'nock';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 import { Agent } from 'http';
 
 import LegacyFirebaseTokenGenerator = require('firebase-token-generator');

--- a/test/unit/auth/user-import-builder.spec.ts
+++ b/test/unit/auth/user-import-builder.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { deepCopy } from '../../../src/utils/deep-copy';
 import {

--- a/test/unit/auth/user-record.spec.ts
+++ b/test/unit/auth/user-record.spec.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { deepCopy } from '../../../src/utils/deep-copy';
 import {

--- a/test/unit/database/database.spec.ts
+++ b/test/unit/database/database.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import { expect } from 'chai';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/app/firebase-app';

--- a/test/unit/database/index.spec.ts
+++ b/test/unit/database/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/eventarc/eventarc-utils.spec.ts
+++ b/test/unit/eventarc/eventarc-utils.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import * as utils from '../../../src/eventarc/eventarc-utils';
-import * as chai from 'chai';
+import chai from 'chai';
 import chaiExclude from 'chai-exclude';
 
 const expect = chai.expect;

--- a/test/unit/eventarc/eventarc.spec.ts
+++ b/test/unit/eventarc/eventarc.spec.ts
@@ -17,7 +17,7 @@
 
 'use strict';
 
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import { Channel, Eventarc } from '../../../src/eventarc';
 import { toCloudEventProtoFormat } from '../../../src/eventarc/eventarc-utils';
 import { CloudEvent } from '../../../src/eventarc/cloudevent';
@@ -25,7 +25,7 @@ import { HttpClient } from '../../../src/utils/api-request';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import * as mocks from '../../resources/mocks';
 import * as utils from '../utils';
-import * as chai from 'chai';
+import chai from 'chai';
 import chaiExclude from 'chai-exclude';
 import { getSdkVersion } from '../../../src/utils/index';
 

--- a/test/unit/firebase.spec.ts
+++ b/test/unit/firebase.spec.ts
@@ -18,12 +18,12 @@
 'use strict';
 
 // Use untyped import syntax for Node built-ins
-import path = require('path');
+import path from 'path';
 
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import sinon from 'sinon';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../resources/mocks';
 

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -17,7 +17,7 @@
 
 'use strict';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import { expect } from 'chai';
 
 import * as mocks from '../../resources/mocks';

--- a/test/unit/firestore/index.spec.ts
+++ b/test/unit/firestore/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/functions/functions-api-client-internal.spec.ts
+++ b/test/unit/functions/functions-api-client-internal.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';
 import { getSdkVersion } from '../../../src/utils';

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import * as mocks from '../../resources/mocks';
 
 import { FirebaseApp } from '../../../src/app/firebase-app';

--- a/test/unit/functions/index.spec.ts
+++ b/test/unit/functions/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/installations/installations-request-handler.spec.ts
+++ b/test/unit/installations/installations-request-handler.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/installations/installations.spec.ts
+++ b/test/unit/installations/installations.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/instance-id/index.spec.ts
+++ b/test/unit/instance-id/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/instance-id/instance-id.spec.ts
+++ b/test/unit/instance-id/instance-id.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/machine-learning/index.spec.ts
+++ b/test/unit/machine-learning/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import { FirebaseMachineLearningError } from '../../../src/machine-learning/machine-learning-utils';
 import { HttpClient } from '../../../src/utils/api-request';
 import * as utils from '../utils';

--- a/test/unit/machine-learning/machine-learning.spec.ts
+++ b/test/unit/machine-learning/machine-learning.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import * as mocks from '../../resources/mocks';
 import {

--- a/test/unit/messaging/batch-requests.spec.ts
+++ b/test/unit/messaging/batch-requests.spec.ts
@@ -16,10 +16,10 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 

--- a/test/unit/messaging/index.spec.ts
+++ b/test/unit/messaging/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -17,12 +17,12 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import chai from 'chai';
+import nock from 'nock';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { FirebaseApp } from '../../../src/app/firebase-app';

--- a/test/unit/project-management/android-app.spec.ts
+++ b/test/unit/project-management/android-app.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
+import chai from 'chai';
+import _ from 'lodash';
+import sinon from 'sinon';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import {
   ProjectManagementRequestHandler

--- a/test/unit/project-management/index.spec.ts
+++ b/test/unit/project-management/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/project-management/ios-app.spec.ts
+++ b/test/unit/project-management/ios-app.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
+import chai from 'chai';
+import _ from 'lodash';
+import sinon from 'sinon';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import {
   ProjectManagementRequestHandler

--- a/test/unit/project-management/project-management-api-request.spec.ts
+++ b/test/unit/project-management/project-management-api-request.spec.ts
@@ -16,11 +16,11 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import {
   ProjectManagementRequestHandler

--- a/test/unit/project-management/project-management.spec.ts
+++ b/test/unit/project-management/project-management.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
+import chai from 'chai';
+import _ from 'lodash';
+import sinon from 'sinon';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import {
   ProjectManagementRequestHandler

--- a/test/unit/remote-config/index.spec.ts
+++ b/test/unit/remote-config/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import {
   FirebaseRemoteConfigError,
   RemoteConfigApiClient

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import {
   ParameterValueType,
   RemoteConfig,

--- a/test/unit/security-rules/index.spec.ts
+++ b/test/unit/security-rules/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import { SecurityRulesApiClient, RulesetContent } from '../../../src/security-rules/security-rules-api-client-internal';
 import { FirebaseSecurityRulesError } from '../../../src/security-rules/security-rules-internal';
 import { HttpClient } from '../../../src/utils/api-request';

--- a/test/unit/security-rules/security-rules.spec.ts
+++ b/test/unit/security-rules/security-rules.spec.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
 import { SecurityRules } from '../../../src/security-rules/index';
 import { FirebaseApp } from '../../../src/app/firebase-app';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/storage/index.spec.ts
+++ b/test/unit/storage/index.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { App } from '../../../src/app/index';

--- a/test/unit/storage/storage.spec.ts
+++ b/test/unit/storage/storage.spec.ts
@@ -17,7 +17,7 @@
 
 'use strict';
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import { expect } from 'chai';
 
 import * as mocks from '../../resources/mocks';

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import sinon from 'sinon';
 import * as mocks from '../resources/mocks';
 import { AppOptions } from '../../src/firebase-namespace-api';
 import { FirebaseApp, FirebaseAppInternals, FirebaseAccessToken } from '../../src/app/firebase-app';

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -17,11 +17,11 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import nock from 'nock';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as utils from '../utils';
 import * as mocks from '../../resources/mocks';

--- a/test/unit/utils/crypto-signer.spec.ts
+++ b/test/unit/utils/crypto-signer.spec.ts
@@ -17,10 +17,10 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as mocks from '../../resources/mocks';
 import { ServiceAccountSigner, IAMSigner, CryptoSignerError } from '../../../src/utils/crypto-signer';

--- a/test/unit/utils/error.spec.ts
+++ b/test/unit/utils/error.spec.ts
@@ -17,9 +17,9 @@
 
 'use strict';
 
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import {
   FirebaseError, FirebaseAuthError, FirebaseMessagingError, MessagingClientErrorCode,

--- a/test/unit/utils/index.spec.ts
+++ b/test/unit/utils/index.spec.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import * as _ from 'lodash';
+import _ from 'lodash';
 import { expect } from 'chai';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import * as mocks from '../../resources/mocks';
 import {

--- a/test/unit/utils/jwt.spec.ts
+++ b/test/unit/utils/jwt.spec.ts
@@ -19,10 +19,10 @@
 // Use untyped import syntax for Node built-ins
 import https = require('https');
 
-import * as _ from 'lodash';
-import * as chai from 'chai';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
+import _ from 'lodash';
+import chai from 'chai';
+import nock from 'nock';
+import sinon from 'sinon';
 
 import * as mocks from '../../resources/mocks';
 import {

--- a/test/unit/utils/validator.spec.ts
+++ b/test/unit/utils/validator.spec.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
-import * as _ from 'lodash';
-import * as sinonChai from 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import _ from 'lodash';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import {
   isArray, isNonEmptyArray, isBoolean, isNumber, isString, isNonEmptyString, isNonNullObject,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "sourceMap": true,
     "noImplicitAny": true,
+    "esModuleInterop": true,
     "noUnusedLocals": true,
     // TODO(rsgowman): enable `"strict": true,` and remove explicit setting of: noImplicitAny, noImplicitThis, alwaysStrict, strictBindCallApply, strictNullChecks, strictFunctionTypes, strictPropertyInitialization.
     "noImplicitThis": true,


### PR DESCRIPTION
as for now `esModuleInterop` is not enabled, this has caused some issues when importing, for example:
 
```ts
import firestore from 'firebase-admin/firestore'
const st = firestore.FieldValue.serverTimestamp()
```
with `@babel/preset-env`, it is translated into
```ts
"use strict";

var _firestore = _interopRequireDefault(require("firebase-admin/firestore"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var st = _firestore.default.FieldValue.serverTimestamp();
```
[playground](JYWwDg9gTgLgBAM2FApgZxtFioRHAciVQCMBDNFAWjIBMRgA7AemPU1QICgBjCRjHEEBeRMnZYAdADFgKADa0AamXkBXFJMpQAbiigAVUOzLgAFAEogA)

this import will not work because, in the built code, we have something like this 
![image](https://user-images.githubusercontent.com/5227509/179986073-8839963c-2bea-44f6-ac22-4bab6c07573e.png)

the `__esModule` prop is set to true

and according to `_interopRequireDefault` logic, it will evaluate into `obj`, not `{ default: obj }; }`

the problem, import x from 'y' is equivalent to `const x = require('y').default`

and the `default` prop is not defined.

the solution is to simply enable [esModuleInterop](https://www.typescriptlang.org/tsconfig/#esModuleInterop) in ts config

======================================
I did the changes needed for `esModuleInterop` to work and fix some types along the way:
1. enable esModuleInterop in ts config
2. change import as x to import x for multiple files
3. fix some type issue:
-. test/integration/auth.spec.ts
-. test/integration/firestore.spec.ts

