### PR TITLE
fix: `getToken()` returns existing promise to a token if one exists instead of a new token.

### DIFF
--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -118,7 +118,8 @@ export class FirebaseAppInternals {
   }
 
   private shouldRefresh(): boolean {
-    return (!this.cachedToken_ || (this.cachedToken_.expirationTime - Date.now()) <= TOKEN_EXPIRY_THRESHOLD_MILLIS) && !this.isRefreshing;
+    return (!this.cachedToken_ || (this.cachedToken_.expirationTime - Date.now()) <= TOKEN_EXPIRY_THRESHOLD_MILLIS) 
+      && !this.isRefreshing;
   }
 
   /**

--- a/src/app/firebase-app.ts
+++ b/src/app/firebase-app.ts
@@ -39,19 +39,21 @@ export interface FirebaseAccessToken {
  */
 export class FirebaseAppInternals {
   private cachedToken_: FirebaseAccessToken;
+  private promiseToCachedToken_: Promise<FirebaseAccessToken>;
   private tokenListeners_: Array<(token: string) => void>;
+  private isRefreshing: boolean;
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   constructor(private credential_: Credential) {
     this.tokenListeners_ = [];
+    this.isRefreshing = false;
   }
 
   public getToken(forceRefresh = false): Promise<FirebaseAccessToken> {
     if (forceRefresh || this.shouldRefresh()) {
-      return this.refreshToken();
+      this.promiseToCachedToken_ = this.refreshToken();
     }
-
-    return Promise.resolve(this.cachedToken_);
+    return this.promiseToCachedToken_
   }
 
   public getCachedToken(): FirebaseAccessToken | null {
@@ -59,6 +61,7 @@ export class FirebaseAppInternals {
   }
 
   private refreshToken(): Promise<FirebaseAccessToken> {
+    this.isRefreshing = true;
     return Promise.resolve(this.credential_.getAccessToken())
       .then((result) => {
         // Since the developer can provide the credential implementation, we want to weakly verify
@@ -108,11 +111,14 @@ export class FirebaseAppInternals {
         }
 
         throw new FirebaseAppError(AppErrorCodes.INVALID_CREDENTIAL, errorMessage);
-      });
+      })
+      .finally(() => {
+        this.isRefreshing = false;
+      })
   }
 
   private shouldRefresh(): boolean {
-    return !this.cachedToken_ || (this.cachedToken_.expirationTime - Date.now()) <= TOKEN_EXPIRY_THRESHOLD_MILLIS;
+    return (!this.cachedToken_ || (this.cachedToken_.expirationTime - Date.now()) <= TOKEN_EXPIRY_THRESHOLD_MILLIS) && !this.isRefreshing;
   }
 
   /**

--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -278,7 +278,7 @@ describe('admin.messaging', () => {
       });
   });
 
-  xit('sendToDeviceGroup() returns a response with success count', () => {
+  it('sendToDeviceGroup() returns a response with success count', () => {
     return getMessaging().sendToDeviceGroup(notificationKey, payload, options)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');

--- a/test/unit/app/firebase-app.spec.ts
+++ b/test/unit/app/firebase-app.spec.ts
@@ -808,6 +808,16 @@ describe('FirebaseApp', () => {
       });
     });
 
+    it('only refreshes the token once for concurrent calls', () => {
+      const promise1 = mockApp.INTERNAL.getToken();
+      const promise2 = mockApp.INTERNAL.getToken();
+      expect(getTokenStub).to.have.been.calledOnce;
+      return Promise.all([promise1, promise2]).then((tokens) => {
+        expect(tokens[0]).to.equal(tokens[1]);
+        expect(getTokenStub).to.have.been.calledOnce;
+      })
+    });
+
     it('Includes the original error in exception', () => {
       getTokenStub.restore();
       const mockError = new FirebaseAppError(


### PR DESCRIPTION
- Concurrent calls to getToken() don't utilize cache because of a race condition which causes multiple token refreshes.
- Fixing by returning the existing promise to a token if one is still pending instead of requesting a new one.