### PR TITLE
fix(rtdb): Apply fake credentials when getting rules for rtdb emulator

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -196,7 +196,7 @@ const RULES_URL_PATH = '.settings/rules.json';
 class DatabaseRulesClient {
 
   private readonly dbUrl: string;
-  private readonly httpClient: DatabaseHttpClient;
+  private readonly httpClient: DatabaseRulesHttpClient;
 
   constructor(app: App, dbUrl: string) {
     let parsedUrl = new URL(dbUrl);
@@ -208,7 +208,7 @@ class DatabaseRulesClient {
 
     parsedUrl.pathname = path.join(parsedUrl.pathname, RULES_URL_PATH);
     this.dbUrl = parsedUrl.toString();
-    this.httpClient = new DatabaseHttpClient(app as FirebaseApp);
+    this.httpClient = new DatabaseRulesHttpClient(app as FirebaseApp);
   }
 
   /**
@@ -316,7 +316,7 @@ class DatabaseRulesClient {
   }
 }
 
-class DatabaseHttpClient extends AuthorizedHttpClient {
+class DatabaseRulesHttpClient extends AuthorizedHttpClient {
   protected getToken(): Promise<string> {
     const emulatorHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
     if (emulatorHost) {


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.

---
Fixes #2034

Running the ff code:
```js
import { initializeApp, cert } from "firebase-admin/app";
import { getDatabase } from "firebase-admin/database";

process.env.FIREBASE_DATABASE_EMULATOR_HOST = "127.0.0.1:9000";

const admin = initializeApp({
  projectId: "demo-project",
  databaseURL: "http://127.0.0.1:9000/?ns=demo-project-default-rtdb",
});
const rtdb = getDatabase(admin);

async function main() {
  const rules = await rtdb.getRules();
  console.log(rules);
}

main();
```
Outputs
```
>node .
{
  "rules": {
    ".read": true, // Message from rules json
    ".write": false
  }
}
```
