### PR TITLE
[FDL deprecation #1] Added mobileLinksConfig field for project and tenant configs

### DIFF
--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -760,6 +760,14 @@ export interface ListUsersResult {
 }
 
 // @public
+export interface MobileLinksConfig {
+    domain?: MobileLinksDomain;
+}
+
+// @public
+export type MobileLinksDomain = 'HOSTING_DOMAIN' | 'FIREBASE_DYNAMIC_LINK_DOMAIN';
+
+// @public
 export interface MultiFactorConfig {
     factorIds?: AuthFactorType[];
     providerConfigs?: MultiFactorProviderConfig[];
@@ -849,6 +857,7 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
 // @public
 export class ProjectConfig {
     readonly emailPrivacyConfig?: EmailPrivacyConfig;
+    readonly mobileLinksConfig?: MobileLinksConfig;
     get multiFactorConfig(): MultiFactorConfig | undefined;
     readonly passwordPolicyConfig?: PasswordPolicyConfig;
     get recaptchaConfig(): RecaptchaConfig | undefined;
@@ -934,6 +943,7 @@ export class Tenant {
     readonly displayName?: string;
     readonly emailPrivacyConfig?: EmailPrivacyConfig;
     get emailSignInConfig(): EmailSignInProviderConfig | undefined;
+    readonly mobileLinksConfig?: MobileLinksConfig;
     get multiFactorConfig(): MultiFactorConfig | undefined;
     readonly passwordPolicyConfig?: PasswordPolicyConfig;
     get recaptchaConfig(): RecaptchaConfig | undefined;
@@ -988,6 +998,7 @@ export interface UpdatePhoneMultiFactorInfoRequest extends BaseUpdateMultiFactor
 // @public
 export interface UpdateProjectConfigRequest {
     emailPrivacyConfig?: EmailPrivacyConfig;
+    mobileLinksConfig?: MobileLinksConfig;
     multiFactorConfig?: MultiFactorConfig;
     passwordPolicyConfig?: PasswordPolicyConfig;
     recaptchaConfig?: RecaptchaConfig;
@@ -1014,6 +1025,7 @@ export interface UpdateTenantRequest {
     displayName?: string;
     emailPrivacyConfig?: EmailPrivacyConfig;
     emailSignInConfig?: EmailSignInProviderConfig;
+    mobileLinksConfig?: MobileLinksConfig;
     multiFactorConfig?: MultiFactorConfig;
     passwordPolicyConfig?: PasswordPolicyConfig;
     recaptchaConfig?: RecaptchaConfig;

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -1966,6 +1966,60 @@ export interface PasswordPolicyConfig {
 }
 
 /**
+ * Configuration for settings related to univeral links (iOS)
+ * and app links (Android).
+ */
+export interface MobileLinksConfig {
+  /**
+   * Use firebase Hosting or dynamic link domain as the out-of-band code domain.
+   */
+  domain?: MobileLinksDomain;
+}
+
+/**
+ * Open code in app domain to use for app links and universal links.
+ */
+export type MobileLinksDomain = 'HOSTING_DOMAIN' | 'FIREBASE_DYNAMIC_LINK_DOMAIN';
+
+/**
+ * Defines the MobileLinksAuthConfig class used for validation.
+ *
+ * @internal
+ */
+export class MobileLinksAuthConfig {
+  public static validate(options: MobileLinksConfig): void {
+    if (!validator.isNonNullObject(options)) {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_CONFIG,
+        '"MobileLinksConfig" must be a non-null object.',
+      );
+    }
+
+    const validKeys = {
+      domain: true,
+    };
+
+    for (const key in options) {
+      if (!(key in validKeys)) {
+        throw new FirebaseAuthError(
+          AuthClientErrorCode.INVALID_CONFIG,
+          `"${key}" is not a valid "MobileLinksConfig" parameter.`,
+        );
+      }
+    }
+
+    if (typeof options.domain !== 'undefined'
+      && options.domain !== 'HOSTING_DOMAIN'
+      && options.domain !== 'FIREBASE_DYNAMIC_LINK_DOMAIN') {
+      throw new FirebaseAuthError(
+        AuthClientErrorCode.INVALID_CONFIG,
+        '"MobileLinksConfig.domain" must be either "HOSTING_DOMAIN" or "FIREBASE_DYNAMIC_LINK_DOMAIN".',
+      );
+    }
+  }
+}
+
+/**
  * A password policy's enforcement state.
  */
 export type PasswordPolicyEnforcementState = 'ENFORCE' | 'OFF';

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -103,6 +103,8 @@ export {
   PasswordPolicyEnforcementState,
   CustomStrengthOptionsConfig,
   EmailPrivacyConfig,
+  MobileLinksConfig,
+  MobileLinksDomain,
 } from './auth-config';
 
 export {

--- a/src/auth/project-config.ts
+++ b/src/auth/project-config.ts
@@ -28,6 +28,8 @@ import {
   PasswordPolicyConfig,
   EmailPrivacyConfig,
   EmailPrivacyAuthConfig,
+  MobileLinksConfig,
+  MobileLinksAuthConfig,
 } from './auth-config';
 import { deepCopy } from '../utils/deep-copy';
 
@@ -59,6 +61,11 @@ export interface UpdateProjectConfigRequest {
    * The email privacy configuration to update on the project
    */
   emailPrivacyConfig?: EmailPrivacyConfig;
+
+  /**
+   * The mobile links configuration for the project
+   */
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /**
@@ -70,6 +77,7 @@ export interface ProjectConfigServerResponse {
   recaptchaConfig?: RecaptchaConfig;
   passwordPolicyConfig?: PasswordPolicyAuthServerConfig;
   emailPrivacyConfig?: EmailPrivacyConfig;
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /**
@@ -81,6 +89,7 @@ export interface ProjectConfigClientRequest {
   recaptchaConfig?: RecaptchaConfig;
   passwordPolicyConfig?: PasswordPolicyAuthServerConfig;
   emailPrivacyConfig?: EmailPrivacyConfig;
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /**
@@ -123,6 +132,11 @@ export class ProjectConfig {
   public readonly emailPrivacyConfig?: EmailPrivacyConfig;
 
   /**
+   * The mobile links configuration for the project
+   */
+  public readonly mobileLinksConfig?: MobileLinksConfig
+  
+  /**
    * Validates a project config options object. Throws an error on failure.
    *
    * @param request - The project config options object to validate.
@@ -140,6 +154,7 @@ export class ProjectConfig {
       recaptchaConfig: true,
       passwordPolicyConfig: true,
       emailPrivacyConfig: true,
+      mobileLinksConfig: true,
     }
     // Check for unsupported top level attributes.
     for (const key in request) {
@@ -173,6 +188,11 @@ export class ProjectConfig {
     if (typeof request.emailPrivacyConfig !== 'undefined') {
       EmailPrivacyAuthConfig.validate(request.emailPrivacyConfig);
     }
+
+    // Validate Mobile Links Config if provided.
+    if (typeof request.mobileLinksConfig !== 'undefined') {
+      MobileLinksAuthConfig.validate(request.mobileLinksConfig);
+    }
   }
 
   /**
@@ -199,6 +219,9 @@ export class ProjectConfig {
     }
     if (typeof configOptions.emailPrivacyConfig !== 'undefined') {
       request.emailPrivacyConfig = configOptions.emailPrivacyConfig;
+    }
+    if (typeof configOptions.mobileLinksConfig !== 'undefined') {
+      request.mobileLinksConfig = configOptions.mobileLinksConfig;
     }
     return request;
   }
@@ -234,6 +257,9 @@ export class ProjectConfig {
     if (typeof response.emailPrivacyConfig !== 'undefined') {
       this.emailPrivacyConfig = response.emailPrivacyConfig;
     }
+    if (typeof response.mobileLinksConfig !== 'undefined') {
+      this.mobileLinksConfig = response.mobileLinksConfig;
+    }
   }
   /**
    * Returns a JSON-serializable representation of this object.
@@ -248,6 +274,7 @@ export class ProjectConfig {
       recaptchaConfig: this.recaptchaConfig_?.toJSON(),
       passwordPolicyConfig: deepCopy(this.passwordPolicyConfig),
       emailPrivacyConfig: deepCopy(this.emailPrivacyConfig),
+      mobileLinksConfig: deepCopy(this.mobileLinksConfig),
     };
     if (typeof json.smsRegionConfig === 'undefined') {
       delete json.smsRegionConfig;
@@ -263,6 +290,9 @@ export class ProjectConfig {
     }
     if (typeof json.emailPrivacyConfig === 'undefined') {
       delete json.emailPrivacyConfig;
+    }
+    if (typeof json.mobileLinksConfig === 'undefined') {
+      delete json.mobileLinksConfig;
     }
     return json;
   }

--- a/src/auth/tenant.ts
+++ b/src/auth/tenant.ts
@@ -24,6 +24,7 @@ import {
   MultiFactorAuthConfig, SmsRegionConfig, SmsRegionsAuthConfig, RecaptchaAuthConfig, RecaptchaConfig,
   PasswordPolicyConfig,
   PasswordPolicyAuthConfig, PasswordPolicyAuthServerConfig, EmailPrivacyConfig, EmailPrivacyAuthConfig,
+  MobileLinksConfig, MobileLinksAuthConfig
 } from './auth-config';
 
 /**
@@ -77,6 +78,11 @@ export interface UpdateTenantRequest {
    * The email privacy configuration for the tenant
    */
   emailPrivacyConfig?: EmailPrivacyConfig;
+
+  /**
+   * The mobile links configuration for the project
+   */
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /**
@@ -95,6 +101,7 @@ export interface TenantOptionsServerRequest extends EmailSignInConfigServerReque
   recaptchaConfig?: RecaptchaConfig;
   passwordPolicyConfig?: PasswordPolicyAuthServerConfig;
   emailPrivacyConfig?: EmailPrivacyConfig;
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /** The tenant server response interface. */
@@ -110,6 +117,7 @@ export interface TenantServerResponse {
   recaptchaConfig? : RecaptchaConfig;
   passwordPolicyConfig?: PasswordPolicyAuthServerConfig;
   emailPrivacyConfig?: EmailPrivacyConfig;
+  mobileLinksConfig?: MobileLinksConfig;
 }
 
 /**
@@ -175,6 +183,11 @@ export class Tenant {
    * The email privacy configuration for the tenant
    */
   public readonly emailPrivacyConfig?: EmailPrivacyConfig;
+  /**
+   * The mobile links configuration for the tenant
+   */
+  public readonly mobileLinksConfig?: MobileLinksConfig
+  
 
   /**
    * Builds the corresponding server request for a TenantOptions object.
@@ -217,6 +230,9 @@ export class Tenant {
     if (typeof tenantOptions.emailPrivacyConfig !== 'undefined') {
       request.emailPrivacyConfig = tenantOptions.emailPrivacyConfig;
     }
+    if (typeof tenantOptions.mobileLinksConfig !== 'undefined') {
+      request.mobileLinksConfig = tenantOptions.mobileLinksConfig;
+    }
     return request;
   }
 
@@ -254,6 +270,7 @@ export class Tenant {
       recaptchaConfig: true,
       passwordPolicyConfig: true,
       emailPrivacyConfig: true,
+      mobileLinksConfig: true,
     };
     const label = createRequest ? 'CreateTenantRequest' : 'UpdateTenantRequest';
     if (!validator.isNonNullObject(request)) {
@@ -317,6 +334,10 @@ export class Tenant {
     if (typeof request.emailPrivacyConfig !== 'undefined') {
       EmailPrivacyAuthConfig.validate(request.emailPrivacyConfig);
     }
+    // Validate Mobile Links Config if provided.
+    if (typeof request.mobileLinksConfig !== 'undefined') {
+      MobileLinksAuthConfig.validate(request.mobileLinksConfig);
+    }
   }
 
   /**
@@ -363,6 +384,9 @@ export class Tenant {
     if (typeof response.emailPrivacyConfig !== 'undefined') {
       this.emailPrivacyConfig = deepCopy(response.emailPrivacyConfig);
     }
+    if (typeof response.mobileLinksConfig !== 'undefined') {
+      this.mobileLinksConfig = deepCopy(response.mobileLinksConfig);
+    }
   }
 
   /**
@@ -403,6 +427,7 @@ export class Tenant {
       recaptchaConfig: this.recaptchaConfig_?.toJSON(),
       passwordPolicyConfig: deepCopy(this.passwordPolicyConfig),
       emailPrivacyConfig: deepCopy(this.emailPrivacyConfig),
+      mobileLinksConfig: deepCopy(this.mobileLinksConfig),
     };
     if (typeof json.multiFactorConfig === 'undefined') {
       delete json.multiFactorConfig;
@@ -421,6 +446,9 @@ export class Tenant {
     }
     if (typeof json.emailPrivacyConfig === 'undefined') {
       delete json.emailPrivacyConfig;
+    }
+    if (typeof json.mobileLinksConfig === 'undefined') {
+      delete json.mobileLinksConfig;
     }
     return json;
   }

--- a/test/unit/auth/auth-config.spec.ts
+++ b/test/unit/auth/auth-config.spec.ts
@@ -28,6 +28,8 @@ import {
   MAXIMUM_TEST_PHONE_NUMBERS,
   PasswordPolicyAuthConfig,
   CustomStrengthOptionsConfig,
+  MobileLinksAuthConfig,
+  MobileLinksConfig,
 } from '../../../src/auth/auth-config';
 import {
   SAMLUpdateAuthProviderRequest, OIDCUpdateAuthProviderRequest,
@@ -1319,6 +1321,33 @@ describe('PasswordPolicyAuthConfig',() => {
           }
         ]
       });
+    });
+  });
+});
+
+describe('MobileLinksAuthConfig',() => {
+  describe('validate',() => {
+    it('should throw an error on invalid MobileLinksConfig key',() => {
+      const config: any = {
+        link: 'HOSTING_DOMAIN'
+      };
+      expect(() =>
+        MobileLinksAuthConfig.validate(config)
+      ).to.throw('"link" is not a valid "MobileLinksConfig" parameter.');
+    });
+
+    it('should throw an error on invalid MobileLinksDomain',() => {
+      const config: any = {
+        domain: 'WRONG_DOMAIN'
+      };
+      expect(() => MobileLinksAuthConfig.validate(config))
+        .to.throw('"MobileLinksConfig.domain" must be either "HOSTING_DOMAIN" or "FIREBASE_DYNAMIC_LINK_DOMAIN".');
+    });//
+    it('should now throw an error on valid MobileLinksConfig',() => {
+      const config: MobileLinksConfig = {
+        domain: 'HOSTING_DOMAIN'
+      };
+      expect(() => MobileLinksAuthConfig.validate(config)).not.to.throw();
     });
   });
 });

--- a/test/unit/auth/tenant.spec.ts
+++ b/test/unit/auth/tenant.spec.ts
@@ -103,6 +103,9 @@ describe('Tenant', () => {
     emailPrivacyConfig: {
       enableImprovedEmailPrivacy: true,
     },
+    mobileLinksConfig: {
+      domain: 'HOSTING_DOMAIN'
+    },
   };
 
   const clientRequest: UpdateTenantRequest = {
@@ -132,6 +135,9 @@ describe('Tenant', () => {
     emailPrivacyConfig: {
       enableImprovedEmailPrivacy: true,
     },
+    mobileLinksConfig: {
+      domain: 'HOSTING_DOMAIN'
+    },
   };
 
   const serverRequestWithoutMfa: TenantServerResponse = {
@@ -142,6 +148,9 @@ describe('Tenant', () => {
     passwordPolicyConfig: passwordPolicyServerConfig,
     emailPrivacyConfig: {
       enableImprovedEmailPrivacy: true,
+    },
+    mobileLinksConfig: {
+      domain: 'HOSTING_DOMAIN'
     },
   };
 
@@ -154,6 +163,9 @@ describe('Tenant', () => {
     passwordPolicyConfig: passwordPolicyClientConfig,
     emailPrivacyConfig: {
       enableImprovedEmailPrivacy: true,
+    },
+    mobileLinksConfig: {
+      domain: 'HOSTING_DOMAIN'
     },
   };
 
@@ -218,6 +230,9 @@ describe('Tenant', () => {
     passwordPolicyConfig: passwordPolicyServerConfig,
     emailPrivacyConfig: {
       enableImprovedEmailPrivacy: true,
+    },
+    mobileLinksConfig: {
+      domain: 'HOSTING_DOMAIN'
     },
   };
 
@@ -582,6 +597,22 @@ describe('Tenant', () => {
         expect(() => {
           Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest);
         }).to.throw('"EmailPrivacyConfig.enableImprovedEmailPrivacy" must be a valid boolean value.');
+      });
+
+      it('should throw on invalid MobileLinksConfig attribute', () => {
+        const tenantOptionsClientRequest = deepCopy(clientRequest) as any;
+        tenantOptionsClientRequest.mobileLinksConfig.invalidParameter = 'invalid';
+        expect(() => {
+          Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest);
+        }).to.throw('"invalidParameter" is not a valid "MobileLinksConfig" parameter.');
+      });
+
+      it('should throw on invalid domain attribute', () => {
+        const tenantOptionsClientRequest = deepCopy(clientRequest) as any;
+        tenantOptionsClientRequest.mobileLinksConfig.domain = 'random domain';
+        expect(() => {
+          Tenant.buildServerRequest(tenantOptionsClientRequest, !createRequest);
+        }).to.throw('"MobileLinksConfig.domain" must be either "HOSTING_DOMAIN" or "FIREBASE_DYNAMIC_LINK_DOMAIN".');
       });
 
       it('should not throw on valid client request object', () => {
@@ -979,6 +1010,22 @@ describe('Tenant', () => {
         }).to.throw('"EmailPrivacyConfig.enableImprovedEmailPrivacy" must be a valid boolean value.');
       });
 
+      it('should throw on invalid MobileLinksConfig attribute', () => {
+        const tenantOptionsClientRequest = deepCopy(clientRequest) as any;
+        tenantOptionsClientRequest.mobileLinksConfig.invalidParameter = 'invalid';
+        expect(() => {
+          Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
+        }).to.throw('"invalidParameter" is not a valid "MobileLinksConfig" parameter.');
+      });
+
+      it('should throw on invalid domain attribute', () => {
+        const tenantOptionsClientRequest = deepCopy(clientRequest) as any;
+        tenantOptionsClientRequest.mobileLinksConfig.domain = 'random domain';
+        expect(() => {
+          Tenant.buildServerRequest(tenantOptionsClientRequest, createRequest);
+        }).to.throw('"MobileLinksConfig.domain" must be either "HOSTING_DOMAIN" or "FIREBASE_DYNAMIC_LINK_DOMAIN".');
+      });
+
       const nonObjects = [null, NaN, 0, 1, true, false, '', 'a', [], [1, 'a'], _.noop];
       nonObjects.forEach((request) => {
         it('should throw on invalid CreateTenantRequest:' + JSON.stringify(request), () => {
@@ -1098,6 +1145,13 @@ describe('Tenant', () => {
         deepCopy(clientRequest.passwordPolicyConfig));
     });
 
+    it('should set readonly property mobileLinksConfig', () => {
+      const expectedMobileLinksConfig = {
+        domain: 'HOSTING_DOMAIN',
+      };
+      expect(clientRequest.mobileLinksConfig).to.deep.equal(expectedMobileLinksConfig);
+    });
+
     it('should set readonly property emailPrivacyConfig', () => {
       const expectedEmailPrivacyConfig = {
         enableImprovedEmailPrivacy: true,
@@ -1147,6 +1201,7 @@ describe('Tenant', () => {
         recaptchaConfig: deepCopy(serverResponseWithRecaptcha.recaptchaConfig),
         passwordPolicyConfig: deepCopy(clientRequest.passwordPolicyConfig),
         emailPrivacyConfig: deepCopy(clientRequest.emailPrivacyConfig),
+        mobileLinksConfig: deepCopy(clientRequest.mobileLinksConfig),
       });
     });
 
@@ -1158,6 +1213,7 @@ describe('Tenant', () => {
       delete serverRequestCopyWithoutMfa.recaptchaConfig;
       delete serverRequestCopyWithoutMfa.passwordPolicyConfig;
       delete serverRequestCopyWithoutMfa.emailPrivacyConfig;
+      delete serverRequestCopyWithoutMfa.mobileLinksConfig;
       expect(new Tenant(serverRequestCopyWithoutMfa).toJSON()).to.deep.equal({
         tenantId: 'TENANT-ID',
         displayName: 'TENANT-DISPLAY-NAME',


### PR DESCRIPTION
1. Added mobileLinksConfig field for project and tenant creation and/or updating workflows.
This will be later used in Firebase Dynamic links deprecation work.

2. Fixed some legacy failing tests.

* Any API changes after the review will be addressed in a different PR.
* This PR will be merge to the main branch of FDL deprecation work called `fdl-deprecation`.  Later when launched, `fdl-deprecation` will be merged  into `master` branch.
