### PR TITLE
WIP: Parse SSRC JSON strings into objects

### DIFF
--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -29,7 +29,7 @@ export {
   EvaluationContext,
   ExplicitParameterValue,
   InAppDefaultValue,
-  JSONData,
+  JSONObject,
   ListVersionsOptions,
   ListVersionsResult,
   MicroPercentRange,

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -29,6 +29,7 @@ export {
   EvaluationContext,
   ExplicitParameterValue,
   InAppDefaultValue,
+  JSONData,
   ListVersionsOptions,
   ListVersionsResult,
   MicroPercentRange,

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -537,15 +537,15 @@ export interface ListVersionsOptions {
 /**
  * Represents the configuration produced by evaluating a server template.
  */
-export type ServerConfig = { [key: string]: string | boolean | number | JSONData }
+export type ServerConfig = { [key: string]: string | boolean | number | JSONObject }
 
 /**
- * Represents parameter values of type JSON.
+ * Represents a parameter value of type JSON parsed into an object.
  */
-export type JSONData =
+export type JSONObject =
   | string
   | number
   | boolean
   | null
-  | JSONData[]
-  | {[key: string]: JSONData};
+  | JSONObject[]
+  | {[key: string]: JSONObject};

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -537,4 +537,15 @@ export interface ListVersionsOptions {
 /**
  * Represents the configuration produced by evaluating a server template.
  */
-export type ServerConfig = { [key: string]: string | boolean | number }
+export type ServerConfig = { [key: string]: string | boolean | number | JSONData }
+
+/**
+ * Represents parameter values of type JSON.
+ */
+export type JSONData =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONData[]
+  | {[key: string]: JSONData};

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -19,6 +19,7 @@ import * as validator from '../utils/validator';
 import { FirebaseRemoteConfigError, RemoteConfigApiClient } from './remote-config-api-client-internal';
 import { ConditionEvaluator } from './condition-evaluator-internal';
 import {
+  JSONData,
   ListVersionsOptions,
   ListVersionsResult,
   RemoteConfigCondition,
@@ -390,7 +391,7 @@ class ServerTemplateImpl implements ServerTemplate {
    * Private helper method that coerces a parameter value string to the {@link ParameterValueType}.
    */
   private parseRemoteConfigParameterValue(parameterType: ParameterValueType | undefined,
-    parameterValue: string): string | number | boolean {
+    parameterValue: string): string | number | boolean | JSONData {
     const BOOLEAN_TRUTHY_VALUES = ['1', 'true', 't', 'yes', 'y', 'on'];
     const DEFAULT_VALUE_FOR_NUMBER = 0;
     const DEFAULT_VALUE_FOR_STRING = '';
@@ -403,6 +404,14 @@ class ServerTemplateImpl implements ServerTemplate {
         return DEFAULT_VALUE_FOR_NUMBER;
       }
       return num;
+    } else if (parameterType === 'JSON') {
+      let parsed = {};
+      try {
+        parsed = JSON.parse(parameterValue);
+      } catch (e) {
+        // TODO: add logging once we have a wrapped logger.
+      }
+      return parsed as JSONData
     } else {
       // Treat everything else as string
       return parameterValue || DEFAULT_VALUE_FOR_STRING;

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -19,7 +19,7 @@ import * as validator from '../utils/validator';
 import { FirebaseRemoteConfigError, RemoteConfigApiClient } from './remote-config-api-client-internal';
 import { ConditionEvaluator } from './condition-evaluator-internal';
 import {
-  JSONData,
+  JSONObject,
   ListVersionsOptions,
   ListVersionsResult,
   RemoteConfigCondition,
@@ -391,7 +391,7 @@ class ServerTemplateImpl implements ServerTemplate {
    * Private helper method that coerces a parameter value string to the {@link ParameterValueType}.
    */
   private parseRemoteConfigParameterValue(parameterType: ParameterValueType | undefined,
-    parameterValue: string): string | number | boolean | JSONData {
+    parameterValue: string): string | number | boolean | JSONObject {
     const BOOLEAN_TRUTHY_VALUES = ['1', 'true', 't', 'yes', 'y', 'on'];
     const DEFAULT_VALUE_FOR_NUMBER = 0;
     const DEFAULT_VALUE_FOR_STRING = '';
@@ -411,7 +411,7 @@ class ServerTemplateImpl implements ServerTemplate {
       } catch (e) {
         // TODO: add logging once we have a wrapped logger.
       }
-      return parsed as JSONData
+      return parsed as JSONObject
     } else {
       // Treat everything else as string
       return parameterValue || DEFAULT_VALUE_FOR_STRING;

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -924,7 +924,12 @@ describe('RemoteConfig', () => {
             expect(config.dog_type).to.equal('corgi');
             expect(config.dog_type_enabled).to.equal(true);
             expect(config.dog_age).to.equal(22);
-            expect(config.dog_jsonified).to.equal('{"name":"Taro","breed":"Corgi","age":1,"fluffiness":100}');
+            expect(config.dog_jsonified).to.deep.equal({
+              name: 'Taro',
+              breed: 'Corgi',
+              age: 1,
+              fluffiness: 100
+            });
           });
       });
 


### PR DESCRIPTION
### Discussion

As discussed with the API council, this change parses JSON string values into objects for convenience.

Given an interface:
```
interface GameConfig {
  user_level: number;
};
```

Instead of this:
```
let gameConfig: GameConfig = {};
try {
  gameConfig = JSON.parse(config.game_config_json as string);
} catch (e) { ... }

if (gameConfig.user_level > 10) { ... }
```

We can do this:
```
const gameConfig = config.game_config_json as unknown as GameConfig;

if (gameConfig.user_level > 10) { ... }
```

### Testing

Ran npm test and all tests pass.

Functionally tested using a local server.

### API Changes

Add `JSONObject` to RC API.
