### PR TITLE
Add a CHANGELOG.md that just points people to the GitHub release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Firebase Admin Changelog
+
+For detailed version notes and breaking changes, see our release notes on GitHub:  
+https://github.com/firebase/firebase-admin-node/releases


### PR DESCRIPTION
Add a CHANGELOG.md that just points people to the GitHub release notes. Just a convenient way to redirect those who go looking for a CHANGELOG at first.