### PR TITLE
fix(functions): Allow both partial and full resource names to enqueue tasks in emulator

### DIFF
--- a/src/functions/functions-api-client-internal.ts
+++ b/src/functions/functions-api-client-internal.ts
@@ -92,7 +92,7 @@ export class FunctionsApiClient {
     }
 
     try {
-      const serviceUrl = tasksEmulatorUrl(resources, functionName)?.concat('/', id)
+      const serviceUrl = tasksEmulatorUrl(resources)?.concat('/', id)
         ?? await this.getUrl(resources, CLOUD_TASKS_API_URL_FORMAT.concat('/', id));
       const request: HttpRequestConfig = {
         method: 'DELETE',
@@ -147,7 +147,7 @@ export class FunctionsApiClient {
     const task = this.validateTaskOptions(data, resources, opts);
     try {
       const serviceUrl =
-        tasksEmulatorUrl(resources, functionName) ??
+        tasksEmulatorUrl(resources) ??
         await this.getUrl(resources, CLOUD_TASKS_API_URL_FORMAT);
 
       const taskPayload = await this.updateTaskPayload(task, resources, extensionId);
@@ -436,9 +436,9 @@ export class FirebaseFunctionsError extends PrefixedFirebaseError {
   }
 }
 
-function tasksEmulatorUrl(resources: utils.ParsedResource, functionName: string): string | undefined {
+function tasksEmulatorUrl(resources: utils.ParsedResource): string | undefined {
   if (process.env.CLOUD_TASKS_EMULATOR_HOST) {
-    return `http://${process.env.CLOUD_TASKS_EMULATOR_HOST}/projects/${resources.projectId}/locations/${resources.locationId}/queues/${functionName}/tasks`;
+    return `http://${process.env.CLOUD_TASKS_EMULATOR_HOST}/projects/${resources.projectId}/locations/${resources.locationId}/queues/${resources.resourceId}/tasks`;
   }
   return undefined;
 }


### PR DESCRIPTION
The docstring for `getFunctions.taskQueue()` advertises that task queues can be referenced by both fully and partially qualified resource names, but a user reported that fully qualified resource names was not working. This PR updates the resource resolution logic to properly resolve to the corresponding task queue in the new Cloud Tasks emulator.

Fixes https://github.com/firebase/firebase-admin-node/issues/2725.