### PR TITLE
change(ml): Deprecate AutoML model support

### DIFF
--- a/etc/firebase-admin.api.md
+++ b/etc/firebase-admin.api.md
@@ -320,6 +320,8 @@ export function machineLearning(app?: App): machineLearning.MachineLearning;
 // @public (undocumented)
 export namespace machineLearning {
     // Warning: (ae-forgotten-export) The symbol "AutoMLTfliteModelOptions" needs to be exported by the entry point default-namespace.d.ts
+    //
+    // @deprecated
     export type AutoMLTfliteModelOptions = AutoMLTfliteModelOptions;
     // Warning: (ae-forgotten-export) The symbol "GcsTfliteModelOptions" needs to be exported by the entry point default-namespace.d.ts
     export type GcsTfliteModelOptions = GcsTfliteModelOptions;

--- a/etc/firebase-admin.machine-learning.api.md
+++ b/etc/firebase-admin.machine-learning.api.md
@@ -8,7 +8,7 @@
 
 import { Agent } from 'http';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface AutoMLTfliteModelOptions extends ModelOptionsBase {
     // (undocumented)
     tfliteModel: {
@@ -86,6 +86,7 @@ export interface ModelOptionsBase {
 
 // @public
 export interface TFLiteModel {
+    // @deprecated
     readonly automlModel?: string;
     readonly gcsTfliteUri?: string;
     readonly sizeBytes: number;

--- a/src/machine-learning/machine-learning-api-client.ts
+++ b/src/machine-learning/machine-learning-api-client.ts
@@ -38,6 +38,9 @@ export interface GcsTfliteModelOptions extends ModelOptionsBase {
   };
 }
 
+/**
+ * @deprecated AutoMLTfliteModelOptions will be removed in the next major version.
+ */
 export interface AutoMLTfliteModelOptions extends ModelOptionsBase {
   tfliteModel: {
     automlModel: string;

--- a/src/machine-learning/machine-learning-namespace.ts
+++ b/src/machine-learning/machine-learning-namespace.ts
@@ -82,6 +82,8 @@ export namespace machineLearning {
 
   /**
    * Type alias to {@link firebase-admin.machine-learning#AutoMLTfliteModelOptions}.
+   * 
+   * @deprecated AutoMLTfliteModelOptions will be removed in the next major version.
    */
   export type AutoMLTfliteModelOptions = TAutoMLTfliteModelOptions;
 

--- a/src/machine-learning/machine-learning.ts
+++ b/src/machine-learning/machine-learning.ts
@@ -53,6 +53,8 @@ export interface TFLiteModel {
   /**
    * The AutoML model reference from which the model was originally provided
    * to Firebase.
+   * 
+   * @deprecated AutoML model support will be removed in the next major version.
    */
   readonly automlModel?: string;
 }


### PR DESCRIPTION
Mark AutoML model support as deprecated. A prequel to #1974  

Internal API: go/yiyfd