### PR TITLE
Differentiate options for sync and async SSRC initialization

### DIFF
--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -29,8 +29,19 @@ export interface ExplicitParameterValue {
 export function getRemoteConfig(app?: App): RemoteConfig;
 
 // @public
+export interface GetServerTemplateOptions {
+    defaultConfig?: ServerConfig;
+}
+
+// @public
 export interface InAppDefaultValue {
     useInAppDefault: boolean;
+}
+
+// @public
+export interface InitServerTemplateOptions {
+    defaultConfig?: ServerConfig;
+    template?: ServerTemplateData;
 }
 
 // @public
@@ -98,10 +109,10 @@ export class RemoteConfig {
     // (undocumented)
     readonly app: App;
     createTemplateFromJSON(json: string): RemoteConfigTemplate;
-    getServerTemplate(options?: ServerTemplateOptions): Promise<ServerTemplate>;
+    getServerTemplate(options?: GetServerTemplateOptions): Promise<ServerTemplate>;
     getTemplate(): Promise<RemoteConfigTemplate>;
     getTemplateAtVersion(versionNumber: number | string): Promise<RemoteConfigTemplate>;
-    initServerTemplate(options?: ServerTemplateOptions): ServerTemplate;
+    initServerTemplate(options?: InitServerTemplateOptions): ServerTemplate;
     listVersions(options?: ListVersionsOptions): Promise<ListVersionsResult>;
     publishTemplate(template: RemoteConfigTemplate, options?: {
         force: boolean;
@@ -179,12 +190,6 @@ export interface ServerTemplateData {
         [key: string]: RemoteConfigParameter;
     };
     version?: Version;
-}
-
-// @public
-export interface ServerTemplateOptions {
-    defaultConfig?: ServerConfig;
-    template?: ServerTemplateData;
 }
 
 // @public

--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -39,8 +39,7 @@ export interface InAppDefaultValue {
 }
 
 // @public
-export interface InitServerTemplateOptions {
-    defaultConfig?: ServerConfig;
+export interface InitServerTemplateOptions extends GetServerTemplateOptions {
     template?: ServerTemplateData;
 }
 

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -28,7 +28,9 @@ export {
   AndCondition,
   EvaluationContext,
   ExplicitParameterValue,
+  GetServerTemplateOptions,
   InAppDefaultValue,
+  InitServerTemplateOptions,
   ListVersionsOptions,
   ListVersionsResult,
   MicroPercentRange,
@@ -47,7 +49,6 @@ export {
   ServerConfig,
   ServerTemplate,
   ServerTemplateData,
-  ServerTemplateOptions,
   TagColor,
   Version,
 } from './remote-config-api';

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -354,7 +354,21 @@ export interface ServerTemplateData {
 /**
  * Represents optional arguments that can be used when instantiating {@link ServerTemplate}.
  */
-export interface ServerTemplateOptions {
+export interface GetServerTemplateOptions {
+
+  /**
+   * Defines in-app default parameter values, so that your app behaves as
+   * intended before it connects to the Remote Config backend, and so that
+   * default values are available if none are set on the backend.
+   */
+  defaultConfig?: ServerConfig,
+}
+
+/**
+ * Represents optional arguments that can be used when instantiating
+ * {@link ServerTemplate} synchonously.
+ */
+export interface InitServerTemplateOptions {
 
   /**
    * Defines in-app default parameter values, so that your app behaves as

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -368,14 +368,7 @@ export interface GetServerTemplateOptions {
  * Represents optional arguments that can be used when instantiating
  * {@link ServerTemplate} synchonously.
  */
-export interface InitServerTemplateOptions {
-
-  /**
-   * Defines in-app default parameter values, so that your app behaves as
-   * intended before it connects to the Remote Config backend, and so that
-   * default values are available if none are set on the backend.
-   */
-  defaultConfig?: ServerConfig,
+export interface InitServerTemplateOptions extends GetServerTemplateOptions {
 
   /**
    * Enables integrations to use template data loaded independently. For

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -35,8 +35,9 @@ import {
   RemoteConfigParameterValue,
   EvaluationContext,
   ServerTemplateData,
-  ServerTemplateOptions,
   NamedCondition,
+  GetServerTemplateOptions,
+  InitServerTemplateOptions,
 } from './remote-config-api';
 
 /**
@@ -184,7 +185,7 @@ export class RemoteConfig {
    * Instantiates {@link ServerTemplate} and then fetches and caches the latest
    * template version of the project.
    */
-  public async getServerTemplate(options?: ServerTemplateOptions): Promise<ServerTemplate> {
+  public async getServerTemplate(options?: GetServerTemplateOptions): Promise<ServerTemplate> {
     const template = this.initServerTemplate(options);
     await template.load();
     return template;
@@ -193,7 +194,7 @@ export class RemoteConfig {
   /**
    * Synchronously instantiates {@link ServerTemplate}.
    */
-  public initServerTemplate(options?: ServerTemplateOptions): ServerTemplate {
+  public initServerTemplate(options?: InitServerTemplateOptions): ServerTemplate {
     const template = new ServerTemplateImpl(
       this.client, new ConditionEvaluator(), options?.defaultConfig);
     if (options?.template) {


### PR DESCRIPTION
### Discussion

It doesn't make sense to pass a cached template to `getServerTemplate` because the method loads a new template immediately.

I see a recommendation to define distinct interfaces for method options: https://github.com/microsoft/tsdoc/issues/19.

So, this change splits `ServerTemplateOptions` into `GetServerTemplateOptions` and `InitServerTemplateOptions`.

### Testing

Tested with `npm test`.

### API Changes

Splits `ServerTemplateOptions` into `GetServerTemplateOptions` and `InitServerTemplateOptions`.