### PR TITLE
fix(firestore): added missing 'ReadWriteTransactionOptions' export (#1874)

### DIFF
--- a/etc/firebase-admin.firestore.api.md
+++ b/etc/firebase-admin.firestore.api.md
@@ -36,6 +36,7 @@ import { QueryPartition } from '@google-cloud/firestore';
 import { QuerySnapshot } from '@google-cloud/firestore';
 import { ReadOnlyTransactionOptions } from '@google-cloud/firestore';
 import { ReadOptions } from '@google-cloud/firestore';
+import { ReadWriteTransactionOptions } from '@google-cloud/firestore';
 import { setLogFunction } from '@google-cloud/firestore';
 import { SetOptions } from '@google-cloud/firestore';
 import { Settings } from '@google-cloud/firestore';
@@ -111,6 +112,8 @@ export { QuerySnapshot }
 export { ReadOnlyTransactionOptions }
 
 export { ReadOptions }
+
+export { ReadWriteTransactionOptions }
 
 export { setLogFunction }
 

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -55,6 +55,7 @@ export {
   QuerySnapshot,
   ReadOptions,
   ReadOnlyTransactionOptions,
+  ReadWriteTransactionOptions,
   Settings,
   SetOptions,
   Timestamp,


### PR DESCRIPTION
**ReadWriteTransactionOptions**  is not exported from `firebase-admin/firestore` however available in `@google-cloud/firestore`