### PR TITLE
fix: equality comparison for semantic version when number of segments = max allowed segments

### DIFF
--- a/src/remote-config/condition-evaluator-internal.ts
+++ b/src/remote-config/condition-evaluator-internal.ts
@@ -302,6 +302,10 @@ function compareSemanticVersions(
   const version1 = String(actualValue).split('.').map(Number);
   const version2 = targetValue.split('.').map(Number);
 
+  if (version1.length > MAX_LENGTH || version2.length > MAX_LENGTH) {
+    return false;
+  }
+
   for (let i = 0; i < MAX_LENGTH; i++) {
     // Check to see if segments are present. Note that these may be present and be NaN.
     const version1HasSegment = version1[i] !== undefined;
@@ -321,5 +325,5 @@ function compareSemanticVersions(
     if (version1[i] < version2[i]) return predicateFn(-1);
     if (version1[i] > version2[i]) return predicateFn(1);
   }
-  return false;
+  return predicateFn(0);
 }

--- a/src/remote-config/condition-evaluator-internal.ts
+++ b/src/remote-config/condition-evaluator-internal.ts
@@ -311,9 +311,6 @@ function compareSemanticVersions(
     const version1HasSegment = version1[i] !== undefined;
     const version2HasSegment = version2[i] !== undefined;
 
-    // If both are undefined, we've consumed everything and they're equal.
-    if (!version1HasSegment && !version2HasSegment) return predicateFn(0)
-
     // Insert zeros if undefined for easier comparison.
     if (!version1HasSegment) version1[i] = 0;
     if (!version2HasSegment) version2[i] = 0;
@@ -325,5 +322,6 @@ function compareSemanticVersions(
     if (version1[i] < version2[i]) return predicateFn(-1);
     if (version1[i] > version2[i]) return predicateFn(1);
   }
+  // If this point is reached, the semantic versions equal.
   return predicateFn(0);
 }

--- a/src/remote-config/condition-evaluator-internal.ts
+++ b/src/remote-config/condition-evaluator-internal.ts
@@ -322,6 +322,6 @@ function compareSemanticVersions(
     if (version1[i] < version2[i]) return predicateFn(-1);
     if (version1[i] > version2[i]) return predicateFn(1);
   }
-  // If this point is reached, the semantic versions equal.
+  // If this point is reached, the semantic versions are equal.
   return predicateFn(0);
 }

--- a/test/unit/remote-config/condition-evaluator.spec.ts
+++ b/test/unit/remote-config/condition-evaluator.spec.ts
@@ -1114,6 +1114,7 @@ describe('ConditionEvaluator', () => {
           { targets: ['5.12.3'], actual: '5.11.9', outcome: true },
           { targets: ['5.12.3'], actual: '5.12.3', outcome: true },
           { targets: ['5.12.3'], actual: '5.12.9', outcome: false },
+          { targets: ['5.6.7.8.9'], actual: '5.6.7.8.9', outcome: true },
           invalidNumericSignalTestCase,
         ];
 
@@ -1127,6 +1128,8 @@ describe('ConditionEvaluator', () => {
           { targets: ['5.0'], actual: 5.0, outcome: true },
           { targets: ['5.12.3'], actual: '5.12.9', outcome: false },
           { targets: ['5.12.3'], actual: '5.12.3.0.0.0.0', outcome: false },
+          { targets: ['5.6.7.8.9'], actual: '5.6.7.8.9', outcome: true },
+          { targets: ['5.6.7.8.9.0'], actual: '5.6.7.8.9.0', outcome: false },
           invalidNumericSignalTestCase,
         ];
 
@@ -1166,6 +1169,7 @@ describe('ConditionEvaluator', () => {
           { targets: ['5'], actual: 5.0, outcome: true },
           { targets: ['5.0'], actual: 5.0, outcome: true },
           { targets: ['5.12.3'], actual: '5.11.9', outcome: false },
+          { targets: ['5.6.7.8.9'], actual: '5.6.7.8.9', outcome: true },
           invalidNumericSignalTestCase
         ];
 

--- a/test/unit/remote-config/condition-evaluator.spec.ts
+++ b/test/unit/remote-config/condition-evaluator.spec.ts
@@ -1129,6 +1129,7 @@ describe('ConditionEvaluator', () => {
           { targets: ['5.12.3'], actual: '5.12.9', outcome: false },
           { targets: ['5.12.3'], actual: '5.12.3.0.0.0.0', outcome: false },
           { targets: ['5.6.7.8.9'], actual: '5.6.7.8.9', outcome: true },
+          { targets: ['5.6.7.8.9'], actual: '4.5.6.7.8', outcome: false },
           { targets: ['5.6.7.8.9.0'], actual: '5.6.7.8.9.0', outcome: false },
           invalidNumericSignalTestCase,
         ];


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Testing

  * Make sure all existing tests in the repository pass after your change [Verified all existing tests pass]
  * If you fixed a bug or added a feature, add a new test to cover your code [Unit tests added]

Fixes #2793 
