### PR TITLE
SSRC default naming

### DIFF
--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -27,6 +27,7 @@ import { RemoteConfig } from './remote-config';
 export {
   ExplicitParameterValue,
   InAppDefaultValue,
+  InServerDefaultValue,
   ListVersionsOptions,
   ListVersionsResult,
   ParameterValueType,

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -96,11 +96,21 @@ export interface InAppDefaultValue {
 }
 
 /**
+ * Represents an in-server-default value.
+ */
+export interface InServerDefaultValue {
+  /**
+   * If `true`, `RemoteConfigServerTemplate` will use the parameter's default value.
+   */
+  useInServerDefault: boolean;
+}
+
+/**
  * Type representing a Remote Config parameter value.
  * A `RemoteConfigParameterValue` could be either an `ExplicitParameterValue` or
  * an `InAppDefaultValue`.
  */
-export type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue;
+export type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue | InServerDefaultValue;
 
 /**
  * Interface representing a Remote Config parameter.

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -28,7 +28,7 @@ import {
   RemoteConfigUser,
   Version,
   ExplicitParameterValue,
-  InAppDefaultValue,
+  InServerDefaultValue,
   ParameterValueType,
   RemoteConfigServerConfig,
   RemoteConfigServerTemplateData,
@@ -323,8 +323,8 @@ class RemoteConfigServerTemplateImpl implements RemoteConfigServerTemplate {
         continue;
       }
 
-      if ((defaultValue as InAppDefaultValue).useInAppDefault) {
-        console.log(`Filtering out parameter ${key} with "use in-app default" value`);
+      if ((defaultValue as InServerDefaultValue).useInServerDefault) {
+        console.log(`Filtering out parameter ${key} with "use in-server default" value`);
         continue;
       }
 

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -120,7 +120,7 @@ describe('RemoteConfig', () => {
     parameters: {
       holiday_promo_enabled: {
         defaultValue: { value: 'true' },
-        conditionalValues: { ios: { useInAppDefault: true } },
+        conditionalValues: { ios: { useInServerDefault: true } },
         description: 'this is a promo',
         valueType: 'BOOLEAN',
       },
@@ -580,7 +580,7 @@ describe('RemoteConfig', () => {
           const key = 'holiday_promo_enabled';
           const p1 = template.cache.parameters[key];
           expect(p1.defaultValue).deep.equals({ value: 'true' });
-          expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
+          expect(p1.conditionalValues).deep.equals({ ios: { useInServerDefault: true } });
           expect(p1.description).equals('this is a promo');
           expect(p1.valueType).equals('BOOLEAN');
 
@@ -791,7 +791,7 @@ describe('RemoteConfig', () => {
             const key = 'holiday_promo_enabled';
             const p1 = template.cache.parameters[key];
             expect(p1.defaultValue).deep.equals({ value: 'true' });
-            expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
+            expect(p1.conditionalValues).deep.equals({ ios: { useInServerDefault: true } });
             expect(p1.description).equals('this is a promo');
             expect(p1.valueType).equals('BOOLEAN');
 


### PR DESCRIPTION
Clarifies the name of in-app default when used in a server context.

This is based on PR https://github.com/firebase/firebase-admin-node/pull/2458, which defined the public API.

## Discussion

Working with @lahirumaramba and @trekforever.

## Testing

Ran npm test and all tests pass.