### PR TITLE
Add #set and #toJSON to RC ServerTemplate

### DIFF
--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -183,9 +183,10 @@ export interface ServerConfig {
 
 // @public
 export interface ServerTemplate {
-    cache: ServerTemplateData;
     evaluate(context?: EvaluationContext): ServerConfig;
     load(): Promise<void>;
+    set(template: ServerTemplateData | string): void;
+    toJSON(): ServerTemplateData;
 }
 
 // @public

--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -45,7 +45,8 @@ export interface InAppDefaultValue {
 
 // @public
 export interface InitServerTemplateOptions extends GetServerTemplateOptions {
-    template?: ServerTemplateData | string;
+    // Warning: (ae-forgotten-export) The symbol "ServerTemplateDataType" needs to be exported by the entry point index.d.ts
+    template?: ServerTemplateDataType;
 }
 
 // @public
@@ -185,7 +186,7 @@ export interface ServerConfig {
 export interface ServerTemplate {
     evaluate(context?: EvaluationContext): ServerConfig;
     load(): Promise<void>;
-    set(template: ServerTemplateData | string): void;
+    set(template: ServerTemplateDataType): void;
     toJSON(): ServerTemplateData;
 }
 

--- a/etc/firebase-admin.remote-config.api.md
+++ b/etc/firebase-admin.remote-config.api.md
@@ -45,7 +45,6 @@ export interface InAppDefaultValue {
 
 // @public
 export interface InitServerTemplateOptions extends GetServerTemplateOptions {
-    // Warning: (ae-forgotten-export) The symbol "ServerTemplateDataType" needs to be exported by the entry point index.d.ts
     template?: ServerTemplateDataType;
 }
 
@@ -199,6 +198,9 @@ export interface ServerTemplateData {
     };
     version?: Version;
 }
+
+// @public
+export type ServerTemplateDataType = ServerTemplateData | string;
 
 // @public
 export type TagColor = 'BLUE' | 'BROWN' | 'CYAN' | 'DEEP_ORANGE' | 'GREEN' | 'INDIGO' | 'LIME' | 'ORANGE' | 'PINK' | 'PURPLE' | 'TEAL';

--- a/src/remote-config/index.ts
+++ b/src/remote-config/index.ts
@@ -50,6 +50,7 @@ export {
   ServerConfig,
   ServerTemplate,
   ServerTemplateData,
+  ServerTemplateDataType,
   TagColor,
   Value,
   ValueSource,

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -365,6 +365,13 @@ export interface GetServerTemplateOptions {
 }
 
 /**
+ * Represents the type of a Remote Config server template that can be set on
+ * {@link ServerTemplate}. This can either be a {@link ServerTemplateData} object
+ * or a template JSON string.
+ */
+export type ServerTemplateDataType = ServerTemplateData | string;
+
+/**
  * Represents optional arguments that can be used when instantiating
  * {@link ServerTemplate} synchonously.
  */
@@ -378,13 +385,6 @@ export interface InitServerTemplateOptions extends GetServerTemplateOptions {
    */
   template?: ServerTemplateDataType,
 }
-
-/**
- * Represents the type of a Remote Config server template that can be set on
- * {@link ServerTemplate}. This can either be a {@link ServerTemplateData} object
- * or a template JSON string.
- */
-export type ServerTemplateDataType = ServerTemplateData | string;
 
 /**
  * Represents a stateful abstraction for a Remote Config server template.

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -385,12 +385,6 @@ export interface InitServerTemplateOptions extends GetServerTemplateOptions {
  * Represents a stateful abstraction for a Remote Config server template.
  */
 export interface ServerTemplate {
-
-  /**
-   * Cached {@link ServerTemplateData}.
-   */
-  cache: ServerTemplateData;
-
   /**
    * Evaluates the current template to produce a {@link ServerConfig}.
    */
@@ -401,6 +395,17 @@ export interface ServerTemplate {
    * project's {@link ServerTemplate}.
    */
   load(): Promise<void>;
+
+  /**
+   * Sets and caches a {@link ServerTemplateData} or a JSON string representing
+   * the server template
+   */
+  set(template: ServerTemplateData | string): void;
+
+  /**
+   * Returns a JSON representation of {@link ServerTemplateData}
+   */
+  toJSON(): ServerTemplateData;
 }
 
 /**

--- a/src/remote-config/remote-config-api.ts
+++ b/src/remote-config/remote-config-api.ts
@@ -375,11 +375,16 @@ export interface InitServerTemplateOptions extends GetServerTemplateOptions {
    * example, customers can reduce initialization latency by pre-fetching and
    * caching template data and then using this option to initialize the SDK with
    * that data.
-   * The template can be initialized with either a {@link ServerTemplateData}
-   * object or a JSON string.
    */
-  template?: ServerTemplateData|string,
+  template?: ServerTemplateDataType,
 }
+
+/**
+ * Represents the type of a Remote Config server template that can be set on
+ * {@link ServerTemplate}. This can either be a {@link ServerTemplateData} object
+ * or a template JSON string.
+ */
+export type ServerTemplateDataType = ServerTemplateData | string;
 
 /**
  * Represents a stateful abstraction for a Remote Config server template.
@@ -400,7 +405,7 @@ export interface ServerTemplate {
    * Sets and caches a {@link ServerTemplateData} or a JSON string representing
    * the server template
    */
-  set(template: ServerTemplateData | string): void;
+  set(template: ServerTemplateDataType): void;
 
   /**
    * Returns a JSON representation of {@link ServerTemplateData}

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -40,6 +40,7 @@ import {
   DefaultConfig,
   GetServerTemplateOptions,
   InitServerTemplateOptions,
+  ServerTemplateDataType,
 } from './remote-config-api';
 import { isString } from 'lodash';
 
@@ -326,19 +327,22 @@ class ServerTemplateImpl implements ServerTemplate {
    * Takes in either a {@link ServerTemplateData} or a JSON string
    * representing the template, parses it, and caches it.
    */
-  public set(template: ServerTemplateData | string): void {
+  public set(template: ServerTemplateDataType): void {
+    let parsed;
     if (isString(template)) {
       try {
-        this.cache = new ServerTemplateDataImpl(JSON.parse(template));
+        parsed = JSON.parse(template);
       } catch (e) {
+        // Transforms JSON parse errors to Firebase error.
         throw new FirebaseRemoteConfigError(
           'invalid-argument',
-          `Failed to parse the JSON string: ${template}. ` + e
-        );
+          `Failed to parse the JSON string: ${template}. ` + e);
       }
     } else {
-      this.cache = template;
+      parsed = template;
     }
+    // Throws template parse errors.
+    this.cache = new ServerTemplateDataImpl(parsed);
   }
 
   /**

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -198,26 +198,11 @@ export class RemoteConfig {
    * Synchronously instantiates {@link ServerTemplate}.
    */
   public initServerTemplate(options?: InitServerTemplateOptions): ServerTemplate {
-    let template = new ServerTemplateImpl(
+    const template = new ServerTemplateImpl(
       this.client, new ConditionEvaluator(), options?.defaultConfig);
 
     if (options?.template) {
-      if (isString(options.template)) {
-        // Check and instantiates the template via a json string
-        try {
-          template = new ServerTemplateImpl(
-            this.client, new ConditionEvaluator(), options?.defaultConfig,
-            new ServerTemplateDataImpl(JSON.parse(options?.template)));
-        } catch (e) {
-          throw new FirebaseRemoteConfigError(
-            'invalid-argument',
-            `Failed to parse the JSON string: ${template}. ` + e
-          );
-        }
-      } else {
-        template = new ServerTemplateImpl(
-          this.client, new ConditionEvaluator(), options?.defaultConfig, new ServerTemplateDataImpl(options?.template));
-      }
+      template.set(options?.template);
     }
     return template;
   }
@@ -317,11 +302,8 @@ class ServerTemplateImpl implements ServerTemplate {
   constructor(
     private readonly apiClient: RemoteConfigApiClient,
     private readonly conditionEvaluator: ConditionEvaluator,
-    public readonly defaultConfig: DefaultConfig = {},
-    template?: ServerTemplateData
+    public readonly defaultConfig: DefaultConfig = {}
   ) {
-    if (template) { this.cache = template; }
-
     // RC stores all remote values as string, but it's more intuitive
     // to declare default values with specific types, so this converts
     // the external declaration to an internal string representation.

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -324,8 +324,7 @@ class ServerTemplateImpl implements ServerTemplate {
   }
 
   /**
-   * Takes in either a {@link ServerTemplateData} or a JSON string
-   * representing the template, parses it, and caches it.
+   * Parses a {@link ServerTemplateDataType} and caches it.
    */
   public set(template: ServerTemplateDataType): void {
     let parsed;

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -596,7 +596,7 @@ describe('RemoteConfig', () => {
           const cond = c as NamedCondition;
           expect(cond.name).to.equal('ios');
 
-          const parsed = JSON.parse(JSON.stringify(template.toJSON()));
+          const parsed = template.toJSON();
           const expectedTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
           const expectedVersion = deepCopy(VERSION_INFO);
           expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
@@ -866,7 +866,7 @@ describe('RemoteConfig', () => {
               }
             });
 
-            const parsed = JSON.parse(JSON.stringify(template.toJSON()));
+            const parsed = template.toJSON();
             const expectedTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
             const expectedVersion = deepCopy(VERSION_INFO);
             expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();

--- a/test/unit/remote-config/remote-config.spec.ts
+++ b/test/unit/remote-config/remote-config.spec.ts
@@ -572,11 +572,11 @@ describe('RemoteConfig', () => {
 
       return remoteConfig.getServerTemplate()
         .then((template) => {
-          expect(template.cache.conditions.length).to.equal(1);
-          expect(template.cache.conditions[0].name).to.equal('ios');
-          expect(template.cache.etag).to.equal('etag-123456789012-5');
+          expect(template.toJSON().conditions.length).to.equal(1);
+          expect(template.toJSON().conditions[0].name).to.equal('ios');
+          expect(template.toJSON().etag).to.equal('etag-123456789012-5');
 
-          const version = template.cache.version!;
+          const version = template.toJSON().version!;
           expect(version.versionNumber).to.equal('86');
           expect(version.updateOrigin).to.equal('ADMIN_SDK_NODE');
           expect(version.updateType).to.equal('INCREMENTAL_UPDATE');
@@ -587,16 +587,16 @@ describe('RemoteConfig', () => {
           expect(version.updateTime).to.equal('Mon, 15 Jun 2020 16:45:03 GMT');
 
           const key = 'holiday_promo_enabled';
-          const p1 = template.cache.parameters[key];
+          const p1 = template.toJSON().parameters[key];
           expect(p1.defaultValue).deep.equals({ value: 'true' });
           expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
 
-          const c = template.cache.conditions.find((c) => c.name === 'ios');
+          const c = template.toJSON().conditions.find((c) => c.name === 'ios');
           expect(c).to.be.not.undefined;
           const cond = c as NamedCondition;
           expect(cond.name).to.equal('ios');
 
-          const parsed = JSON.parse(JSON.stringify(template.cache));
+          const parsed = JSON.parse(JSON.stringify(template.toJSON()));
           const expectedTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
           const expectedVersion = deepCopy(VERSION_INFO);
           expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
@@ -643,7 +643,10 @@ describe('RemoteConfig', () => {
         }
       };
       const initializedTemplate = remoteConfig.initServerTemplate({ template });
-      const parsed = JSON.parse(JSON.stringify(initializedTemplate.cache));
+      const parsed = initializedTemplate.toJSON();
+      const expectedVersion = deepCopy(VERSION_INFO);
+      expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
+      template.version = expectedVersion as Version;
       expect(parsed).deep.equals(deepCopy(template));
     });
 
@@ -660,7 +663,7 @@ describe('RemoteConfig', () => {
       };
       const templateJson = JSON.stringify(template);
       const initializedTemplate = remoteConfig.initServerTemplate({ template: templateJson });
-      const parsed = JSON.parse(JSON.stringify(initializedTemplate.cache));
+      const parsed = initializedTemplate.toJSON();
       const expectedVersion = deepCopy(VERSION_INFO);
       expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
       template.version = expectedVersion as Version;
@@ -798,7 +801,7 @@ describe('RemoteConfig', () => {
         return remoteConfig.getServerTemplate()
           .then((template) => {
             // If parameters are not present in the response, we set it to an empty object.
-            expect(template.cache.parameters).deep.equals({});
+            expect(template.toJSON().parameters).deep.equals({});
           });
       });
 
@@ -812,7 +815,7 @@ describe('RemoteConfig', () => {
         return remoteConfig.getServerTemplate()
           .then((template) => {
             // If conditions are not present in the response, we set it to an empty array.
-            expect(template.cache.conditions).deep.equals([]);
+            expect(template.toJSON().conditions).deep.equals([]);
           });
       });
 
@@ -824,11 +827,11 @@ describe('RemoteConfig', () => {
 
         return remoteConfig.getServerTemplate()
           .then((template) => {
-            expect(template.cache.conditions.length).to.equal(1);
-            expect(template.cache.conditions[0].name).to.equal('ios');
-            expect(template.cache.etag).to.equal('etag-123456789012-5');
+            expect(template.toJSON().conditions.length).to.equal(1);
+            expect(template.toJSON().conditions[0].name).to.equal('ios');
+            expect(template.toJSON().etag).to.equal('etag-123456789012-5');
 
-            const version = template.cache.version!;
+            const version = template.toJSON().version!;
             expect(version.versionNumber).to.equal('86');
             expect(version.updateOrigin).to.equal('ADMIN_SDK_NODE');
             expect(version.updateType).to.equal('INCREMENTAL_UPDATE');
@@ -839,11 +842,11 @@ describe('RemoteConfig', () => {
             expect(version.updateTime).to.equal('Mon, 15 Jun 2020 16:45:03 GMT');
 
             const key = 'holiday_promo_enabled';
-            const p1 = template.cache.parameters[key];
+            const p1 = template.toJSON().parameters[key];
             expect(p1.defaultValue).deep.equals({ value: 'true' });
             expect(p1.conditionalValues).deep.equals({ ios: { useInAppDefault: true } });
 
-            const c = template.cache.conditions.find((c) => c.name === 'ios');
+            const c = template.toJSON().conditions.find((c) => c.name === 'ios');
             expect(c).to.be.not.undefined;
             const cond = c as NamedCondition;
             expect(cond.name).to.equal('ios');
@@ -863,7 +866,7 @@ describe('RemoteConfig', () => {
               }
             });
 
-            const parsed = JSON.parse(JSON.stringify(template.cache));
+            const parsed = JSON.parse(JSON.stringify(template.toJSON()));
             const expectedTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
             const expectedVersion = deepCopy(VERSION_INFO);
             expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
@@ -884,9 +887,9 @@ describe('RemoteConfig', () => {
 
         return remoteConfig.getServerTemplate()
           .then((template) => {
-            expect(template.cache.etag).to.equal('etag-123456789012-5');
+            expect(template.toJSON().etag).to.equal('etag-123456789012-5');
 
-            const version = template.cache.version!;
+            const version = template.toJSON().version!;
             expect(version.versionNumber).to.equal('86');
             expect(version.updateOrigin).to.equal('ADMIN_SDK_NODE');
             expect(version.updateType).to.equal('INCREMENTAL_UPDATE');
@@ -910,9 +913,9 @@ describe('RemoteConfig', () => {
 
         return remoteConfig.getServerTemplate()
           .then((template) => {
-            expect(template.cache.etag).to.equal('etag-123456789012-5');
+            expect(template.toJSON().etag).to.equal('etag-123456789012-5');
 
-            const version = template.cache.version!;
+            const version = template.toJSON().version!;
             expect(version.versionNumber).to.equal('86');
             expect(version.updateOrigin).to.equal('ADMIN_SDK_NODE');
             expect(version.updateType).to.equal('INCREMENTAL_UPDATE');
@@ -936,9 +939,9 @@ describe('RemoteConfig', () => {
 
         return remoteConfig.getServerTemplate()
           .then((template) => {
-            expect(template.cache.etag).to.equal('etag-123456789012-5');
+            expect(template.toJSON().etag).to.equal('etag-123456789012-5');
 
-            const version = template.cache.version!;
+            const version = template.toJSON().version!;
             expect(version.versionNumber).to.equal('86');
             expect(version.updateOrigin).to.equal('ADMIN_SDK_NODE');
             expect(version.updateType).to.equal('INCREMENTAL_UPDATE');
@@ -949,6 +952,82 @@ describe('RemoteConfig', () => {
             expect(version.updateTime).to.equal('Sun, 15 Nov 2020 06:57:26 GMT');
           });
       });
+    });
+
+    describe('set', () => {
+      const INVALID_PARAMETERS: any[] = [null, '', 'abc', 1, true, []];
+      const INVALID_CONDITIONS: any[] = [null, '', 'abc', 1, true, {}];
+      let sourceTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
+
+      it('should set template when passed', () => {
+        const template = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE) as ServerTemplateData;
+        template.parameters = {
+          dog_type: {
+            defaultValue: {
+              value: 'shiba'
+            },
+            description: 'Type of dog breed',
+            valueType: 'STRING'
+          }
+        };
+        const initializedTemplate = remoteConfig.initServerTemplate();
+        initializedTemplate.set(template);
+        const parsed = initializedTemplate.toJSON();
+        const expectedVersion = deepCopy(VERSION_INFO);
+        expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
+        template.version = expectedVersion as Version;
+        expect(parsed).deep.equals(deepCopy(template));
+      });
+
+      it('should set and instantiates template when json string is passed', () => {
+        const template = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE) as ServerTemplateData;
+        template.parameters = {
+          dog_type: {
+            defaultValue: {
+              value: 'shiba'
+            },
+            description: 'Type of dog breed',
+            valueType: 'STRING'
+          }
+        };
+        const templateJson = JSON.stringify(template);
+        const initializedTemplate = remoteConfig.initServerTemplate();
+        initializedTemplate.set(templateJson);
+        const parsed = initializedTemplate.toJSON();
+        const expectedVersion = deepCopy(VERSION_INFO);
+        expectedVersion.updateTime = new Date(expectedVersion.updateTime).toUTCString();
+        template.version = expectedVersion as Version;
+        expect(parsed).deep.equals(deepCopy(template));
+      });
+
+      it('should throw if template is an invalid JSON', () => {
+        const jsonString = '{invalidJson: null}';
+        const initializedTemplate = remoteConfig.initServerTemplate();
+        expect(() => initializedTemplate.set(jsonString))
+          .to.throw(/Failed to parse the JSON string: ([\D\w]*)\./);
+      });
+
+      INVALID_PARAMETERS.forEach((invalidParameter) => {
+        sourceTemplate.parameters = invalidParameter;
+        it(`should throw if the parameters is ${JSON.stringify(invalidParameter)}`, () => {
+          const jsonString = JSON.stringify(sourceTemplate);
+          const initializedTemplate = remoteConfig.initServerTemplate();
+          expect(() => initializedTemplate.set(jsonString))
+            .to.throw(/Failed to parse the JSON string: ([\D\w]*)\./);
+        });
+      });
+
+      sourceTemplate = deepCopy(SERVER_REMOTE_CONFIG_RESPONSE);
+      INVALID_CONDITIONS.forEach((invalidConditions) => {
+        sourceTemplate.conditions = invalidConditions;
+        it(`should throw if the conditions is ${JSON.stringify(invalidConditions)}`, () => {
+          const jsonString = JSON.stringify(sourceTemplate);
+          const initializedTemplate = remoteConfig.initServerTemplate();
+          expect(() => initializedTemplate.set(jsonString))
+            .to.throw(/Failed to parse the JSON string: ([\D\w]*)\./);
+        });
+      });
+
     });
 
     describe('evaluate', () => {
@@ -1151,7 +1230,7 @@ describe('RemoteConfig', () => {
           },
         }
 
-        template.cache = response as ServerTemplateData;
+        template.set(response as ServerTemplateData);
 
         let config = template.evaluate();
 
@@ -1165,7 +1244,7 @@ describe('RemoteConfig', () => {
           },
         }
 
-        template.cache = response as ServerTemplateData;
+        template.set(response as ServerTemplateData);
 
         config = template.evaluate();
 


### PR DESCRIPTION
### Discussion

Right now, we can set a RC server template via the constructor. Customers, however, would need to update the template multiple times. The current API exposes `template.cache`, but that feels more like an internal detail than an API now.

* Mark `ServerTemplate.cache` as `private`, and should only be used with-in the class
* Add a new `ServerTemplate.set` to allow for setting the template or templateJSON
* Add a `ServerTemplate.toJSON` to return JSON representation (`ServerTemplateData`) of the template
* Update `InitServerTemplate` to make use of the new set method.

### Testing

Added new unit tests for the new `set` method. Update existing tests to make use of `toJSON()` instead of the cache.

### API Changes

* `ServerTemplate.cache` is now private and cannot be accessed outside of the class
* New  `ServerTemplate.set` to allow for setting the template or templateJSON
* New `ServerTemplate.toJSON` to return JSON representation (`ServerTemplateData`) of the template
