### PR TITLE
issue 2467: add async to send each loop to prevent local validation f…

### DIFF
--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -294,7 +294,7 @@ export class Messaging {
 
     return this.getUrlPath()
       .then((urlPath) => {
-        const requests: Promise<SendResponse>[] = copy.map((message) => {
+        const requests: Promise<SendResponse>[] = copy.map(async (message) => {
           validateMessage(message);
           const request: { message: Message; validate_only?: boolean } = { message };
           if (dryRun) {

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -604,6 +604,19 @@ describe('Messaging', () => {
         .should.eventually.be.rejectedWith('Exactly one of topic, token or condition is required');
     });
 
+    it('should reject a message when it does not pass local validation, but still try the other messages', () => {
+      const invalidMessage: Message = { token: 'a', notification: { imageUrl: 'abc' } };
+      const messageIds = [
+        'projects/projec_id/messages/1',
+      ];
+      messageIds.forEach(id => mockedRequests.push(mockSendRequest(id)))
+      return messaging.sendEach([invalidMessage, validMessage])
+        .then((response: BatchResponse) => {
+          expect(response.successCount).to.equal(1);
+          expect(response.failureCount).to.equal(1);
+        });
+    });
+
     const invalidDryRun = [null, NaN, 0, 1, '', 'a', [], [1, 'a'], {}, { a: 1 }, _.noop];
     invalidDryRun.forEach((dryRun) => {
       it(`should throw given invalid dryRun parameter: ${JSON.stringify(dryRun)}`, () => {


### PR DESCRIPTION
### Discussion
adds async to send each loop to prevent local validation from throwing errors which could result in messages being sent and accepted by the api, while the function would still throw an error.


### Testing

adds a test with a successful message and one that does not pass local validation. Previously, this would throw an error. 
