### PR TITLE
fix: Set the Quota Project ID only for ADC human accounts

### DIFF
--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -72,7 +72,7 @@ export class ApplicationDefaultCredential implements Credential {
 
   public getQuotaProjectId(): string | undefined {
     if (!this.quotaProjectId) {
-      this.quotaProjectId = this.authClient.quotaProjectId;
+      this.quotaProjectId = this.authClient?.quotaProjectId;
     }
     return this.quotaProjectId;
   }

--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -39,6 +39,7 @@ export class ApplicationDefaultCredential implements Credential {
   private readonly googleAuth: GoogleAuth;
   private authClient: AnyAuthClient;
   private projectId?: string;
+  private quotaProjectId?: string;
   private accountId?: string;
 
   constructor(httpAgent?: Agent) {
@@ -58,6 +59,7 @@ export class ApplicationDefaultCredential implements Credential {
     }
     await this.authClient.getAccessToken();
     const credentials = this.authClient.credentials;
+    this.quotaProjectId = this.authClient.quotaProjectId;
     return populateCredential(credentials);
   }
 
@@ -66,6 +68,13 @@ export class ApplicationDefaultCredential implements Credential {
       this.projectId = await this.googleAuth.getProjectId();
     }
     return Promise.resolve(this.projectId);
+  }
+
+  public getQuotaProjectId(): string | undefined {
+    if (!this.quotaProjectId) {
+      this.quotaProjectId = this.authClient.quotaProjectId;
+    }
+    return this.quotaProjectId;
   }
 
   public async isComputeEngineCredential(): Promise<boolean> {

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -1079,10 +1079,13 @@ export class AuthorizedHttpClient extends HttpClient {
       requestCopy.headers[authHeader] = `Bearer ${token}`;
 
       let quotaProjectId: string | undefined;
-      if (this.app.options.credential instanceof ApplicationDefaultCredential){
+      if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
+        quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
+      }
+      else if (this.app.options.credential instanceof ApplicationDefaultCredential){
         quotaProjectId = this.app.options.credential.getQuotaProjectId();
       }
-      quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT || undefined;
+
       if (!requestCopy.headers['x-goog-user-project'] && validator.isNonEmptyString(quotaProjectId)) {
         requestCopy.headers['x-goog-user-project'] = quotaProjectId;
       }

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -1079,13 +1079,10 @@ export class AuthorizedHttpClient extends HttpClient {
       requestCopy.headers[authHeader] = `Bearer ${token}`;
 
       let quotaProjectId: string | undefined;
-      if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
-        quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
-      }
-      else if (this.app.options.credential instanceof ApplicationDefaultCredential){
+      if (this.app.options.credential instanceof ApplicationDefaultCredential) {
         quotaProjectId = this.app.options.credential.getQuotaProjectId();
       }
-
+      quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT || quotaProjectId;
       if (!requestCopy.headers['x-goog-user-project'] && validator.isNonEmptyString(quotaProjectId)) {
         requestCopy.headers['x-goog-user-project'] = quotaProjectId;
       }
@@ -1118,6 +1115,15 @@ export class AuthorizedHttp2Client extends Http2Client {
       requestCopy.headers = Object.assign({}, request.headers);
       const authHeader = 'Authorization';
       requestCopy.headers[authHeader] = `Bearer ${token}`;
+
+      let quotaProjectId: string | undefined;
+      if (this.app.options.credential instanceof ApplicationDefaultCredential) {
+        quotaProjectId = this.app.options.credential.getQuotaProjectId();
+      }
+      quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT || quotaProjectId;
+      if (!requestCopy.headers['x-goog-user-project'] && validator.isNonEmptyString(quotaProjectId)) {
+        requestCopy.headers['x-goog-user-project'] = quotaProjectId;
+      }
 
       requestCopy.headers['X-Goog-Api-Client'] = getMetricsHeader()
 

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -26,6 +26,7 @@ import url = require('url');
 import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 import * as zlibmod from 'zlib';
+import { ApplicationDefaultCredential } from '../app/credential-internal';
 import { getMetricsHeader } from '../utils/index';
 
 /** Http method type definition. */
@@ -1077,10 +1078,13 @@ export class AuthorizedHttpClient extends HttpClient {
       const authHeader = 'Authorization';
       requestCopy.headers[authHeader] = `Bearer ${token}`;
 
-      // Fix issue where firebase-admin does not specify quota project that is
-      // necessary for use when utilizing human account with ADC (RSDF)
-      if (!requestCopy.headers['x-goog-user-project'] && this.app.options.projectId) {
-        requestCopy.headers['x-goog-user-project'] = this.app.options.projectId
+      let quotaProjectId: string | undefined;
+      if (this.app.options.credential instanceof ApplicationDefaultCredential){
+        quotaProjectId = this.app.options.credential.getQuotaProjectId();
+      }
+      quotaProjectId = process.env.GOOGLE_CLOUD_QUOTA_PROJECT || undefined;
+      if (!requestCopy.headers['x-goog-user-project'] && validator.isNonEmptyString(quotaProjectId)) {
+        requestCopy.headers['x-goog-user-project'] = quotaProjectId;
       }
 
       if (!requestCopy.httpAgent && this.app.options.httpAgent) {

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -19,7 +19,7 @@ import minimist = require('minimist');
 import path = require('path');
 import { random } from 'lodash';
 import {
-  App, Credential, GoogleOAuthAccessToken, cert, deleteApp, initializeApp,
+  App, Credential, GoogleOAuthAccessToken, applicationDefault, cert, deleteApp, initializeApp,
 } from '../../lib/app/index'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -87,7 +87,8 @@ before(() => {
   storageBucket = projectId + '.appspot.com';
 
   defaultApp = initializeApp({
-    ...getCredential(),
+    //...getCredential(),
+    credential: applicationDefault(),
     projectId,
     databaseURL: databaseUrl,
     storageBucket,

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -19,7 +19,7 @@ import minimist = require('minimist');
 import path = require('path');
 import { random } from 'lodash';
 import {
-  App, Credential, GoogleOAuthAccessToken, applicationDefault, cert, deleteApp, initializeApp,
+  App, Credential, GoogleOAuthAccessToken, cert, deleteApp, initializeApp,
 } from '../../lib/app/index'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -87,8 +87,7 @@ before(() => {
   storageBucket = projectId + '.appspot.com';
 
   defaultApp = initializeApp({
-    //...getCredential(),
-    credential: applicationDefault(),
+    ...getCredential(),
     projectId,
     databaseURL: databaseUrl,
     storageBucket,

--- a/test/unit/app-check/app-check-api-client-internal.spec.ts
+++ b/test/unit/app-check/app-check-api-client-internal.spec.ts
@@ -45,7 +45,6 @@ describe('AppCheckApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
 

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -43,7 +43,6 @@ describe('DataConnectApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
 

--- a/test/unit/extensions/extensions-api-client-internal.spec.ts
+++ b/test/unit/extensions/extensions-api-client-internal.spec.ts
@@ -43,7 +43,6 @@ describe('Extension API client', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   }
   

--- a/test/unit/functions/functions-api-client-internal.spec.ts
+++ b/test/unit/functions/functions-api-client-internal.spec.ts
@@ -46,7 +46,6 @@ describe('FunctionsApiClient', () => {
   const EXPECTED_HEADERS = {
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'Authorization': 'Bearer mock-token',
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
 

--- a/test/unit/machine-learning/machine-learning-api-client.spec.ts
+++ b/test/unit/machine-learning/machine-learning-api-client.spec.ts
@@ -117,7 +117,6 @@ describe('MachineLearningApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/remote-config/remote-config-api-client.spec.ts
+++ b/test/unit/remote-config/remote-config-api-client.spec.ts
@@ -57,7 +57,6 @@ describe('RemoteConfigApiClient', () => {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'Accept-Encoding': 'gzip',
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
 

--- a/test/unit/security-rules/security-rules-api-client.spec.ts
+++ b/test/unit/security-rules/security-rules-api-client.spec.ts
@@ -44,7 +44,6 @@ describe('SecurityRulesApiClient', () => {
   const EXPECTED_HEADERS = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
-    'x-goog-user-project': 'test-project',
     'X-Goog-Api-Client': getMetricsHeader(),
   };
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -17,6 +17,7 @@
 
 'use strict';
 
+import * as _ from 'lodash';
 import * as chai from 'chai';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
@@ -35,6 +36,7 @@ import {
 import { deepCopy } from '../../../src/utils/deep-copy';
 import { Agent } from 'http';
 import * as zlib from 'zlib';
+import { getMetricsHeader } from '../../../src/utils';
 
 chai.should();
 chai.use(sinonChai);
@@ -2569,9 +2571,6 @@ describe('AuthorizedHttpClient', () => {
     afterEach(() => {
       transportSpy!.restore();
       transportSpy = null;
-      if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
-        delete process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
-      }
       return mockAppWithAgent.delete();
     });
 
@@ -2648,6 +2647,45 @@ describe('AuthorizedHttpClient', () => {
       expect(resp.status).to.equal(200);
       expect(resp.headers['content-type']).to.equal('application/json');
       expect(resp.data).to.deep.equal(respData);
+    });
+  });
+
+  describe('Quota Project', () => {
+    let stubs: sinon.SinonStub[] = [];
+
+    afterEach(() => {
+      _.forEach(stubs, (stub) => stub.restore());
+      stubs = [];
+      if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
+        delete process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
+      }
+    });
+
+    it('should include quota project id in headers when GOOGLE_CLOUD_QUOTA_PROJECT is set', () => {
+      const reqData = { request: 'data' };
+      const stub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom({}, 200));
+      stubs.push(stub);
+      process.env.GOOGLE_CLOUD_QUOTA_PROJECT = 'test-project-id';
+      const client = new AuthorizedHttpClient(mockApp);
+      return client.send({
+        method: 'POST',
+        url: mockUrl,
+        data: reqData,
+      })
+        .then(() => {
+          expect(stub).to.have.been.calledOnce.and.calledWith({
+            method: 'POST',
+            url: mockUrl,
+            headers: {
+              ...requestHeaders.reqheaders,
+              'x-goog-user-project': 'test-project-id',
+              'X-Goog-Api-Client': getMetricsHeader(),
+            },
+            data: reqData
+          });
+        });
     });
   });
 

--- a/test/unit/utils/api-request.spec.ts
+++ b/test/unit/utils/api-request.spec.ts
@@ -2569,6 +2569,9 @@ describe('AuthorizedHttpClient', () => {
     afterEach(() => {
       transportSpy!.restore();
       transportSpy = null;
+      if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
+        delete process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
+      }
       return mockAppWithAgent.delete();
     });
 


### PR DESCRIPTION
- The quota project id should only be set for Application default credentials with human accounts.
- The SDK will use the quota project id found in credentials (through google-auth-client).
- `GOOGLE_CLOUD_QUOTA_PROJECT` overrides the project id found in credentials.

This PR fixes #2658