### PR TITLE
chore: update app check integration tests

### DIFF
--- a/test/integration/app-check.spec.ts
+++ b/test/integration/app-check.spec.ts
@@ -103,7 +103,7 @@ describe('admin.appCheck', () => {
       return admin.appCheck().verifyToken(validToken.token)
         .then((verifedToken) => {
           expect(verifedToken).to.have.keys(['token', 'appId']);
-          expect(verifedToken.token).to.have.keys(['iss', 'sub', 'aud', 'exp', 'iat', 'app_id']);
+          expect(verifedToken.token).to.include.keys(['iss', 'sub', 'aud', 'exp', 'iat', 'app_id']);
           expect(verifedToken.token.app_id).to.be.a('string').and.equals(appId);
         });
     });


### PR DESCRIPTION
- App check tokens are getting additional claims (ex: `jti`) and the current test expects only the given claims to be in the token and fails if there are additional claims.
- Updating the test case to expect "at least" the main claims.