### PR TITLE
Add functionality to accept a JSON template string when initializing a RC server template

### DIFF
--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -40,7 +40,7 @@ export interface InAppDefaultValue {
 
 // @public
 export interface InitServerTemplateOptions extends GetServerTemplateOptions {
-    template?: ServerTemplateData;
+    template?: ServerTemplateData | string;
 }
 
 // @public
@@ -178,6 +178,7 @@ export interface ServerTemplate {
     cache: ServerTemplateData;
     evaluate(context?: EvaluationContext): ServerConfig;
     load(): Promise<void>;
+    toJSON(): string;
 }
 
 // @public

--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -178,7 +178,6 @@ export interface ServerTemplate {
     cache: ServerTemplateData;
     evaluate(context?: EvaluationContext): ServerConfig;
     load(): Promise<void>;
-    toJSON(): string;
 }
 
 // @public

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -354,7 +354,7 @@ export interface ServerTemplateData {
 /**
  * Represents optional arguments that can be used when instantiating {@link ServerTemplate}.
  */
-export interface GetServerTemplateOptions {
+export interface ServerTemplateOptions {
 
   /**
    * Defines in-app default parameter values, so that your app behaves as
@@ -362,13 +362,6 @@ export interface GetServerTemplateOptions {
    * default values are available if none are set on the backend.
    */
   defaultConfig?: ServerConfig,
-}
-
-/**
- * Represents optional arguments that can be used when instantiating
- * {@link ServerTemplate} synchonously.
- */
-export interface InitServerTemplateOptions extends GetServerTemplateOptions {
 
   /**
    * Enables integrations to use template data loaded independently. For
@@ -376,7 +369,7 @@ export interface InitServerTemplateOptions extends GetServerTemplateOptions {
    * caching template data and then using this option to initialize the SDK with
    * that data.
    */
-  template?: ServerTemplateData,
+  template?: ServerTemplateData|string,
 }
 
 /**
@@ -390,6 +383,11 @@ export interface ServerTemplate {
   cache: ServerTemplateData;
 
   /**
+   * A {@link ServerConfig} that contains default Config values.
+   */
+  defaultConfig: ServerConfig;
+
+  /**
    * Evaluates the current template to produce a {@link ServerConfig}.
    */
   evaluate(context?: EvaluationContext): ServerConfig;
@@ -399,6 +397,12 @@ export interface ServerTemplate {
    * project's {@link ServerTemplate}.
    */
   load(): Promise<void>;
+
+  /** 
+   * Convenient method that returns the JSON string of the cached template data
+   * @returns A JSON-string of this object.
+   */
+  toJSON(): string;
 }
 
 /**

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -399,12 +399,6 @@ export interface ServerTemplate {
    * project's {@link ServerTemplate}.
    */
   load(): Promise<void>;
-
-  /** 
-   * Convenient method that returns the JSON string of the cached template data
-   * @returns A JSON-string of this object.
-   */
-  toJSON(): string;
 }
 
 /**

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -375,6 +375,8 @@ export interface InitServerTemplateOptions extends GetServerTemplateOptions {
    * example, customers can reduce initialization latency by pre-fetching and
    * caching template data and then using this option to initialize the SDK with
    * that data.
+   * The template can be initialized with either a {@link ServerTemplateData}
+   * object or a JSON string.
    */
   template?: ServerTemplateData|string,
 }

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -354,7 +354,7 @@ export interface ServerTemplateData {
 /**
  * Represents optional arguments that can be used when instantiating {@link ServerTemplate}.
  */
-export interface ServerTemplateOptions {
+export interface GetServerTemplateOptions {
 
   /**
    * Defines in-app default parameter values, so that your app behaves as
@@ -362,6 +362,13 @@ export interface ServerTemplateOptions {
    * default values are available if none are set on the backend.
    */
   defaultConfig?: ServerConfig,
+}
+
+/**
+ * Represents optional arguments that can be used when instantiating
+ * {@link ServerTemplate} synchonously.
+ */
+export interface InitServerTemplateOptions extends GetServerTemplateOptions {
 
   /**
    * Enables integrations to use template data loaded independently. For
@@ -381,11 +388,6 @@ export interface ServerTemplate {
    * Cached {@link ServerTemplateData}.
    */
   cache: ServerTemplateData;
-
-  /**
-   * A {@link ServerConfig} that contains default Config values.
-   */
-  defaultConfig: ServerConfig;
 
   /**
    * Evaluates the current template to produce a {@link ServerConfig}.

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -186,7 +186,7 @@ export class RemoteConfig {
    * Instantiates {@link ServerTemplate} and then fetches and caches the latest
    * template version of the project.
    */
-  public async getServerTemplate(options?: ServerTemplateOptions): Promise<ServerTemplate> {
+  public async getServerTemplate(options?: GetServerTemplateOptions): Promise<ServerTemplate> {
     const template = this.initServerTemplate(options);
     await template.load();
     return template;
@@ -195,24 +195,10 @@ export class RemoteConfig {
   /**
    * Synchronously instantiates {@link ServerTemplate}.
    */
-  public initServerTemplate(options?: ServerTemplateOptions): ServerTemplate {
+  public initServerTemplate(options?: InitServerTemplateOptions): ServerTemplate {
     const template = new ServerTemplateImpl(
       this.client, new ConditionEvaluator(), options?.defaultConfig);
     if (options?.template) {
-      // Check and instantiates via json string
-      if (isString(options?.template)) {
-        try {
-          template.cache = new ServerTemplateDataImpl(JSON.parse(options?.template));
-        } catch (e) {
-          throw new FirebaseRemoteConfigError(
-            'invalid-argument',
-            `Failed to parse the JSON string: ${options?.template}. ` + e
-          );
-        }
-      } else {
-        // check and instantiates via ServerTemplateData
-        template.cache = options?.template;
-      }
       // Check and instantiates via json string
       if (isString(options?.template)) {
         try {
@@ -325,7 +311,7 @@ class ServerTemplateImpl implements ServerTemplate {
   constructor(
     private readonly apiClient: RemoteConfigApiClient,
     private readonly conditionEvaluator: ConditionEvaluator,
-    public readonly defaultConfig: ServerConfig = {}
+    private readonly defaultConfig: ServerConfig = {}
   ) { }
 
   /**
@@ -413,14 +399,6 @@ class ServerTemplateImpl implements ServerTemplate {
     };
 
     return new Proxy(mergedConfig, proxyHandler);
-  }
-
-  /** 
-   * Convenient method that returns the JSON string of the cached template data
-   * @returns A JSON-string of this object.
-   */
-  public toJSON(): string {
-    return JSON.stringify(this.cache);
   }
 
   /** 

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -35,9 +35,9 @@ import {
   RemoteConfigParameterValue,
   EvaluationContext,
   ServerTemplateData,
+  NamedCondition,
   GetServerTemplateOptions,
   InitServerTemplateOptions,
-  NamedCondition,
 } from './remote-config-api';
 import { isString } from 'lodash';
 

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -400,14 +400,6 @@ class ServerTemplateImpl implements ServerTemplate {
     return new Proxy(mergedConfig, proxyHandler);
   }
 
-  /** 
-   * Convenient method that returns the JSON string of the cached template data
-   * @returns A JSON-string of this object.
-   */
-  public toJSON(): string {
-    return JSON.stringify(this.cache);
-  }
-
   /**
    * Private helper method that coerces a parameter value string to the {@link ParameterValueType}.
    */

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -199,7 +199,7 @@ export class RemoteConfig {
     const template = new ServerTemplateImpl(
       this.client, new ConditionEvaluator(), options?.defaultConfig);
     if (options?.template) {
-      // Check and instantiates via json string
+      // Check and instantiates the template via a json string
       if (isString(options?.template)) {
         try {
           template.cache = new ServerTemplateDataImpl(JSON.parse(options?.template));
@@ -210,7 +210,6 @@ export class RemoteConfig {
           );
         }
       } else {
-        // check and instantiates via ServerTemplateData
         template.cache = options?.template;
       }
     }

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -649,7 +649,7 @@ describe('RemoteConfig', () => {
         }
       };
       const initializedTemplate = remoteConfig.initServerTemplate({ template });
-      const parsed = JSON.parse(initializedTemplate.toJSON());
+      const parsed = JSON.parse(JSON.stringify(initializedTemplate.cache));
       expect(parsed).deep.equals(deepCopy(template));
     });
 
@@ -666,7 +666,7 @@ describe('RemoteConfig', () => {
       };
       const templateJson = JSON.stringify(template);
       const initializedTemplate = remoteConfig.initServerTemplate({ template: templateJson });
-      const parsed = JSON.parse(initializedTemplate.toJSON());
+      const parsed = JSON.parse(JSON.stringify(initializedTemplate.cache));
       const expectedVersion = deepCopy(VERSION_INFO);
       expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
       template.version = expectedVersion as Version;


### PR DESCRIPTION
### Discussion
During testing, we commonly stored a template as JSON. It was then inconvenient to parse that into an object of a specific type (TemplateData) just to accommodate the type expected by the option. 

This change updates `initServerTemplate` to also accept a JSON string, in addition to the existing ServerTemplateData.

### Testing

Unit tested via npm test

### API Changes

The `InitServerTemplateOptions.template` now accepts a union type `ServerTemplateData|string` instead of just `ServerTemplateData`
