### PR TITLE
chore: Update auth.spec.ts

### DIFF
--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -1393,7 +1393,7 @@ describe('admin.auth', () => {
     });
   });
 
-  describe.only('Tenant management operations', () => {
+  describe('Tenant management operations', () => {
     let createdTenantId: string;
     const createdTenants: string[] = [];
     const mfaSmsEnabledTotpEnabledConfig: MultiFactorConfig = {


### PR DESCRIPTION
- Remove an accidental `describe.only(...`  tag that went in #2625
