### PR TITLE
fix(functions): Use emulated credentials when connecting to the emulator

### DIFF
--- a/src/functions/functions-api-client-internal.ts
+++ b/src/functions/functions-api-client-internal.ts
@@ -54,7 +54,7 @@ export class FunctionsApiClient {
         'invalid-argument',
         'First argument passed to getFunctions() must be a valid Firebase app instance.');
     }
-    this.httpClient = new AuthorizedHttpClient(app as FirebaseApp);
+    this.httpClient = new FunctionsHttpClient(app as FirebaseApp);
   }
   /**
    * Deletes a task from a queue.
@@ -359,6 +359,19 @@ export class FunctionsApiClient {
     }
     const message = error.message || `Unknown server error: ${response.text}`;
     return new FirebaseFunctionsError(code, message);
+  }
+}
+
+/**
+ * Functions-specific HTTP client which uses the special "owner" token
+ * when communicating with the Emulator.
+ */
+class FunctionsHttpClient extends AuthorizedHttpClient {
+  protected getToken(): Promise<string> {
+    if (process.env.CLOUD_TASKS_EMULATOR_HOST) {
+      return Promise.resolve('owner');
+    }
+    return super.getToken();
   }
 }
 


### PR DESCRIPTION
Fixes: #2754 

Added a new `FunctionsHttpClient` class that extends `AuthorizedHttpClient` to handle credentials when communicating with the Task Queue Emulator.