### PR TITLE
refactor: remove uuid dependency and use native crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "google-auth-library": "^9.14.2",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
-        "uuid": "^11.0.2"
+        "node-forge": "^1.3.1"
       },
       "devDependencies": {
         "@firebase/api-documenter": "^0.5.0",
@@ -40,7 +39,6 @@
         "@types/request-promise": "^4.1.41",
         "@types/sinon": "^17.0.2",
         "@types/sinon-chai": "^3.0.0",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@typescript-eslint/parser": "^7.16.1",
         "bcrypt": "^6.0.0",
@@ -2260,13 +2258,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -11762,19 +11753,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -215,8 +215,7 @@
     "google-auth-library": "^9.14.2",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.1.0",
-    "node-forge": "^1.3.1",
-    "uuid": "^11.0.2"
+    "node-forge": "^1.3.1"
   },
   "optionalDependencies": {
     "@google-cloud/firestore": "^7.11.0",
@@ -241,7 +240,6 @@
     "@types/request-promise": "^4.1.41",
     "@types/sinon": "^17.0.2",
     "@types/sinon-chai": "^3.0.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",
     "bcrypt": "^6.0.0",

--- a/src/eventarc/eventarc-client-internal.ts
+++ b/src/eventarc/eventarc-client-internal.ts
@@ -78,7 +78,7 @@ export class EventarcApiClient {
    * 
    * The following CloudEvent fields are auto-populated if not set:
    *  * specversion - `1.0`
-   *  * id - uuidv4()
+   *  * id - a randomly generated UUID v4 string
    *  * source - populated with `process.env.EVENTARC_CLOUD_EVENT_SOURCE` and 
    *             if not set an error is thrown.
    *  

--- a/src/eventarc/eventarc-utils.ts
+++ b/src/eventarc/eventarc-utils.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
+import { randomUUID } from 'crypto';
 import { PrefixedFirebaseError } from '../utils/error';
 import { CloudEvent } from './cloudevent';
-import { v4 as uuid } from 'uuid';
 import * as validator from '../utils/validator';
 
 // List of CloudEvent properties that are handled "by hand" and should be skipped by
@@ -50,7 +50,7 @@ export function toCloudEventProtoFormat(ce: CloudEvent): any {
   }
   const out: Record<string, any> = {
     '@type': 'type.googleapis.com/io.cloudevents.v1.CloudEvent',
-    'id': ce.id ?? uuid(),
+    'id': ce.id ?? randomUUID(),
     'type': ce.type,
     'specVersion': ce.specversion ?? '1.0',
     'source': source

--- a/src/eventarc/eventarc-utils.ts
+++ b/src/eventarc/eventarc-utils.ts
@@ -16,6 +16,7 @@
  */
 
 import { randomUUID } from 'crypto';
+
 import { PrefixedFirebaseError } from '../utils/error';
 import { CloudEvent } from './cloudevent';
 import * as validator from '../utils/validator';

--- a/test/unit/remote-config/condition-evaluator.spec.ts
+++ b/test/unit/remote-config/condition-evaluator.spec.ts
@@ -26,7 +26,6 @@ import {
   NamedCondition,
   OneOfCondition,
 } from '../../../src/remote-config/remote-config-api';
-import { v4 as uuidv4 } from 'uuid';
 import { clone } from 'lodash';
 import * as crypto from 'crypto';
 
@@ -907,7 +906,7 @@ describe('ConditionEvaluator', () => {
             ...clone(condition),
             seed: 'seed'
           };
-          const context = { randomizationId: uuidv4() }
+          const context = { randomizationId: crypto.randomUUID() }
           if (conditionEvaluator.evaluateConditions([{
             name: 'is_enabled',
             condition: { percent: clonedCondition }


### PR DESCRIPTION
## Description

This PR removes the external `uuid` dependency and replaces it with Node.js native `crypto.randomUUID()` for UUID generation.

## Motivation

Since PR #2756 updated the minimum Node.js version requirement to v18, and `crypto.randomUUID()` has been available since Node.js v14.17.0, there is no longer a need for the external `uuid` package dependency.

## Changes

- Removed `uuid` package from `package.json`
- Replaced `import { v4 as uuid } from 'uuid'` with `import { randomUUID } from 'crypto'`
- Updated all `uuidv4()` calls to `randomUUID()`
- Updated tests to use the native implementation

## Testing

- [x] Existing unit tests pass

## References

- Node.js crypto.randomUUID() documentation: https://nodejs.org/api/crypto.html#cryptorandomuuidoptions
- PR #2756