### PR TITLE
Fixing links to externally defined RTDB APIs.

### DIFF
--- a/docgen/extras/firebase-admin.database.md
+++ b/docgen/extras/firebase-admin.database.md
@@ -4,9 +4,9 @@ The following externally defined APIs are re-exported from this module entry poi
 
 |  Symbol | Description |
 |  --- | --- |
-|  [DataSnapshot](https://firebase.google.com/docs/reference/js/firebase.database.DataSnapshot) | `DataSnapshot` type from the `@firebase/database` package. |
-|  [EventType](https://firebase.google.com/docs/reference/js/firebase.database#eventtype) | `EventType` type from the `@firebase/database` package. |
-|  [OnDisconnect](https://firebase.google.com/docs/reference/js/firebase.database.OnDisconnect) | `OnDisconnect` type from the `@firebase/database` package. |
-|  [Query](https://firebase.google.com/docs/reference/js/firebase.database.Query) | `Query` type from the `@firebase/database` package. |
-|  [Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference) | `Reference` type from the `@firebase/database` package. |
-|  [ThenableReference](https://firebase.google.com/docs/reference/js/firebase.database.ThenableReference) | `ThenableReference` type from the `@firebase/database` package. |
+|  [DataSnapshot](https://firebase.google.com/docs/reference/js/database.datasnapshot) | `DataSnapshot` type from the `@firebase/database` package. |
+|  [EventType](https://firebase.google.com/docs/reference/js/database#eventtype) | `EventType` type from the `@firebase/database` package. |
+|  [OnDisconnect](https://firebase.google.com/docs/reference/js/database.ondisconnect) | `OnDisconnect` type from the `@firebase/database` package. |
+|  [Query](https://firebase.google.com/docs/reference/js/database.query) | `Query` type from the `@firebase/database` package. |
+|  [DatabaseReference](https://firebase.google.com/docs/reference/js/database.databasereference) | `DatabaseReference` type from the `@firebase/database` package. |
+|  [ThenableReference](https://firebase.google.com/docs/reference/js/database.thenablereference) | `ThenableReference` type from the `@firebase/database` package. |


### PR DESCRIPTION
Issues here discovered via doc feedback: https://listnr.corp.google.com/report/90770486778

I *think* these may have been broken for a while, since we updated the JS v9 docgen process.  