### PR TITLE
feat(fcm): Support `apns.live_activity_token` field in FCM `ApnsConfig`

### DIFF
--- a/etc/firebase-admin.messaging.api.md
+++ b/etc/firebase-admin.messaging.api.md
@@ -57,6 +57,7 @@ export interface AndroidNotification {
 
 // @public
 export interface ApnsConfig {
+    live_activity_token?: string;
     fcmOptions?: ApnsFcmOptions;
     headers?: {
         [key: string]: string;

--- a/src/messaging/messaging-api.ts
+++ b/src/messaging/messaging-api.ts
@@ -242,6 +242,10 @@ export interface WebpushNotification {
  */
 export interface ApnsConfig {
   /**
+   * APN `live_activity_push_to_start_token` or `live_activity_push_token` to start or update live activities.
+   */
+  live_activity_token?: string;
+  /**
    * A collection of APNs headers. Header values must be strings.
    */
   headers?: { [key: string]: string };

--- a/src/messaging/messaging-internal.ts
+++ b/src/messaging/messaging-internal.ts
@@ -123,9 +123,26 @@ function validateApnsConfig(config: ApnsConfig | undefined): void {
     throw new FirebaseMessagingError(
       MessagingClientErrorCode.INVALID_PAYLOAD, 'apns must be a non-null object');
   }
+  validateApnsLiveActivityToken(config.live_activity_token);
   validateStringMap(config.headers, 'apns.headers');
   validateApnsPayload(config.payload);
   validateApnsFcmOptions(config.fcmOptions);
+}
+
+function validateApnsLiveActivityToken(liveActivityToken: ApnsConfig['live_activity_token']): void {
+  if (typeof liveActivityToken === 'undefined') {
+    return;
+  } else if (!validator.isString(liveActivityToken)) {
+    throw new FirebaseMessagingError(
+      MessagingClientErrorCode.INVALID_PAYLOAD,
+      'apns.live_activity_token must be a string value',
+    );
+  } else if (!validator.isNonEmptyString(liveActivityToken)) {
+    throw new FirebaseMessagingError(
+      MessagingClientErrorCode.INVALID_PAYLOAD,
+      'apns.live_activity_token must be a non-empty string',
+    );
+  }
 }
 
 /**

--- a/test/unit/messaging/messaging.spec.ts
+++ b/test/unit/messaging/messaging.spec.ts
@@ -1725,6 +1725,21 @@ describe('Messaging', () => {
       });
     });
 
+    const invalidApnsLiveActivityTokens: any[] = [null, NaN, 0, 1, true, false]
+    invalidApnsLiveActivityTokens.forEach((arg) => {
+      it(`should throw given invalid apns live activity token: ${JSON.stringify(arg)}`, () => {
+        expect(() => {
+          messaging.send({ apns: { live_activity_token: arg }, topic: 'test' });
+        }).to.throw('apns.live_activity_token must be a string value');
+      });
+    })
+
+    it('should throw given empty apns live activity token', () => {
+      expect(() => {
+        messaging.send({ apns: { live_activity_token: '' }, topic: 'test' });
+      }).to.throw('apns.live_activity_token must be a non-empty string');
+    });
+
     const invalidApnsPayloads: any[] = [null, '', 'payload', true, 1.23];
     invalidApnsPayloads.forEach((payload) => {
       it(`should throw given APNS payload with invalid object: ${JSON.stringify(payload)}`, () => {


### PR DESCRIPTION
* feat(fcm): Support `live_activity_token` field on `ApnsConfig`
* added validation
* update documentation

Fixes #2875