### PR TITLE
chore(fcm): Deprecate sendToTopic and Condition

### DIFF
--- a/etc/firebase-admin.messaging.api.md
+++ b/etc/firebase-admin.messaging.api.md
@@ -198,11 +198,13 @@ export class Messaging {
     sendEachForMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse>;
     // @deprecated
     sendMulticast(message: MulticastMessage, dryRun?: boolean): Promise<BatchResponse>;
+    // @deprecated
     sendToCondition(condition: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingConditionResponse>;
     // @deprecated
     sendToDevice(registrationTokenOrTokens: string | string[], payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingDevicesResponse>;
     // @deprecated
     sendToDeviceGroup(notificationKey: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingDeviceGroupResponse>;
+    // @deprecated
     sendToTopic(topic: string, payload: MessagingPayload, options?: MessagingOptions): Promise<MessagingTopicResponse>;
     subscribeToTopic(registrationTokenOrTokens: string | string[], topic: string): Promise<MessagingTopicManagementResponse>;
     unsubscribeFromTopic(registrationTokenOrTokens: string | string[], topic: string): Promise<MessagingTopicManagementResponse>;

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -686,6 +686,8 @@ export class Messaging {
    *
    * @returns A promise fulfilled with the server's response after the message
    *   has been sent.
+   * 
+   * @deprecated Use {@link Messaging.send} instead.
    */
   public sendToTopic(
     topic: string,
@@ -737,6 +739,8 @@ export class Messaging {
    *
    * @returns A promise fulfilled with the server's response after the message
    *   has been sent.
+   * 
+   * @deprecated Use {@link Messaging.send} instead.
    */
   public sendToCondition(
     condition: string,


### PR DESCRIPTION
- Mark legacy functions `sendToTopic` and `sendToCondition` as deprecated.
- Remove integration tests for FCM legacy (deprecated) APIs as these APIs will be removed in the upcoming major release.