### PR TITLE
fix(auth): Add missing `Math.floor()` when setting `validDuration` in `createSessionCookie()`

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1094,7 +1094,7 @@ export abstract class AbstractAuthRequestHandler {
     const request = {
       idToken,
       // Convert to seconds.
-      validDuration: expiresIn / 1000,
+      validDuration: Math.floor(expiresIn / 1000),
     };
     return this.invokeRequestHandler(this.getAuthUrlBuilder(), FIREBASE_AUTH_CREATE_SESSION_COOKIE, request)
       .then((response: any) => response.sessionCookie);

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -2563,7 +2563,7 @@ describe('admin.auth', () => {
   describe('createSessionCookie()', () => {
     let expectedExp: number;
     let expectedIat: number;
-    const expiresIn = 24 * 60 * 60 * 1000;
+    const expiresIn = (24 * 60 * 60 * 1000) + 234;
     let payloadClaims: any;
     let currentIdToken: string;
     const uid = sessionCookieUids[0];

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -1055,7 +1055,8 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
         const expectedError = new FirebaseAuthError(
           AuthClientErrorCode.INVALID_SESSION_COOKIE_DURATION,
         );
-        const outOfBoundDuration = 60 * 60 * 1000 * 24 * 14 + 1;
+        // Add more than a second since this value is Math.floor()'ed
+        const outOfBoundDuration = 60 * 60 * 1000 * 24 * 14 + 1001;
 
         const requestHandler = handler.init(mockApp);
         return requestHandler.createSessionCookie('ID_TOKEN', outOfBoundDuration)


### PR DESCRIPTION
- Add missing `Math.floor()` when setting `validDuration` in `createSessionCookie()`
- Modified test to use an `expiresIn` value set to the millisecond to verify this resolves the issue.