### PR TITLE
chore: Skip sendToDeviceGroup integration test

### DIFF
--- a/test/integration/messaging.spec.ts
+++ b/test/integration/messaging.spec.ts
@@ -278,7 +278,7 @@ describe('admin.messaging', () => {
       });
   });
 
-  it('sendToDeviceGroup() returns a response with success count', () => {
+  it.skip('sendToDeviceGroup() returns a response with success count', () => {
     return getMessaging().sendToDeviceGroup(notificationKey, payload, options)
       .then((response) => {
         expect(typeof response.successCount).to.equal('number');


### PR DESCRIPTION
Re-skip broken test originally skipped in #1292