### PR TITLE
chore: Add firebaseAdminVersion to Firestore settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^7.10.0",
+        "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.14.0"
       }
     },
@@ -705,10 +705,9 @@
       }
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.10.0.tgz",
-      "integrity": "sha512-VFNhdHvfnmqcHHs6YhmSNHHxQqaaD64GwiL0c+e1qz85S8SWZPC2XFRf8p9yHRTF40Kow424s1KBU9f0fdQa+Q==",
-      "license": "Apache-2.0",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.0.tgz",
+      "integrity": "sha512-88uZ+jLsp1aVMj7gh3EKYH1aulTAMFAp8sH/v5a9w8q8iqSG27RiWLoxSAFr/XocZ9hGiWH1kEnBw+zl3xAgNA==",
       "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "uuid": "^11.0.2"
   },
   "optionalDependencies": {
-    "@google-cloud/firestore": "^7.10.0",
+    "@google-cloud/firestore": "^7.11.0",
     "@google-cloud/storage": "^7.14.0"
   },
   "devDependencies": {

--- a/src/firestore/firestore-internal.ts
+++ b/src/firestore/firestore-internal.ts
@@ -113,7 +113,7 @@ export function getFirestoreOptions(app: App, firestoreSettings?: FirestoreSetti
   const projectId: string | null = utils.getExplicitProjectId(app);
   const credential = app.options.credential;
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { version: firebaseVersion } = require('../../package.json');
+  const sdkVersion = utils.getSdkVersion();
   const preferRest = firestoreSettings?.preferRest;
   if (credential instanceof ServiceAccountCredential) {
     return {
@@ -124,7 +124,8 @@ export function getFirestoreOptions(app: App, firestoreSettings?: FirestoreSetti
       // When the SDK is initialized with ServiceAccountCredentials an explicit projectId is
       // guaranteed to be available.
       projectId: projectId!,
-      firebaseVersion,
+      firebaseVersion: sdkVersion,
+      firebaseAdminVersion: sdkVersion,
       preferRest,
     };
   } else if (isApplicationDefault(app.options.credential)) {
@@ -132,8 +133,17 @@ export function getFirestoreOptions(app: App, firestoreSettings?: FirestoreSetti
     // If an explicit project ID is not available, let Firestore client discover one from the
     // environment. This prevents the users from having to set GOOGLE_CLOUD_PROJECT in GCP runtimes.
     return validator.isNonEmptyString(projectId)
-      ? { projectId, firebaseVersion, preferRest }
-      : { firebaseVersion, preferRest };
+      ? {
+        projectId,
+        firebaseVersion: sdkVersion,
+        firebaseAdminVersion: sdkVersion,
+        preferRest
+      }
+      : {
+        firebaseVersion: sdkVersion,
+        firebaseAdminVersion: sdkVersion,
+        preferRest
+      };
   }
 
   throw new FirebaseFirestoreError({
@@ -155,8 +165,8 @@ function initFirestore(app: App, databaseId: string, firestoreSettings?: Firesto
     throw new FirebaseFirestoreError({
       code: 'missing-dependencies',
       message: 'Failed to import the Cloud Firestore client library for Node.js. '
-          + 'Make sure to install the "@google-cloud/firestore" npm package. '
-          + `Original error: ${err}`,
+        + 'Make sure to install the "@google-cloud/firestore" npm package. '
+        + `Original error: ${err}`,
     });
   }
 

--- a/test/unit/firestore/firestore.spec.ts
+++ b/test/unit/firestore/firestore.spec.ts
@@ -27,6 +27,7 @@ import {
   RefreshTokenCredential
 } from '../../../src/app/credential-internal';
 import { FirestoreService, getFirestoreOptions } from '../../../src/firestore/firestore-internal';
+import { getSdkVersion } from '../../../src/utils/index';
 import { DEFAULT_DATABASE_ID } from '@google-cloud/firestore/build/src/path';
 
 describe('Firestore', () => {
@@ -44,7 +45,7 @@ describe('Firestore', () => {
     + 'credentials to use Cloud Firestore API.';
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { version: firebaseVersion } = require('../../../package.json');
+  const sdkVersion = getSdkVersion();
   const defaultCredentialApps = [
     {
       name: 'ComputeEngineCredentials',
@@ -191,13 +192,27 @@ describe('Firestore', () => {
   describe('options.firebaseVersion', () => {
     it('should return firebaseVersion when using credential with service account certificate', () => {
       const options = getFirestoreOptions(mockApp);
-      expect(options.firebaseVersion).to.equal(firebaseVersion);
+      expect(options.firebaseVersion).to.equal(sdkVersion);
     });
 
     defaultCredentialApps.forEach((config) => {
       it(`should return firebaseVersion when using default ${config.name}`, () => {
         const options = getFirestoreOptions(config.app);
-        expect(options.firebaseVersion).to.equal(firebaseVersion);
+        expect(options.firebaseVersion).to.equal(sdkVersion);
+      });
+    });
+  });
+
+  describe('options.firebaseAdminVersion', () => {
+    it('should return firebaseAdminVersion when using credential with service account certificate', () => {
+      const options = getFirestoreOptions(mockApp);
+      expect(options.firebaseAdminVersion).to.equal(sdkVersion);
+    });
+
+    defaultCredentialApps.forEach((config) => {
+      it(`should return firebaseAdminVersion when using default ${config.name}`, () => {
+        const options = getFirestoreOptions(config.app);
+        expect(options.firebaseAdminVersion).to.equal(sdkVersion);
       });
     });
   });


### PR DESCRIPTION
- Set `firebaseAdminVersion` in Firestore setting to append `fire-admin` tag to `x-goog-api-client`.
- Bump `@google-cloud/firestore` to v7.11.0

This is dependent on https://github.com/googleapis/nodejs-firestore/pull/2238 which is available in `@google-cloud/firestore` v7.11.0 but does not break previous versions.
