### PR TITLE
fix(fcm): Provide sub errors from a session `AggregateError` to remove ambiguity

### DIFF
--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -1345,9 +1345,16 @@ export class Http2SessionHandler {
       })
 
       http2Session.on('error', (error) => {
+        let errorMessage: any;
+        if (error.name == 'AggregateError' && error.errors) {
+          errorMessage = `Session error while making requests: ${error.code} - ${error.name}: ` +
+            `[${error.errors.map((error: any) => error.message).join(', ')}]`
+        } else {
+          errorMessage = `Session error while making requests: ${error.code} - ${error.message} `
+        }
         this.reject(new FirebaseAppError(
           AppErrorCodes.NETWORK_ERROR,
-          `Session error while making requests: ${error}`
+          errorMessage
         ));
       })
 


### PR DESCRIPTION
RELEASE NOTE: Unwrapped aggregated HTTP/2 session errors to surface the sub errors which caused it.

* Unwraps an `AggregateError` and surfaces the sub errors that caused it.