### PR TITLE
fix: Unregister socket timeout listener to prevent MaxListenersExceededWarning

### DIFF
--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -505,7 +505,12 @@ class AsyncHttpCall {
       // Listen to timeouts and throw an error.
       req.setTimeout(timeout, timeoutCallback);
       req.on('socket', (socket) => {
+        socket.setMaxListeners(socket.getMaxListeners() + 1);
         socket.setTimeout(timeout, timeoutCallback);
+        socket.on('end', () => {
+          socket.setTimeout(0);
+          socket.setMaxListeners(socket.getMaxListeners() - 1);
+        });
       });
     }
 

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -509,7 +509,7 @@ class AsyncHttpCall {
         socket.setTimeout(timeout, timeoutCallback);
         socket.on('end', () => {
           socket.setTimeout(0);
-          socket.setMaxListeners(socket.getMaxListeners() - 1);
+          socket.setMaxListeners(Math.max(socket.getMaxListeners() - 1, 0));
         });
       });
     }


### PR DESCRIPTION
Hey there,

after updating our application to node 19 we noticed that the firebase package is causing a `MaxListenersExceededWarning` error. The error occurs in the underlying method call in `HttpClient.send` namely in `AsyncHttpCall.execute`. There the timeout listener is not removed after the socket is closed. I could provoke the error only in the integration tests, in the unit tests to the mentioned method the error does not occur. Therefore I added a listener spy check in the `afterEach` of the auth integration tests which should not be called. 

Attention, the error only occurs with Node 19, if someone wants to test the behavior it must be done with this version.

Thanks for the great work – I am looking forward to your review.

PS: we mainly use the auth feature of firebase. so i may have missed something in other features/tests.

### Discussion

  * Added  #1995

### Testing

  * Added `afterEach` to `test/integration/auth.spec.ts` which expects the `process.on` not be called with an `MaxListenersExceededWarning` error.

### API Changes

  * No changes to API
