### PR TITLE
add: error handling in firestore-internal for version extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .DS_Store
 npm-debug.log
+yarn.lock
 
 lib/
 .tmp/


### PR DESCRIPTION
### Discussion

* Bug: Async Problem

I think firebase-internal.ts has async problem. It goes to if-else state before credential is created. So, in my case, I normally send credential in nestJS project with `applicationDefault()` method and credential was consoled out to be instance ServiceAccountCredential, but it gave error. 

So, I suggest using try-catch statement in firestore-internal.ts and it would handle origin error. Also, in 'else' case It returns original credential.  

### Testing

  * I did all the test 
  * Success percentage was 99.4 % ( 3 errors occurred )
  * 3 errors was engaged with FirestoreSerivce constructor, but i did not modify it.
  
### API Changes

  * There is no API Changes.
