### PR TITLE
fix: Revert "chore: upgrade database-compat"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       }
     },
     "@firebase/database": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.0.tgz",
-      "integrity": "sha512-ZD750VzQUpdf0uejSuIwvmCrGUgl8jJfUW3WKwAdSgVQsg4xZeepekDcpnVZrT+ZH+j7DwJ98vV/Fsg9uDwBMA==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.4.tgz",
+      "integrity": "sha512-+Ea/IKGwh42jwdjCyzTmeZeLM3oy1h0mFPsTy6OqCWzcu/KFqRAr5Tt1HRCOBlNOdbh84JPZC47WLU18n2VbxQ==",
       "requires": {
         "@firebase/auth-interop-types": "0.2.1",
         "@firebase/component": "0.6.4",
@@ -545,22 +545,22 @@
       }
     },
     "@firebase/database-compat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.0.tgz",
-      "integrity": "sha512-Udkz3/lfF1RZa6A1ygergG/xT7fHSeIUk2kx5bsiv0ChllaNkgovkhC2sgSJuGUBYqlnhLmkDwX2nkAwSutgEQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz",
+      "integrity": "sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==",
       "requires": {
         "@firebase/component": "0.6.4",
-        "@firebase/database": "1.0.0",
-        "@firebase/database-types": "1.0.0",
+        "@firebase/database": "0.14.4",
+        "@firebase/database-types": "0.10.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.0.tgz",
-      "integrity": "sha512-SjnXStoE0Q56HcFgNQ+9SsmJc0c8TqGARdI/T44KXy+Ets3r6x/ivhQozT66bMnCEjJRywYoxNurRTMlZF8VNg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz",
+      "integrity": "sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==",
       "requires": {
         "@firebase/app-types": "0.9.0",
         "@firebase/util": "1.9.3"
@@ -3721,7 +3721,8 @@
         "eslint-visitor-keys": {
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -197,8 +197,8 @@
   },
   "dependencies": {
     "@fastify/busboy": "^1.2.1",
-    "@firebase/database-compat": "^1.0.0",
-    "@firebase/database-types": "^1.0.0",
+    "@firebase/database-compat": "^0.3.4",
+    "@firebase/database-types": "^0.10.4",
     "@types/node": ">=12.12.47",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.0.1",


### PR DESCRIPTION
Reverts firebase/firebase-admin-node#2244

This change was accidentally included in `firebase-admin` `11.10.0`. Reverting to prepare an emergency patch release. `database-compat` upgrade should be included in the next major version of `firebase-admin`

RELEASE NOTES: Fixed an issue which caused the incompatibility in database types in version `11.10.0`