### PR TITLE
Optimize Token Retrieval for Messaging#sendEach to Reduce Unnecessary Fetch Requests

### DIFF
--- a/src/messaging/messaging-api-request-internal.ts
+++ b/src/messaging/messaging-api-request-internal.ts
@@ -19,7 +19,8 @@ import { App } from '../app';
 import { FirebaseApp } from '../app/firebase-app';
 import {
   HttpMethod, AuthorizedHttpClient, HttpRequestConfig, RequestResponseError, RequestResponse,
-  AuthorizedHttp2Client, Http2SessionHandler, Http2RequestConfig,
+  AuthorizedHttp2Client, Http2SessionHandler,
+  Http2AuthorizedRequestConfig,
 } from '../utils/api-request';
 import { createFirebaseError, getErrorCode } from './messaging-errors-internal';
 import { SubRequest, BatchRequestClient } from './batch-request-internal';
@@ -54,7 +55,7 @@ export class FirebaseMessagingRequestHandler {
    */
   constructor(app: App) {
     this.httpClient = new AuthorizedHttpClient(app as FirebaseApp);
-    this.http2Client = new AuthorizedHttp2Client(app as FirebaseApp);
+    this.http2Client = new AuthorizedHttp2Client();
     this.batchClient = new BatchRequestClient(
       this.httpClient, FIREBASE_MESSAGING_BATCH_URL, FIREBASE_MESSAGING_HEADERS);
   }
@@ -138,14 +139,15 @@ export class FirebaseMessagingRequestHandler {
    * @returns A promise that resolves with the {@link SendResponse}.
    */
   public invokeHttp2RequestHandlerForSendResponse(
-    host: string, path: string, requestData: object, http2SessionHandler: Http2SessionHandler
+    host: string, path: string, requestData: object, accessToken: string, http2SessionHandler: Http2SessionHandler
   ): Promise<SendResponse> {
-    const request: Http2RequestConfig = {
+    const request: Http2AuthorizedRequestConfig = {
       method: FIREBASE_MESSAGING_HTTP_METHOD,
       url: `https://${host}${path}`,
       data: requestData,
       headers: LEGACY_FIREBASE_MESSAGING_HEADERS,
       timeout: FIREBASE_MESSAGING_TIMEOUT,
+      accessToken: accessToken,
       http2SessionHandler: http2SessionHandler
     };
     return this.http2Client.send(request).then((response) => {

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -59,6 +59,13 @@ export interface Http2RequestConfig extends BaseRequestConfig {
   http2SessionHandler: Http2SessionHandler;
 }
 
+/**
+ * Configuration for constructing a new HTTP/2 request.
+ */
+export interface Http2AuthorizedRequestConfig extends Http2RequestConfig {
+  accessToken: string;
+}
+
 type RequestConfig = HttpRequestConfig | Http2RequestConfig
 
 /**
@@ -1097,25 +1104,19 @@ export class AuthorizedHttpClient extends HttpClient {
 
 export class AuthorizedHttp2Client extends Http2Client {
 
-  constructor(private readonly app: FirebaseApp) {
+  constructor() {
     super();
   }
 
-  public send(request: Http2RequestConfig): Promise<RequestResponse> {
-    return this.getToken().then((token) => {
-      const requestCopy = Object.assign({}, request);
-      requestCopy.headers = Object.assign({}, request.headers);
-      const authHeader = 'Authorization';
-      requestCopy.headers[authHeader] = `Bearer ${token}`;
+  public send(request: Http2AuthorizedRequestConfig): Promise<RequestResponse> {
+    const requestCopy = Object.assign({}, request);
+    requestCopy.headers = Object.assign({}, request.headers);
+    const authHeader = 'Authorization';
+    requestCopy.headers[authHeader] = `Bearer ${request.accessToken}`;
 
-      return super.send(requestCopy);
-    });
+    return super.send(requestCopy);
   } 
 
-  protected getToken(): Promise<string> {
-    return this.app.INTERNAL.getToken()
-      .then((accessTokenObj) => accessTokenObj.accessToken);
-  }
 }
 
 /**

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -60,7 +60,7 @@ export interface Http2RequestConfig extends BaseRequestConfig {
 }
 
 /**
- * Configuration for constructing a new HTTP/2 request.
+ * Configuration for constructing a new HTTP/2 request with accessToken.
  */
 export interface Http2AuthorizedRequestConfig extends Http2RequestConfig {
   accessToken: string;

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -31,6 +31,7 @@ import {
   ApiSettings, HttpClient, Http2Client, AuthorizedHttpClient, ApiCallbackFunction, HttpRequestConfig,
   parseHttpResponse, RetryConfig, defaultRetryConfig, Http2SessionHandler, Http2RequestConfig,
   RequestResponseError, RequestResponse, AuthorizedHttp2Client,
+  Http2AuthorizedRequestConfig,
 } from '../../../src/utils/api-request';
 import { deepCopy } from '../../../src/utils/deep-copy';
 import { Agent } from 'http';
@@ -2719,12 +2720,13 @@ describe('AuthorizedHttp2Client', () => {
     mockedHttp2Responses.push(mockHttp2SendRequestResponse(200, headers, respData));
     http2Mocker.http2Stub(mockedHttp2Responses);
 
-    const client = new AuthorizedHttp2Client(mockApp);
+    const client = new AuthorizedHttp2Client();
     http2SessionHandler = new Http2SessionHandler(mockHostUrl);
 
     return client.send({
       method: 'GET',
       url: mockUrl,
+      accessToken: mockAccessToken,
       http2SessionHandler: http2SessionHandler,
     }).then((resp) => {
       expect(http2Mocker.requests.length).to.equal(1);
@@ -2746,7 +2748,7 @@ describe('AuthorizedHttp2Client', () => {
     mockedHttp2Responses.push(mockHttp2SendRequestResponse(200, headers, respData));
     http2Mocker.http2Stub(mockedHttp2Responses);
 
-    const client = new AuthorizedHttp2Client(mockApp);
+    const client = new AuthorizedHttp2Client();
     http2SessionHandler = new Http2SessionHandler(mockHostUrl);
 
     return client.send({
@@ -2756,6 +2758,7 @@ describe('AuthorizedHttp2Client', () => {
         'My-Custom-Header': 'CustomValue',
       },
       data: reqData,
+      accessToken: mockAccessToken,
       http2SessionHandler: http2SessionHandler,
     }).then((resp) => {
       expect(http2Mocker.requests.length).to.equal(1);
@@ -2782,16 +2785,17 @@ describe('AuthorizedHttp2Client', () => {
     ));
     http2Mocker.http2Stub(mockedHttp2Responses);
 
-    const client = new AuthorizedHttp2Client(mockApp);
+    const client = new AuthorizedHttp2Client();
     http2SessionHandler = new Http2SessionHandler(mockHostUrl);
 
-    const request: Http2RequestConfig = {
+    const request: Http2AuthorizedRequestConfig = {
       method: 'POST',
       url: mockUrl,
       headers: {
         'My-Custom-Header': 'CustomValue',
       },
       data: reqData,
+      accessToken: mockAccessToken,
       http2SessionHandler: http2SessionHandler,
     };
     const requestCopy = deepCopy(request);


### PR DESCRIPTION
Closes #2645

Instead of attempting to retrieve a token for each request, an access token should be obtained before sending the requests and then injected into each send request.

#### Changes
- Instead of calling getToken inside `AuthorizedHttp2Client#send`, it now accepts `accessToken` as a parameter.
- `FirebaseMessagingRequestHandler#invokeHttp2RequestHandlerForSendResponse` now accepts `accessToken` as a parameter and passes it to the HTTP2 client.
- `Messaging#sendEach` now calls `getToken` to obtain an access token before creating each request and passes it to the messaging request handler.

#### Considerations
- It might be a better choice to pass `accessToken` as a separate parameter rather than as a field in the request object. In this case, it may be preferable to add a separate method within `Http2Client` rather than creating a separate class inheriting from `Http2Client`, such as `AuthorizedHttp2Client`.
- To store errors occurring in `getToken`, a temporary variable `accessTokenError` was added. Using `async/await` would eliminate the need for a temporary variable and allow for early exit if an error occurs in getToken, making the logic simpler and clearer.
- Changes could not be applied to the existing HTTP client that is not HTTP2. There are many places using `AuthorizedHttpClient#send`. As far as I can tell, all of them are called within internal functions, so applying these changes wouldn't affect the external API. This may need further discussion.
