### PR TITLE
updated error messaging for auth-api-request.getAccountInfoByFederatedUid()

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1152,8 +1152,10 @@ export abstract class AbstractAuthRequestHandler {
   }
 
   public getAccountInfoByFederatedUid(providerId: string, rawId: string): Promise<object> {
-    if (!validator.isNonEmptyString(providerId) || !validator.isNonEmptyString(rawId)) {
+    if (!validator.isNonEmptyString(providerId)) {
       throw new FirebaseAuthError(AuthClientErrorCode.INVALID_PROVIDER_ID);
+    } else if (!validator.isNonEmptyString(rawId)) {
+      throw new FirebaseAuthError(AuthClientErrorCode.INVALID_UID);
     }
 
     const request = {


### PR DESCRIPTION
The previous error handling for the getAccountInfoByFederatedUid() method was misleading. In scenarios where the providerId was valid, but the uid was missing or invalid, the system would still return a "invalid-provider-id" error code. Now, the appropriate error code will be returned depending on which validation is failing.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
