### PR TITLE
Update package.json to use farmhash 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-admin",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3269,12 +3269,12 @@
       }
     },
     "farmhash": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.3.0.tgz",
-      "integrity": "sha512-IZJWJXvX+TZJ4qZrcRZkDqI66s4VxrRD+NsduTSe0PZ9BGEDB53S0cd+e4rTXIWbL5k213W8cN6pMZuPVA+z0Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.3.1.tgz",
+      "integrity": "sha512-XUizHanzlr/v7suBr/o85HSakOoWh6HKXZjFYl5C2+Gj0f0rkw+XTUZzrd9odDsgI9G5tRUcF4wSbKaX04T0DQ==",
       "requires": {
         "node-addon-api": "^5.1.0",
-        "prebuild-install": "^7.1.1"
+        "prebuild-install": "^7.1.2"
       }
     },
     "fast-deep-equal": {
@@ -5961,9 +5961,9 @@
       }
     },
     "node-abi": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.57.0.tgz",
-      "integrity": "sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.58.0.tgz",
+      "integrity": "sha512-pXY1jnGf5T7b8UNzWzIqf0EkX4bx/w8N2AvwlGnk2SYYA/kzDVPaH0Dh0UG4EwxBB5eKOIZKPr8VAHSHL1DPGg==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,9 +1506,9 @@
       }
     },
     "@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA=="
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
     "@types/range-parser": {
       "version": "1.2.7",
@@ -2884,9 +2884,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.736",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.736.tgz",
-      "integrity": "sha512-Rer6wc3ynLelKNM4lOCg7/zPQj8tPOCB2hzD32PX9wd3hgRRi9MxEbmkFCokzcEhRVMiOVLjnL9ig9cefJ+6+Q==",
+      "version": "1.4.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.738.tgz",
+      "integrity": "sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "@firebase/database-compat": "^1.0.2",
     "@firebase/database-types": "^1.0.0",
     "@types/node": "^20.10.3",
-    "farmhash": "^3.3.0",
+    "farmhash": "^3.3.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.0.1",
     "long": "^5.2.3",


### PR DESCRIPTION
### Discussion

Version 12.1.0 of the Admin SDK added a dependency on a package called farmhash. This package has a dev dependency on python via node-gyp. The node-gyp package on older versions of Node looks for a binary called `python`. This results in `npm install` of the Admin SDK failing if it can't find a binary with that name ("env: python: No such file or directory").

Original error report: https://github.com/lovell/farmhash/issues/47#issuecomment-2060441642

Fortunately, the owner of the farmhash package quickly added a prebuilt binary and released a version 3.3.1: https://github.com/lovell/farmhash/issues/41

So, this PR updates the Admin SDK's package-lock.json to use farmhash version 3.3.1.

Folks can workaround this issue in the meantime by installing Python or aliasing an existing binary.

### Testing

Steps to repro original issue:
1. Use Node version 14: `nvm use 14`
2. Perform a clean install: `npm ci`
3. Observe error "No prebuilt binaries found ... env: python: No such file or directory ...  farmhash@3.3.0 install: prebuild-install || node-gyp rebuild"
4. Create Python virtual env named "venv" to define a local `python` binary: `python3 -m venv ~/venv`
5. Activate virtual env: `source ~/venv/bin/activate`
6. Repeat step 2
7. Observe no error

With this change:
1. Use Node version 14: `nvm use 14`
2. Perform a clean install: `npm ci`
3. Observe no error

### API Changes

None
