### PR TITLE
chore: Add Node.js 25.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Test PR to trigger CI on Node.js 25.x
