### PR TITLE
fix(fcm): Increase batch send timeout to 15 seconds

### DIFF
--- a/src/messaging/batch-request-internal.ts
+++ b/src/messaging/batch-request-internal.ts
@@ -20,7 +20,7 @@ import {
 import { FirebaseAppError, AppErrorCodes } from '../utils/error';
 
 const PART_BOUNDARY = '__END_OF_PART__';
-const TEN_SECONDS_IN_MILLIS = 10000;
+const TEN_SECONDS_IN_MILLIS = 15000;
 
 /**
  * Represents a request that can be sent as part of an HTTP batch request.

--- a/test/unit/messaging/batch-requests.spec.ts
+++ b/test/unit/messaging/batch-requests.spec.ts
@@ -249,7 +249,7 @@ describe('BatchRequestClient', () => {
     expect(args.url).to.equal(batchUrl);
     expect(args.headers).to.have.property(
       'Content-Type', 'multipart/mixed; boundary=__END_OF_PART__');
-    expect(args.timeout).to.equal(10000);
+    expect(args.timeout).to.equal(15000);
     const parsedRequest = parseHttpRequest(args.data as Buffer);
     expect(parsedRequest.multipart.length).to.equal(requests.length);
 


### PR DESCRIPTION
- Increase batch send timeout to 15 seconds
- Extension to: #1947 
Resolves: https://github.com/firebase/firebase-admin-node/issues/1900