### PR TITLE
Return the RequestResponse instead of just awaiting and discarding

### DIFF
--- a/src/functions/functions-api-client-internal.ts
+++ b/src/functions/functions-api-client-internal.ts
@@ -18,7 +18,7 @@
 import { App } from '../app';
 import { FirebaseApp } from '../app/firebase-app';
 import {
-  HttpRequestConfig, HttpClient, RequestResponseError, AuthorizedHttpClient
+  AuthorizedHttpClient, HttpClient, HttpRequestConfig, RequestResponse, RequestResponseError
 } from '../utils/api-request';
 import { PrefixedFirebaseError } from '../utils/error';
 import * as utils from '../utils/index';
@@ -121,7 +121,11 @@ export class FunctionsApiClient {
    * @param extensionId - Optional canonical ID of the extension.
    * @param opts - Optional options when enqueuing a new task.
    */
-  public async enqueue(data: any, functionName: string, extensionId?: string, opts?: TaskOptions): Promise<void> {
+  public async enqueue(
+    data: any,
+    functionName: string,
+    extensionId?: string,
+    opts?: TaskOptions): Promise<RequestResponse | void> {
     if (!validator.isNonEmptyString(functionName)) {
       throw new FirebaseFunctionsError(
         'invalid-argument', 'Function name must be a non empty string');
@@ -159,7 +163,7 @@ export class FunctionsApiClient {
           task: taskPayload,
         }
       };
-      await this.httpClient.send(request);
+      return this.httpClient.send(request);
     } catch (err: unknown) {
       if (err instanceof RequestResponseError) {
         if (err.response.status === 409) {

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -18,6 +18,7 @@
 import { App } from '../app';
 import { FirebaseFunctionsError, FunctionsApiClient } from './functions-api-client-internal';
 import { TaskOptions } from './functions-api';
+import { RequestResponse } from '../utils/api-request';
 import * as validator from '../utils/validator';
 
 /**
@@ -99,7 +100,7 @@ export class TaskQueue<Args = Record<string, any>> {
    * @param opts - Optional options when enqueuing a new task.
    * @returns A promise that resolves when the task has successfully been added to the queue.
    */
-  public enqueue(data: Args, opts?: TaskOptions): Promise<void> {
+  public enqueue(data: Args, opts?: TaskOptions): Promise<RequestResponse | void> {
     return this.client.enqueue(data, this.functionName, this.extensionId, opts);
   }
 


### PR DESCRIPTION
The response's data here contains data of the created Task which is vital for identifying purposes like deleting the task later, it makes no sense to just discard, and is different to what occurs with the cloud task library.

I opened a discussion about this: https://github.com/firebase/firebase-admin-node/issues/2791

But, after being extremely blocked by this issue, I remade the client for local tests, and confirmed that just returning the request gives everything needed.

### Testing

All tests passed.
