### PR TITLE
fix(fcm): Increase FCM timeout to 15s

### DIFF
--- a/src/messaging/messaging-api-request-internal.ts
+++ b/src/messaging/messaging-api-request-internal.ts
@@ -27,7 +27,7 @@ import { SendResponse, BatchResponse } from './messaging-api';
 
 
 // FCM backend constants
-const FIREBASE_MESSAGING_TIMEOUT = 10000;
+const FIREBASE_MESSAGING_TIMEOUT = 15000;
 const FIREBASE_MESSAGING_BATCH_URL = 'https://fcm.googleapis.com/batch';
 const FIREBASE_MESSAGING_HTTP_METHOD: HttpMethod = 'POST';
 const FIREBASE_MESSAGING_HEADERS = {

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -3538,7 +3538,7 @@ describe('Messaging', () => {
             expect(httpsRequestStub).to.have.been.calledOnce.and.calledWith({
               method: 'POST',
               data: { message: expectedReq },
-              timeout: 10000,
+              timeout: 15000,
               url: 'https://fcm.googleapis.com/v1/projects/project_id/messages:send',
               headers: expectedHeaders,
             });


### PR DESCRIPTION
- Increase the FCM timeout to 15s to match the recommended timeout in the BE. This will prevent duplicate notifications due to the Admin SDK retrying too early.

Fixes: #1900 
