### PR TITLE
[chore] Update Github action workflows to fix node version and `set-output` deprecation warnings

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -132,7 +132,7 @@ if [[ -n "${EXISTING_TAG}" ]]; then
   echo_warn "  $ git tag -d v${RELEASE_VERSION}"
   echo_warn "  $ git push --delete origin v${RELEASE_VERSION}"
 
-  readonly RELEASE_URL="https://github.com/firebase/firebase-admin-python/releases/tag/v${RELEASE_VERSION}"
+  readonly RELEASE_URL="https://github.com/firebase/firebase-admin-node/releases/tag/v${RELEASE_VERSION}"
   echo_warn "Delete any corresponding releases at ${RELEASE_URL}."
   terminate
 fi

--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -70,7 +70,7 @@ if [[ ! "${RELEASE_VERSION}" =~ ^([0-9]*)\.([0-9]*)\.([0-9]*)$ ]]; then
 fi
 
 echo_info "Extracted release version: ${RELEASE_VERSION}"
-echo "::set-output name=version::v${RELEASE_VERSION}"
+echo "version=v${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
 
 echo_info ""
@@ -132,7 +132,7 @@ if [[ -n "${EXISTING_TAG}" ]]; then
   echo_warn "  $ git tag -d v${RELEASE_VERSION}"
   echo_warn "  $ git push --delete origin v${RELEASE_VERSION}"
 
-  readonly RELEASE_URL="https://github.com/firebase/firebase-admin-node/releases/tag/v${RELEASE_VERSION}"
+  readonly RELEASE_URL="https://github.com/firebase/firebase-admin-python/releases/tag/v${RELEASE_VERSION}"
   echo_warn "Delete any corresponding releases at ${RELEASE_URL}."
   terminate
 fi
@@ -156,12 +156,13 @@ readonly CHANGELOG=`${CURRENT_DIR}/generate_changelog.sh`
 echo "$CHANGELOG"
 
 # Parse and preformat the text to handle multi-line output.
-# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+# See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+# and https://github.com/github/docs/issues/21529#issue-1418590935
 FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"` || true
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//'%'/'%25'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\n'/'%0A'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\r'/'%0D'}"
-echo "::set-output name=changelog::${FILTERED_CHANGELOG}"
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\''/'"'}"
+echo "changelog<<CHANGELOGEOF" >> $GITHUB_OUTPUT
+echo -e "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
+echo "CHANGELOGEOF" >> $GITHUB_OUTPUT
 
 
 echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install and build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 14.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     # via the 'ref' client parameter.
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
@@ -104,7 +104,7 @@ jobs:
 
     steps:
     - name: Checkout source for publish
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Download the artifacts created by the stage_release job.
     - name: Download release candidates
@@ -114,7 +114,7 @@ jobs:
 
     # Node.js and NPM are needed to complete the publish.
     - name: Set up Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 14.x
 
@@ -122,19 +122,13 @@ jobs:
       id: preflight
       run: ./.github/scripts/publish_preflight_check.sh
 
-    # We pull this action from a custom fork of a contributor until
-    # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
-    # this action does not support the "body" parameter.
+    # See: https://cli.github.com/manual/gh_release_create
     - name: Create release tag
-      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.preflight.outputs.version }}
-        release_name: Firebase Admin Node.js SDK ${{ steps.preflight.outputs.version }}
-        body: ${{ steps.preflight.outputs.changelog }}
-        draft: false
-        prerelease: false
+      run: gh release create ${{ steps.preflight.outputs.version }}
+            --title "Firebase Admin Node.js SDK ${{ steps.preflight.outputs.version }}"
+            --notes '${{ steps.preflight.outputs.changelog }}'
 
     - name: Publish to NPM
       run: ./.github/scripts/publish_package.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 14.x
 


### PR DESCRIPTION
- Swapped to Github CLI to create release tag
- `actions/checkout` v1 -> v4
- `actions/setup-node` v1 -> v4
- Replaced `set-output` with `GITHUB_OUTPUT`