### PR TITLE
feat(fcm): Add `sendEach` and `sendEachForMulticast` for FCM batch send

### DIFF
--- a/etc/firebase-admin.messaging.api.md
+++ b/etc/firebase-admin.messaging.api.md
@@ -184,7 +184,11 @@ export type Message = TokenMessage | TopicMessage | ConditionMessage;
 export class Messaging {
     get app(): App;
     send(message: Message, dryRun?: boolean): Promise<string>;
+    // @deprecated
     sendAll(messages: Message[], dryRun?: boolean): Promise<BatchResponse>;
+    sendEach(messages: Message[], dryRun?: boolean): Promise<BatchResponse>;
+    sendEachForMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse>;
+    // @deprecated
     sendMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse>;
     sendToCondition(condition: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingConditionResponse>;
     sendToDevice(registrationTokenOrTokens: string | string[], payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingDevicesResponse>;

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -258,9 +258,9 @@ export class Messaging {
   * in the given array.
   *
   * The responses list obtained from the return value corresponds to the order of `messages`.
-  * An error from this method or a `BatchResponse` with all failures indicates a total failure
-  * -- i.e. none of the messages in the list could be sent. Partial failures or no failures
-  * are only indicated by a `BatchResponse` return value.
+  * An error from this method or a `BatchResponse` with all failures indicates a total failure,
+  * meaning that none of the messages in the list could be sent. Partial failures or no
+  * failures are only indicated by a `BatchResponse` return value.
   *
   * @param messages - A non-empty array
   *   containing up to 500 messages.
@@ -328,9 +328,9 @@ export class Messaging {
    * This method uses the {@link Messaging.sendEach} API under the hood to send the given
    * message to all the target recipients. The responses list obtained from the
    * return value corresponds to the order of tokens in the `MulticastMessage`.
-   * An error from this method or a `BatchResponse` with all failures indicates a total failure
-   * -- i.e. none of the messages in the list could be sent. Partial failures or no failures
-   * are only indicated by a `BatchResponse` return value.
+   * An error from this method or a `BatchResponse` with all failures indicates a total
+   * failure, meaning that the messages in the list could be sent. Partial failures or
+   * failures are only indicated by a `BatchResponse` return value.
    *
    * @param message - A multicast message
    *   containing up to 500 tokens.
@@ -377,8 +377,8 @@ export class Messaging {
    *
    * The responses list obtained from the return value
    * corresponds to the order of tokens in the `MulticastMessage`. An error
-   * from this method indicates a total failure -- i.e. none of the messages in
-   * the list could be sent. Partial failures are indicated by a `BatchResponse`
+   * from this method indicates a total failure, meaning that none of the messages
+   * in the list could be sent. Partial failures are indicated by a `BatchResponse`
    * return value.
    *
    * @param messages - A non-empty array
@@ -437,9 +437,9 @@ export class Messaging {
    * This method uses the `sendAll()` API under the hood to send the given
    * message to all the target recipients. The responses list obtained from the
    * return value corresponds to the order of tokens in the `MulticastMessage`.
-   * An error from this method indicates a total failure -- i.e. the message was
-   * not sent to any of the tokens in the list. Partial failures are indicated by
-   * a `BatchResponse` return value.
+   * An error from this method indicates a total failure, meaning that the message
+   * was not sent to any of the tokens in the list. Partial failures are indicated
+   * by a `BatchResponse` return value.
    *
    * @param message - A multicast message
    *   containing up to 500 tokens.

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -250,6 +250,56 @@ export class Messaging {
       });
   }
 
+  // TODO: Update the comment based on the implementation
+  /**
+  * Sends each message in the given array via Firebase Cloud Messaging.
+  *
+  * Unlike {@link Messaging.sendAll}, this method makes a single RPC call for each message in the given array.
+  *
+  * The responses list obtained from the return value
+  * corresponds to the order of `messages`. An error
+  * from this method indicates a total failure -- i.e. none of the messages in
+  * the list could be sent. Partial failures are indicated by a `BatchResponse`
+  * return value.
+  *
+  * @param messages - A non-empty array
+  *   containing up to 500 messages.
+  * @param dryRun - Whether to send the messages in the dry-run
+  *   (validation only) mode.
+  * @returns A Promise fulfilled with an object representing the result of the
+  *   send operation.
+  */
+  public sendEach(messages: Message[], dryRun?: boolean): Promise<BatchResponse> {
+    //TODO: add implementation
+    console.log(messages, dryRun);
+    return Promise.resolve({ responses: [], successCount: 0, failureCount: 0 });
+  }
+
+  // TODO: Update the comment based on the implementation
+  /**
+   * Sends the given multicast message to all the FCM registration tokens
+   * specified in it.
+   *
+   * This method uses the {@link Messaging.sendEach} API under the hood to send the given
+   * message to all the target recipients. The responses list obtained from the
+   * return value corresponds to the order of tokens in the `MulticastMessage`.
+   * An error from this method indicates a total failure -- i.e. the message was
+   * not sent to any of the tokens in the list. Partial failures are indicated by
+   * a `BatchResponse` return value.
+   *
+   * @param message - A multicast message
+   *   containing up to 500 tokens.
+   * @param dryRun - Whether to send the message in the dry-run
+   *   (validation only) mode.
+   * @returns A Promise fulfilled with an object representing the result of the
+   *   send operation.
+   */
+  public sendEachForMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse> {
+    //TODO: add implementation
+    console.log(message, dryRun);
+    return Promise.resolve({ responses: [], successCount: 0, failureCount: 0 });
+  }
+
   /**
    * Sends all the messages in the given array via Firebase Cloud Messaging.
    * Employs batching to send the entire list as a single RPC call. Compared
@@ -268,6 +318,8 @@ export class Messaging {
    *   (validation only) mode.
    * @returns A Promise fulfilled with an object representing the result of the
    *   send operation.
+   *
+   * @deprecated Use {@link Messaging.sendEach} instead.
    */
   public sendAll(messages: Message[], dryRun?: boolean): Promise<BatchResponse> {
     if (validator.isArray(messages) && messages.constructor !== Array) {
@@ -326,6 +378,8 @@ export class Messaging {
    *   (validation only) mode.
    * @returns A Promise fulfilled with an object representing the result of the
    *   send operation.
+   *
+   * @deprecated Use {@link Messaging.sendEachForMulticast} instead.
    */
   public sendMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse> {
     const copy: MulticastMessage = deepCopy(message);


### PR DESCRIPTION
- Deprecate `sendAll()` and `sendMulticast()` APIs.
- Add new `sendEach()` and `sendEachForMulticast()` APIs.