### PR TITLE
chore: Rename the default branch to `main`

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -146,8 +146,8 @@ echo_info "Generating changelog"
 echo_info "--------------------------------------------"
 echo_info ""
 
-echo_info "---< git fetch origin master --prune --unshallow >---"
-git fetch origin master --prune --unshallow
+echo_info "---< git fetch origin main --prune --unshallow >---"
+git fetch origin main --prune --unshallow
 echo ""
 
 echo_info "Generating changelog from history..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,12 @@ jobs:
 
     # Check whether the release should be published. We publish only when the trigger PR is
     #   1. merged
-    #   2. to the master branch
+    #   2. to the main branch
     #   3. with the label 'release:publish', and
     #   4. the title prefix '[chore] Release '.
-    if: github.event.pull_request.merged &&
-      github.ref == 'refs/heads/master' &&
+    if: |
+      github.event.pull_request.merged &&
+      github.ref == 'refs/heads/main' &&
       contains(github.event.pull_request.labels.*.name, 'release:publish') &&
       startsWith(github.event.pull_request.title, '[chore] Release ')
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Great, we love hearing how we can improve our products! Share you idea through o
 ## <a name="submit"></a>Want to submit a pull request?
 
 Sweet, we'd love to accept your contribution!
-[Open a new pull request](https://github.com/firebase/firebase-admin-node/pull/new/master) and fill
+[Open a new pull request](https://github.com/firebase/firebase-admin-node/pull/new/main) and fill
 out the provided template.
 
 **If you want to implement a new feature, please open an issue with a proposal first so that we can


### PR DESCRIPTION
Updated the default branch name to `main` where it was used in the scripts.

If you have a local clone, you can update it by running the following commands:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```