### PR TITLE
fix: Make ADC + human account work with firebase-admin

### DIFF
--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -818,6 +818,11 @@ export class AuthorizedHttpClient extends HttpClient {
       const authHeader = 'Authorization';
       requestCopy.headers[authHeader] = `Bearer ${token}`;
 
+      // Fix issue where firebase-admin does not specify quota project that is necessary for use when utilizing human account with ADC
+      if (!requestCopy.headers['x-goog-user-project'] && this.app.options.projectId) {
+        requestCopy.headers['x-goog-user-project'] = this.app.options.projectId
+      }
+
       if (!requestCopy.httpAgent && this.app.options.httpAgent) {
         requestCopy.httpAgent = this.app.options.httpAgent;
       }

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -818,7 +818,8 @@ export class AuthorizedHttpClient extends HttpClient {
       const authHeader = 'Authorization';
       requestCopy.headers[authHeader] = `Bearer ${token}`;
 
-      // Fix issue where firebase-admin does not specify quota project that is necessary for use when utilizing human account with ADC
+      // Fix issue where firebase-admin does not specify quota project that is
+      // necessary for use when utilizing human account with ADC (RSDF)
       if (!requestCopy.headers['x-goog-user-project'] && this.app.options.projectId) {
         requestCopy.headers['x-goog-user-project'] = this.app.options.projectId
       }

--- a/test/unit/app-check/app-check-api-client-internal.spec.ts
+++ b/test/unit/app-check/app-check-api-client-internal.spec.ts
@@ -45,6 +45,7 @@ describe('AppCheckApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
+    'x-goog-user-project': 'test-project',
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/functions/functions-api-client-internal.spec.ts
+++ b/test/unit/functions/functions-api-client-internal.spec.ts
@@ -44,7 +44,8 @@ describe('FunctionsApiClient', () => {
 
   const EXPECTED_HEADERS = {
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'Authorization': 'Bearer mock-token'
+    'Authorization': 'Bearer mock-token',
+    'x-goog-user-project': 'test-project',
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -117,6 +117,7 @@ describe('MachineLearningApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
+    'x-goog-user-project': 'test-project',
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -57,6 +57,7 @@ describe('RemoteConfigApiClient', () => {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'Accept-Encoding': 'gzip',
+    'x-goog-user-project': 'test-project',
   };
 
   const VERSION_INFO: Version = {

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -44,6 +44,7 @@ describe('SecurityRulesApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
+    'x-goog-user-project': 'test-project',
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '
     + 'account credentials, or set project ID as an app option. Alternatively, set the '


### PR DESCRIPTION
This PR is intended to fix a current bug in firebase-admin.

Google Cloud recommends utilizing [Application Default Credentials (ADC)] (https://cloud.google.com/docs/authentication/application-default-credentials), however this feature does not fully work with the firebase-admin-node library when you want to utilize a human account (person@domain.com) instead of a service account.

Some GCP APIs require you to specify the quota project associated to the request, however, the current implementation of the firebase-admin-node library does not provide the project ID when making requests to GCP APIs, even if you set them through `gcloud auth application-default set-quota-project YOUR_PROJECT`, because the code that handles the requests never adds the project ID to the request. And you get errors like this:
```
Your application is authenticating by using local Application Default Credentials. The identitytoolkit.googleapis.com API requires a quota project, which is not set by default. To learn how to set your quota project, see https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds .
```

Therefore, this pull request aims to fix this issue by checking if a `projectId` was provided when calling the `initializeApp()` function and adds it to the `x-goog-user-project` header of requests made to GCP APIs, just like the [documentation](https://cloud.google.com/docs/authentication/troubleshoot-adc#user-creds-client-based) states it should be set.

This implementation is similar to how the (working) google-auth-library library handles ADC authentication ([src/auth/authclient.ts:270](https://github.com/googleapis/google-auth-library-nodejs/blob/b2b9676f933c012fb2cd1789ad80b927af0de07c/src/auth/authclient.ts#L270)):
```
    /**
     * Append additional headers, e.g., x-goog-user-project, shared across the
     * classes inheriting AuthClient. This method should be used by any method
     * that overrides getRequestMetadataAsync(), which is a shared helper for
     * setting request information in both gRPC and HTTP API calls.
     *
     * @param headers object to append additional headers to.
     */
    addSharedMetadataHeaders(headers) {
        // quota_project_id, stored in application_default_credentials.json, is set in
        // the x-goog-user-project header, to indicate an alternate account for
        // billing and quota:
        if (!headers['x-goog-user-project'] && // don't override a value the user sets.
            this.quotaProjectId) {
            headers['x-goog-user-project'] = this.quotaProjectId;
        }
        return headers;
    }
```
This should also solve some problems described in #1377 