### PR TITLE
chore: Update postcheck typescript version

### DIFF
--- a/test/integration/postcheck/package.json
+++ b/test/integration/postcheck/package.json
@@ -14,6 +14,6 @@
     "chai": "^4.2.0",
     "mocha": "^8.0.0",
     "ts-node": "^10.8.1",
-    "typescript": "^4.6.4"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
Update typescript version in the post-check test. We use it to verify the build artifacts in staging.
