### PR TITLE
change: Deprecate Node.js 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 14 and higher. However, Node.js 14 support is deprecated. We strongly encourage
-you to use Node.js 16 or higher as we will drop support for Node.js 14 in the next major version.
+We support Node.js 14 and higher. However, Node.js 14, 16, and 18 support is deprecated. We strongly encourage
+you to use Node.js 20 or higher as we will drop support for Node.js 14, 16, and 18 in the next major version.
 
 Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 14 and higher. However, Node.js 14, 16, and 18 support is deprecated. We strongly encourage
-you to use Node.js 20 or higher as we will drop support for Node.js 14, 16, and 18 in the next major version.
+We support Node.js 14 and higher. However, Node.js 14, and 16 support is deprecated. We strongly encourage
+you to use Node.js 18 or higher as we will drop support for Node.js 14 and 16 in the next major version.
 
 Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We support Node.js 14 and higher. However, Node.js 14, and 16 support is deprecated. We strongly encourage
+We support Node.js 14 and higher. However, Node.js 14 and 16 support is deprecated. We strongly encourage
 you to use Node.js 18 or higher as we will drop support for Node.js 14 and 16 in the next major version.
 
 Please also note that the Admin SDK should only

--- a/test/unit/app/firebase-app.spec.ts
+++ b/test/unit/app/firebase-app.spec.ts
@@ -182,7 +182,7 @@ describe('FirebaseApp', () => {
       process.env[FIREBASE_CONFIG_VAR] = '{,,';
       expect(() => {
         firebaseNamespace.initializeApp();
-      }).to.throw('Failed to parse app options file: SyntaxError: Unexpected token ,');
+      }).to.throw(/Failed to parse app options file: SyntaxError:/);
     });
 
     it('should throw when the environment variable points to an empty file', () => {


### PR DESCRIPTION
- Deprecate Node.js 16 support
- Add Node.js 18, 20, and 22 to CIs