### PR TITLE
fix(auth): Fix credentials issue in createToken() when using ADC

### DIFF
--- a/src/utils/crypto-signer.ts
+++ b/src/utils/crypto-signer.ts
@@ -108,14 +108,14 @@ export class IAMSigner implements CryptoSigner {
   private serviceAccountId?: string;
   private app?: App;
 
-  constructor(httpClient: AuthorizedHttpClient, app: App) {
+  constructor(httpClient: AuthorizedHttpClient, app?: App) {
     if (!httpClient) {
       throw new CryptoSignerError({
         code: CryptoSignerErrorCode.INVALID_ARGUMENT,
         message: 'INTERNAL ASSERT: Must provide a HTTP client to initialize IAMSigner.',
       });
     }
-    if (typeof app !== 'object' || app === null || !('options' in app)) {
+    if (app && (typeof app !== 'object' || app === null || !('options' in app))) {
       throw new CryptoSignerError({
         code: CryptoSignerErrorCode.INVALID_ARGUMENT,
         message: 'INTERNAL ASSERT: Must provide a valid Firebase app instance.',
@@ -156,12 +156,14 @@ export class IAMSigner implements CryptoSigner {
    */
   public async getAccountId(): Promise<string> {
     if (validator.isNonEmptyString(this.serviceAccountId)) {
-      return Promise.resolve(this.serviceAccountId);
+      return this.serviceAccountId;
     }
-    const accountId = await utils.findServiceAccountEmail(this.app!)
-    if (accountId) {
-      this.serviceAccountId = accountId;
-      return Promise.resolve(accountId);
+    if (this.app) {
+      const accountId = await utils.findServiceAccountEmail(this.app!)
+      if (accountId) {
+        this.serviceAccountId = accountId;
+        return accountId;
+      }
     }
     const request: HttpRequestConfig = {
       method: 'GET',

--- a/test/unit/utils/crypto-signer.spec.ts
+++ b/test/unit/utils/crypto-signer.spec.ts
@@ -103,7 +103,7 @@ describe('CryptoSigner', () => {
       const input = Buffer.from('input');
       const signRequest = {
         method: 'POST',
-        url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-service-account:signBlob',
+        url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@project_id.iam.gserviceaccount.com:signBlob',
         headers: { 
           Authorization: `Bearer ${mockAccessToken}`, 
           'X-Goog-Api-Client': getMetricsHeader()
@@ -120,7 +120,7 @@ describe('CryptoSigner', () => {
         const expectedResult = utils.responseFrom(response);
         stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
         const requestHandler = new AuthorizedHttpClient(mockApp);
-        const signer = new IAMSigner(requestHandler, 'test-service-account');
+        const signer = new IAMSigner(requestHandler, mockApp);
         return signer.sign(input).then((signature) => {
           expect(signature.toString('base64')).to.equal(response.signedBlob);
           expect(stub).to.have.been.calledOnce.and.calledWith(signRequest);
@@ -136,7 +136,7 @@ describe('CryptoSigner', () => {
         });
         stub = sinon.stub(HttpClient.prototype, 'send').rejects(expectedResult);
         const requestHandler = new AuthorizedHttpClient(mockApp);
-        const signer = new IAMSigner(requestHandler, 'test-service-account');
+        const signer = new IAMSigner(requestHandler, mockApp);
         return signer.sign(input).catch((err) => {
           expect(err).to.be.instanceOf(CryptoSignerError);
           expect(err.message).to.equal('Server responded with status 500.');
@@ -145,9 +145,9 @@ describe('CryptoSigner', () => {
         });
       });
 
-      it('should return the explicitly specified service account', () => {
-        const signer = new IAMSigner(new AuthorizedHttpClient(mockApp), 'test-service-account');
-        return signer.getAccountId().should.eventually.equal('test-service-account');
+      it('should return the service account from the app', () => {
+        const signer = new IAMSigner(new AuthorizedHttpClient(mockApp), mockApp);
+        return signer.getAccountId().should.eventually.equal('foo@project_id.iam.gserviceaccount.com');
       });
     });
 


### PR DESCRIPTION
fixes #2800

Instead of passing in an explicit service account name `IAMSigner` now takes in an app instance. This way we can use credentials (Google Auth) instance to get the service account name