### PR TITLE
chore: Pin `firebase-tools@11.30.0` to fix the CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
       run: npm run api-extractor
     - name: Run emulator-based integration tests
       run: |
-        npm install -g firebase-tools
+        npm install -g firebase-tools@11.30.0
         firebase emulators:exec --project fake-project-id --only auth,database,firestore \
           'npx mocha \"test/integration/{auth,database,firestore}.spec.ts\" --slow 5000 --timeout 20000 --require ts-node/register'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Run emulator-based integration tests
       run: |
-        npm install -g firebase-tools
+        npm install -g firebase-tools@11.30.0
         firebase emulators:exec --project fake-project-id --only auth,database,firestore \
           'npx mocha \"test/integration/{auth,database,firestore}.spec.ts\" --slow 5000 --timeout 20000 --require ts-node/register'
 


### PR DESCRIPTION
- `firebase-tools` (used for emulator tests) has dropped support for Node 14 starting v12.0.0
- Admin SDK still support Node 14 and we run our CIs on the lowest version that we support.
- Installing `firebase-tools@11.30.0` on Github actions to fix the CIs and nightly builds.