### PR TITLE
Remove SSRC async initializer

### DIFF
--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -24,6 +24,11 @@ export interface InAppDefaultValue {
 }
 
 // @public
+export interface InServerDefaultValue {
+    useInServerDefault: boolean;
+}
+
+// @public
 export interface ListVersionsOptions {
     endTime?: Date | string;
     endVersionNumber?: string | number;
@@ -46,7 +51,6 @@ export class RemoteConfig {
     // (undocumented)
     readonly app: App;
     createTemplateFromJSON(json: string): RemoteConfigTemplate;
-    getServerTemplate(options?: RemoteConfigServerTemplateOptions): Promise<RemoteConfigServerTemplate>;
     getTemplate(): Promise<RemoteConfigTemplate>;
     getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
     initServerTemplate(options?: RemoteConfigServerTemplateOptions): RemoteConfigServerTemplate;
@@ -84,7 +88,7 @@ export interface RemoteConfigParameterGroup {
 }
 
 // @public
-export type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue;
+export type RemoteConfigParameterValue = ExplicitParameterValue | InAppDefaultValue | InServerDefaultValue;
 
 // @public
 export interface RemoteConfigServerCondition {

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -177,16 +177,6 @@ export class RemoteConfig {
   }
 
   /**
-   * Instantiates {@link RemoteConfigServerTemplate} and then fetches and caches the latest
-   * template version of the project.
-   */
-  public async getServerTemplate(options?: RemoteConfigServerTemplateOptions): Promise<RemoteConfigServerTemplate> {
-    const template = this.initServerTemplate(options);
-    await template.load();
-    return template;
-  }
-
-  /**
    * Synchronously instantiates {@link RemoteConfigServerTemplate}.
    */
   public initServerTemplate(options?: RemoteConfigServerTemplateOptions): RemoteConfigServerTemplate {


### PR DESCRIPTION
Clarifies the name of in-app default when used in a server context.

PR https://github.com/firebase/firebase-admin-node/pull/2458 defined an async convenience method `getServerTemplate`. In practice, we find the sync alternative `initServerTemplate` much more user-friendly and use it exclusively, so this PR removes `getServerTemplate`.

### Discussion

Working with @lahirumaramba and @trekforever.

### Testing

Ran npm test and all tests pass.

Functionally tested using a local server.