### PR TITLE
fix: Invalid provider UID handling in federated user lookup

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -1152,8 +1152,12 @@ export abstract class AbstractAuthRequestHandler {
   }
 
   public getAccountInfoByFederatedUid(providerId: string, rawId: string): Promise<object> {
-    if (!validator.isNonEmptyString(providerId) || !validator.isNonEmptyString(rawId)) {
+    if (!validator.isNonEmptyString(providerId)) {
       throw new FirebaseAuthError(AuthClientErrorCode.INVALID_PROVIDER_ID);
+    }
+
+    if (!validator.isNonEmptyString(rawId)) {
+      throw new FirebaseAuthError(AuthClientErrorCode.INVALID_UID);
     }
 
     const request = {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -1397,10 +1397,10 @@ AUTH_CONFIGS.forEach((testConfig) => {
           .with.property('code', 'auth/invalid-provider-id');
       });
 
-      it('should be rejected given an invalid provider uid', () => {
+      it('should be rejected given an invalid uid', () => {
         expect(() => auth.getUserByProviderUid('id', ''))
           .to.throw(FirebaseAuthError)
-          .with.property('code', 'auth/invalid-provider-id');
+          .with.property('code', 'auth/invalid-uid');
       });
 
       it('should be rejected given an app which returns null access tokens', () => {


### PR DESCRIPTION
Align federated UID validation with the rest of Auth requests. When [getAccountInfoByFederatedUid](https://github.com/firebase/firebase-admin-node/blob/255851bfd80684e5b75e1fa5e362ac8e19c6cb2c/src/auth/auth-api-request.ts#L1154) receives an empty provider UID, it now returns auth/invalid-provider-uid (previously incorrectly auth/invalid-provider-id), matching [validateProviderUserInfo](https://github.com/firebase/firebase-admin-node/blob/255851bfd80684e5b75e1fa5e362ac8e19c6cb2c/src/auth/auth-api-request.ts#L313). 

Unit test updated accordingly.