### PR TITLE
feat(auth): Add `TotpInfo` field to `UserRecord`

### DIFF
--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -134,6 +134,8 @@ export abstract class MultiFactorInfo {
         multiFactorInfo = new PhoneMultiFactorInfo(response);
       } else if (response.totpInfo !== undefined) {
         multiFactorInfo = new TotpMultiFactorInfo(response);
+      } else {
+        // Ignore the other SDK unsupported MFA factors to prevent blocking developers using the current SDK.
       }
     } catch (e) {
       // Ignore error.
@@ -237,6 +239,7 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
         phoneNumber: this.phoneNumber,
       });
   }
+
   /**
    * Returns the factor ID based on the response provided.
    *

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -49,11 +49,11 @@ export interface MultiFactorInfoResponse {
   phoneInfo?: string;
   totpInfo?: TotpInfoResponse;
   enrolledAt?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface TotpInfoResponse {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ProviderUserInfoResponse {

--- a/src/auth/user-record.ts
+++ b/src/auth/user-record.ts
@@ -47,7 +47,12 @@ export interface MultiFactorInfoResponse {
   mfaEnrollmentId: string;
   displayName?: string;
   phoneInfo?: string;
+  totpInfo?: TotpInfoResponse;
   enrolledAt?: string;
+  [key: string]: any;
+}
+
+export interface TotpInfoResponse {
   [key: string]: any;
 }
 
@@ -84,6 +89,7 @@ export interface GetAccountInfoUserResponse {
 
 enum MultiFactorId {
   Phone = 'phone',
+  Totp = 'totp',
 }
 
 /**
@@ -102,7 +108,9 @@ export abstract class MultiFactorInfo {
   public readonly displayName?: string;
 
   /**
-   * The type identifier of the second factor. For SMS second factors, this is `phone`.
+   * The type identifier of the second factor.
+   * For SMS second factors, this is `phone`.
+   * For TOTP second factors, this is `totp`.
    */
   public readonly factorId: string;
 
@@ -120,9 +128,13 @@ export abstract class MultiFactorInfo {
    */
   public static initMultiFactorInfo(response: MultiFactorInfoResponse): MultiFactorInfo | null {
     let multiFactorInfo: MultiFactorInfo | null = null;
-    // Only PhoneMultiFactorInfo currently available.
+    // PhoneMultiFactorInfo, TotpMultiFactorInfo currently available.
     try {
-      multiFactorInfo = new PhoneMultiFactorInfo(response);
+      if (response.phoneInfo !== undefined) {
+        multiFactorInfo = new PhoneMultiFactorInfo(response);
+      } else if (response.totpInfo !== undefined) {
+        multiFactorInfo = new TotpMultiFactorInfo(response);
+      }
     } catch (e) {
       // Ignore error.
     }
@@ -225,7 +237,6 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
         phoneNumber: this.phoneNumber,
       });
   }
-
   /**
    * Returns the factor ID based on the response provided.
    *
@@ -241,13 +252,67 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
 }
 
 /**
+ * TotpInfo struct associated with a second factor
+ */
+export class TotpInfo {
+
+}
+
+/**
+ * Interface representing a TOTP specific user-enrolled second factor.
+ */
+export class TotpMultiFactorInfo extends MultiFactorInfo {
+
+  /**
+   * TotpInfo struct associated with a second factor
+   */
+  public readonly totpInfo: TotpInfo;
+
+  /**
+   * Initializes the TotpMultiFactorInfo object using the server side response.
+   *
+   * @param response - The server side response.
+   * @constructor
+   * @internal
+   */
+  constructor(response: MultiFactorInfoResponse) {
+    super(response);
+    utils.addReadonlyGetter(this, 'totpInfo', response.totpInfo);
+  }
+
+  /**
+   * {@inheritdoc MultiFactorInfo.toJSON}
+   */
+  public toJSON(): object {
+    return Object.assign(
+      super.toJSON(),
+      {
+        totpInfo: this.totpInfo,
+      });
+  }
+
+  /**
+   * Returns the factor ID based on the response provided.
+   *
+   * @param response - The server side response.
+   * @returns The multi-factor ID associated with the provided response. If the response is
+   *     not associated with any known multi-factor ID, null is returned.
+   *
+   * @internal
+   */
+  protected getFactorId(response: MultiFactorInfoResponse): string | null {
+    return (response && response.totpInfo) ? MultiFactorId.Totp : null;
+  }
+}
+
+/**
  * The multi-factor related user settings.
  */
 export class MultiFactorSettings {
 
   /**
    * List of second factors enrolled with the current user.
-   * Currently only phone second factors are supported.
+   * Currently only phone and totp second factors are supported.
    */
   public enrolledFactors: MultiFactorInfo[];
 


### PR DESCRIPTION
Adding a `TotpInfo` field to `UserRecord` for Admin users to view a user's MFA configuration. TOTP enrollment for users is enabled via client SDKs only. 
Testing was done by manually enrolling a user on TOTP using curl and creating a test app to get the corresponding user's `UserRecord` configuration
Manual testing output:
```
MultiFactorSettings {
  enrolledFactors: [
    TotpMultiFactorInfo {
      uid: 'bd8fa8e0-194c-443e-82e9-77b39868aed7',
      factorId: 'totp',
      displayName: 'enroll-totp-test',
      enrollmentTime: 'Wed, 31 May 2023 20:39:18 GMT',
      totpInfo: {}
    }
  ]
}
```

