### PR TITLE
[chore] Fixed links to rtdb api docs

### DIFF
--- a/docgen/extras/firebase-admin.database.md
+++ b/docgen/extras/firebase-admin.database.md
@@ -4,9 +4,9 @@ The following externally defined APIs are re-exported from this module entry poi
 
 |  Symbol | Description |
 |  --- | --- |
-|  [DataSnapshot](https://firebase.google.com/docs/reference/js/v8/firebase.database.DataSnapshot) | `DataSnapshot` type from the `@firebase/database` package. |
-|  [EventType](https://firebase.google.com/docs/reference/js/v8/firebase.database#eventtype) | `EventType` type from the `@firebase/database` package. |
-|  [OnDisconnect](https://firebase.google.com/docs/reference/js/v8/firebase.database.OnDisconnect) | `OnDisconnect` type from the `@firebase/database` package. |
-|  [Query](https://firebase.google.com/docs/reference/js/v8/firebase.database.Query) | `Query` type from the `@firebase/database` package. |
-|  [Reference](https://firebase.google.com/docs/reference/js/v8/firebase.database.Reference) | `Reference` type from the `@firebase/database` package. |
-|  [ThenableReference](https://firebase.google.com/docs/reference/js/v8/firebase.database.ThenableReference) | `ThenableReference` type from the `@firebase/database` package. |
+|  [DataSnapshot](https://firebase.google.com/docs/reference/js/v8/firebase.database.DataSnapshot) | `DataSnapshot` type from the `@firebase/database-compat` package. |
+|  [EventType](https://firebase.google.com/docs/reference/js/v8/firebase.database#eventtype) | `EventType` type from the `@firebase/database-compat` package. |
+|  [OnDisconnect](https://firebase.google.com/docs/reference/js/v8/firebase.database.OnDisconnect) | `OnDisconnect` type from the `@firebase/database-compat` package. |
+|  [Query](https://firebase.google.com/docs/reference/js/v8/firebase.database.Query) | `Query` type from the `@firebase/database-compat` package. |
+|  [Reference](https://firebase.google.com/docs/reference/js/v8/firebase.database.Reference) | `Reference` type from the `@firebase/database-compat` package. |
+|  [ThenableReference](https://firebase.google.com/docs/reference/js/v8/firebase.database.ThenableReference) | `ThenableReference` type from the `@firebase/database-compat` package. |

--- a/docgen/extras/firebase-admin.database.md
+++ b/docgen/extras/firebase-admin.database.md
@@ -4,9 +4,9 @@ The following externally defined APIs are re-exported from this module entry poi
 
 |  Symbol | Description |
 |  --- | --- |
-|  [DataSnapshot](https://firebase.google.com/docs/reference/js/database.datasnapshot) | `DataSnapshot` type from the `@firebase/database` package. |
-|  [EventType](https://firebase.google.com/docs/reference/js/database#eventtype) | `EventType` type from the `@firebase/database` package. |
-|  [OnDisconnect](https://firebase.google.com/docs/reference/js/database.ondisconnect) | `OnDisconnect` type from the `@firebase/database` package. |
-|  [Query](https://firebase.google.com/docs/reference/js/database.query) | `Query` type from the `@firebase/database` package. |
-|  [DatabaseReference](https://firebase.google.com/docs/reference/js/database.databasereference) | `DatabaseReference` type from the `@firebase/database` package. |
-|  [ThenableReference](https://firebase.google.com/docs/reference/js/database.thenablereference) | `ThenableReference` type from the `@firebase/database` package. |
+|  [DataSnapshot](https://firebase.google.com/docs/reference/js/v8/firebase.database.DataSnapshot) | `DataSnapshot` type from the `@firebase/database` package. |
+|  [EventType](https://firebase.google.com/docs/reference/js/v8/firebase.database#eventtype) | `EventType` type from the `@firebase/database` package. |
+|  [OnDisconnect](https://firebase.google.com/docs/reference/js/v8/firebase.database.OnDisconnect) | `OnDisconnect` type from the `@firebase/database` package. |
+|  [Query](https://firebase.google.com/docs/reference/js/v8/firebase.database.Query) | `Query` type from the `@firebase/database` package. |
+|  [Reference](https://firebase.google.com/docs/reference/js/v8/firebase.database.Reference) | `Reference` type from the `@firebase/database` package. |
+|  [ThenableReference](https://firebase.google.com/docs/reference/js/v8/firebase.database.ThenableReference) | `ThenableReference` type from the `@firebase/database` package. |

--- a/src/database/database-namespace.ts
+++ b/src/database/database-namespace.ts
@@ -57,49 +57,49 @@ export namespace database {
   export type Database = TDatabase;
 
   /**
-   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.DataSnapshot | DataSnapshot}
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.DataSnapshot | DataSnapshot}
    * type from the `@firebase/database` package.
    */
   export type DataSnapshot = rtdb.DataSnapshot;
 
   /**
-   * Type alias to the {@link https://firebase.google.com/docs/reference/js/firebase.database#eventtype | EventType}
+   * Type alias to the {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#eventtype | EventType}
    * type from the `@firebase/database` package.
    */
   export type EventType = rtdb.EventType;
 
   /**
-   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.OnDisconnect | OnDisconnect}
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.OnDisconnect | OnDisconnect}
    * type from the `@firebase/database` package.
    */
   export type OnDisconnect = rtdb.OnDisconnect;
 
   /**
-   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.Query | Query}
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Query | Query}
    * type from the `@firebase/database` package.
    */
   export type Query = rtdb.Query;
 
   /**
-   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.Reference | Reference}
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Reference | Reference}
    * type from the `@firebase/database` package.
    */
   export type Reference = rtdb.Reference;
 
   /**
-   * Type alias to {@link https://firebase.google.com/docs/reference/js/firebase.database.ThenableReference |
+   * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ThenableReference |
    * ThenableReference} type from the `@firebase/database` package.
    */
   export type ThenableReference = rtdb.ThenableReference;
 
   /**
-   * {@link https://firebase.google.com/docs/reference/js/firebase.database#enablelogging | enableLogging}
+   * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#enablelogging | enableLogging}
    * function from the `@firebase/database` package.
    */
   export declare const enableLogging: typeof rtdb.enableLogging;
 
   /**
-   * {@link https://firebase.google.com/docs/reference/js/firebase.database.ServerValue | ServerValue}
+   * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ServerValue | ServerValue}
    * constant from the `@firebase/database` package.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/database/database-namespace.ts
+++ b/src/database/database-namespace.ts
@@ -58,49 +58,49 @@ export namespace database {
 
   /**
    * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.DataSnapshot | DataSnapshot}
-   * type from the `@firebase/database` package.
+   * type from the `@firebase/database-compat` package.
    */
   export type DataSnapshot = rtdb.DataSnapshot;
 
   /**
    * Type alias to the {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#eventtype | EventType}
-   * type from the `@firebase/database` package.
+   * type from the `@firebase/database-compat` package.
    */
   export type EventType = rtdb.EventType;
 
   /**
    * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.OnDisconnect | OnDisconnect}
-   * type from the `@firebase/database` package.
+   * type from the `@firebase/database-compat` package.
    */
   export type OnDisconnect = rtdb.OnDisconnect;
 
   /**
    * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Query | Query}
-   * type from the `@firebase/database` package.
+   * type from the `@firebase/database-compat` package.
    */
   export type Query = rtdb.Query;
 
   /**
    * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Reference | Reference}
-   * type from the `@firebase/database` package.
+   * type from the `@firebase/database-compat` package.
    */
   export type Reference = rtdb.Reference;
 
   /**
    * Type alias to {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ThenableReference |
-   * ThenableReference} type from the `@firebase/database` package.
+   * ThenableReference} type from the `@firebase/database-compat` package.
    */
   export type ThenableReference = rtdb.ThenableReference;
 
   /**
    * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#enablelogging | enableLogging}
-   * function from the `@firebase/database` package.
+   * function from the `@firebase/database-compat` package.
    */
   export declare const enableLogging: typeof rtdb.enableLogging;
 
   /**
    * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ServerValue | ServerValue}
-   * constant from the `@firebase/database` package.
+   * constant from the `@firebase/database-compat` package.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   export declare const ServerValue: rtdb.ServerValue;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -29,7 +29,7 @@ import { getSdkVersion } from '../utils/index';
 
 /**
  * The Firebase Database service interface. Extends the
- * {@link https://firebase.google.com/docs/reference/js/firebase.database.Database | Database}
+ * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Database | Database}
  * interface provided by the `@firebase/database` package.
  */
 export interface Database extends FirebaseDatabase {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -30,7 +30,7 @@ import { getSdkVersion } from '../utils/index';
 /**
  * The Firebase Database service interface. Extends the
  * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.Database | Database}
- * interface provided by the `@firebase/database` package.
+ * interface provided by the `@firebase/database-compat` package.
  */
 export interface Database extends FirebaseDatabase {
   /**

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -44,13 +44,13 @@ export {
 
 /**
  * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#enablelogging | enableLogging}
- * function from the `@firebase/database` package.
+ * function from the `@firebase/database-compat` package.
  */
 export const enableLogging: typeof rtdb.enableLogging = enableLoggingFunc as any;
 
 /**
  * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ServerValue | ServerValue}
- * constant from the `@firebase/database` package.
+ * constant from the `@firebase/database-compat` package.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const ServerValue: rtdb.ServerValue = serverValueConst;

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -43,13 +43,13 @@ export {
 // TODO: Remove the following any-cast once the typins in @firebase/database-types are fixed.
 
 /**
- * {@link https://firebase.google.com/docs/reference/js/firebase.database#enablelogging | enableLogging}
+ * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database#enablelogging | enableLogging}
  * function from the `@firebase/database` package.
  */
 export const enableLogging: typeof rtdb.enableLogging = enableLoggingFunc as any;
 
 /**
- * {@link https://firebase.google.com/docs/reference/js/firebase.database.ServerValue | ServerValue}
+ * {@link https://firebase.google.com/docs/reference/js/v8/firebase.database.ServerValue | ServerValue}
  * constant from the `@firebase/database` package.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
Firebase Admin consumes `@firebase/database-compat` and should reference those docs.