### PR TITLE
fix(storage): Fix getDownloadURL permission error when connected to emulator

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -75,7 +75,14 @@ export async function getDownloadURL(file: File): Promise<string> {
   const endpoint =
     (process.env.STORAGE_EMULATOR_HOST ||
       'https://firebasestorage.googleapis.com') + '/v0';
-  const { downloadTokens } = await getFirebaseMetadata(endpoint, file);
+  const headers = process.env.STORAGE_EMULATOR_HOST
+    ? { Authorization: 'Bearer owner' }
+    : undefined;
+  const { downloadTokens } = await getFirebaseMetadata(
+    endpoint,
+    file,
+    headers
+  );
   if (!downloadTokens) {
     throw new FirebaseError({
       code: 'storage/no-download-token',

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -19,7 +19,8 @@ export interface FirebaseMetadata {
 
 export function getFirebaseMetadata(
   endpoint: string,
-  file: File
+  file: File,
+  headers?: { [key: string]: string }
 ): Promise<FirebaseMetadata> {
   const uri = `${endpoint}/b/${file.bucket.name}/o/${encodeURIComponent(
     file.name
@@ -30,6 +31,7 @@ export function getFirebaseMetadata(
       {
         method: 'GET',
         uri,
+        headers,
       },
       (err, body) => {
         if (err) {


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.

---

fixes #2344

sets Authorization header as `Bearer owner` which bypasses emulator permissions. Similar to other API calls like https://github.com/firebase/firebase-admin-node/blob/255851bfd80684e5b75e1fa5e362ac8e19c6cb2c/src/auth/auth-api-request.ts#L229-L239