### PR TITLE
fix(auth): capture FIREBASE_AUTH_EMULATOR_HOST at init time

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -127,14 +127,15 @@ class AuthResourceUrlBuilder {
   /**
    * The resource URL builder constructor.
    *
-   * @param projectId - The resource project ID.
+   * @param app - The app for this URL builder.
    * @param version - The endpoint API version.
+   * @param emulatorHost - Optional emulator host captured at init time.
    * @constructor
    */
-  constructor(protected app: App, protected version: string = 'v1') {
-    if (useEmulator()) {
+  constructor(protected app: App, protected version: string = 'v1', emHost?: string) {
+    if (emHost) {
       this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT, {
-        host: emulatorHost()
+        host: emHost
       });
     } else {
       this.urlFormat = FIREBASE_AUTH_BASE_URL_FORMAT;
@@ -191,16 +192,17 @@ class TenantAwareAuthResourceUrlBuilder extends AuthResourceUrlBuilder {
   /**
    * The tenant aware resource URL builder constructor.
    *
-   * @param projectId - The resource project ID.
+   * @param app - The app for this URL builder.
    * @param version - The endpoint API version.
    * @param tenantId - The tenant ID.
+   * @param emHost - Optional emulator host captured at init time.
    * @constructor
    */
-  constructor(protected app: App, protected version: string, protected tenantId: string) {
-    super(app, version);
-    if (useEmulator()) {
+  constructor(protected app: App, protected version: string, protected tenantId: string, emHost?: string) {
+    super(app, version, emHost);
+    if (emHost) {
       this.urlFormat = utils.formatString(FIREBASE_AUTH_EMULATOR_TENANT_URL_FORMAT, {
-        host: emulatorHost()
+        host: emHost
       });
     } else {
       this.urlFormat = FIREBASE_AUTH_TENANT_URL_FORMAT;
@@ -229,8 +231,15 @@ class TenantAwareAuthResourceUrlBuilder extends AuthResourceUrlBuilder {
  */
 class AuthHttpClient extends AuthorizedHttpClient {
 
+  private readonly isEmulator: boolean;
+
+  constructor(app: FirebaseApp, isEmulator: boolean) {
+    super(app);
+    this.isEmulator = isEmulator;
+  }
+
   protected getToken(): Promise<string> {
-    if (useEmulator()) {
+    if (this.isEmulator) {
       return Promise.resolve('owner');
     }
 
@@ -1048,6 +1057,7 @@ const LIST_INBOUND_SAML_CONFIGS = new ApiSettings('/inboundSamlConfigs', 'GET')
 export abstract class AbstractAuthRequestHandler {
 
   protected readonly httpClient: AuthorizedHttpClient;
+  public readonly emulatorHostValue: string | undefined;
   private authUrlBuilder: AuthResourceUrlBuilder;
   private projectConfigUrlBuilder: AuthResourceUrlBuilder;
 
@@ -1102,9 +1112,12 @@ export abstract class AbstractAuthRequestHandler {
 
   /**
    * @param app - The app used to fetch access tokens to sign API requests.
+   * @param emHost - Optional emulator host override. When provided (including
+   *     null for explicitly no emulator), this value is used instead of reading
+   *     from the FIREBASE_AUTH_EMULATOR_HOST environment variable.
    * @constructor
    */
-  constructor(protected readonly app: App) {
+  constructor(protected readonly app: App, emHost?: string | null) {
     if (typeof app !== 'object' || app === null || !('options' in app)) {
       throw new FirebaseAuthError(
         authClientErrorCode.INVALID_ARGUMENT,
@@ -1112,7 +1125,8 @@ export abstract class AbstractAuthRequestHandler {
       );
     }
 
-    this.httpClient = new AuthHttpClient(app as FirebaseApp);
+    this.emulatorHostValue = emHost !== undefined ? (emHost || undefined) : emulatorHost();
+    this.httpClient = new AuthHttpClient(app as FirebaseApp, !!this.emulatorHostValue);
   }
 
   /**
@@ -2135,21 +2149,21 @@ export class AuthRequestHandler extends AbstractAuthRequestHandler {
    */
   constructor(app: App) {
     super(app);
-    this.authResourceUrlBuilder = new AuthResourceUrlBuilder(app, 'v2');
+    this.authResourceUrlBuilder = new AuthResourceUrlBuilder(app, 'v2', this.emulatorHostValue);
   }
 
   /**
    * @returns A new Auth user management resource URL builder instance.
    */
   protected newAuthUrlBuilder(): AuthResourceUrlBuilder {
-    return new AuthResourceUrlBuilder(this.app, 'v1');
+    return new AuthResourceUrlBuilder(this.app, 'v1', this.emulatorHostValue);
   }
 
   /**
    * @returns A new project config resource URL builder instance.
    */
   protected newProjectConfigUrlBuilder(): AuthResourceUrlBuilder {
-    return new AuthResourceUrlBuilder(this.app, 'v2');
+    return new AuthResourceUrlBuilder(this.app, 'v2', this.emulatorHostValue);
   }
 
   /**
@@ -2306,24 +2320,25 @@ export class TenantAwareAuthRequestHandler extends AbstractAuthRequestHandler {
    *
    * @param app - The app used to fetch access tokens to sign API requests.
    * @param tenantId - The request handler's tenant ID.
+   * @param emHost - Optional emulator host override captured at init time.
    * @constructor
    */
-  constructor(app: App, private readonly tenantId: string) {
-    super(app);
+  constructor(app: App, private readonly tenantId: string, emHost?: string | null) {
+    super(app, emHost);
   }
 
   /**
    * @returns A new Auth user management resource URL builder instance.
    */
   protected newAuthUrlBuilder(): AuthResourceUrlBuilder {
-    return new TenantAwareAuthResourceUrlBuilder(this.app, 'v1', this.tenantId);
+    return new TenantAwareAuthResourceUrlBuilder(this.app, 'v1', this.tenantId, this.emulatorHostValue);
   }
 
   /**
    * @returns A new project config resource URL builder instance.
    */
   protected newProjectConfigUrlBuilder(): AuthResourceUrlBuilder {
-    return new TenantAwareAuthResourceUrlBuilder(this.app, 'v2', this.tenantId);
+    return new TenantAwareAuthResourceUrlBuilder(this.app, 'v2', this.tenantId, this.emulatorHostValue);
   }
 
   /**

--- a/src/auth/base-auth.ts
+++ b/src/auth/base-auth.ts
@@ -117,9 +117,10 @@ export interface SessionCookieOptions {
  * @internal
  */
 export function createFirebaseTokenGenerator(app: App,
-  tenantId?: string): FirebaseTokenGenerator {
+  tenantId?: string, isEmulator?: boolean): FirebaseTokenGenerator {
   try {
-    const signer = useEmulator() ? new EmulatedSigner() : cryptoSignerFromApp(app);
+    const shouldEmulate = isEmulator !== undefined ? isEmulator : useEmulator();
+    const signer = shouldEmulate ? new EmulatedSigner() : cryptoSignerFromApp(app);
     return new FirebaseTokenGenerator(signer, tenantId);
   } catch (err) {
     throw handleCryptoSignerError(err);
@@ -139,6 +140,7 @@ export abstract class BaseAuth {
   protected readonly authBlockingTokenVerifier: FirebaseTokenVerifier;
   /** @internal */
   protected readonly sessionCookieVerifier: FirebaseTokenVerifier;
+  private readonly emulatorMode: boolean;
 
   /**
    * The BaseAuth class constructor.
@@ -155,6 +157,8 @@ export abstract class BaseAuth {
     app: App,
     /** @internal */ protected readonly authRequestHandler: AbstractAuthRequestHandler,
     tokenGenerator?: FirebaseTokenGenerator) {
+    this.emulatorMode = !!this.authRequestHandler.emulatorHostValue;
+
     if (tokenGenerator) {
       this.tokenGenerator = tokenGenerator;
     } else {
@@ -211,7 +215,7 @@ export abstract class BaseAuth {
    *   promise.
    */
   public verifyIdToken(idToken: string, checkRevoked = false): Promise<DecodedIdToken> {
-    const isEmulator = useEmulator();
+    const isEmulator = this.emulatorMode;
     return this.idTokenVerifier.verifyJWT(idToken, isEmulator)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
@@ -717,7 +721,7 @@ export abstract class BaseAuth {
    */
   public verifySessionCookie(
     sessionCookie: string, checkRevoked = false): Promise<DecodedIdToken> {
-    const isEmulator = useEmulator();
+    const isEmulator = this.emulatorMode;
     return this.sessionCookieVerifier.verifyJWT(sessionCookie, isEmulator)
       .then((decodedIdToken: DecodedIdToken) => {
         // Whether to check if the token was revoked.
@@ -1095,10 +1099,10 @@ export abstract class BaseAuth {
   /** @alpha */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public _verifyAuthBlockingToken(
-    token: string,  
+    token: string,
     audience?: string
   ): Promise<DecodedAuthBlockingToken> {
-    const isEmulator = useEmulator();
+    const isEmulator = this.emulatorMode;
     return this.authBlockingTokenVerifier._verifyAuthBlockingToken(token, isEmulator, audience)
       .then((decodedAuthBlockingToken: DecodedAuthBlockingToken) => {
         return decodedAuthBlockingToken;

--- a/src/auth/tenant-manager.ts
+++ b/src/auth/tenant-manager.ts
@@ -76,12 +76,15 @@ export class TenantAwareAuth extends BaseAuth {
    *
    * @param app - The app that created this tenant.
    * @param tenantId - The corresponding tenant ID.
+   * @param emHost - Optional emulator host captured at init time.
    * @constructor
    * @internal
    */
-  constructor(app: App, tenantId: string) {
+  constructor(app: App, tenantId: string, emHost?: string | null) {
+    const emIsSet = emHost !== undefined;
     super(app, new TenantAwareAuthRequestHandler(
-      app, tenantId), createFirebaseTokenGenerator(app, tenantId));
+      app, tenantId, emHost), createFirebaseTokenGenerator(
+      app, tenantId, emIsSet ? !!emHost : undefined));
     utils.addReadonlyGetter(this, 'tenantId', tenantId);
   }
 
@@ -148,6 +151,7 @@ export class TenantAwareAuth extends BaseAuth {
 export class TenantManager {
   private readonly authRequestHandler: AuthRequestHandler;
   private readonly tenantsMap: {[key: string]: TenantAwareAuth};
+  private readonly emulatorHost: string | undefined;
 
   /**
    * Initializes a TenantManager instance for a specified FirebaseApp.
@@ -159,6 +163,7 @@ export class TenantManager {
    */
   constructor(private readonly app: App) {
     this.authRequestHandler = new AuthRequestHandler(app);
+    this.emulatorHost = this.authRequestHandler.emulatorHostValue;
     this.tenantsMap = {};
   }
 
@@ -174,7 +179,7 @@ export class TenantManager {
       throw new FirebaseAuthError(authClientErrorCode.INVALID_TENANT_ID);
     }
     if (typeof this.tenantsMap[tenantId] === 'undefined') {
-      this.tenantsMap[tenantId] = new TenantAwareAuth(this.app, tenantId);
+      this.tenantsMap[tenantId] = new TenantAwareAuth(this.app, tenantId, this.emulatorHost ?? null);
     }
     return this.tenantsMap[tenantId];
   }

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -959,6 +959,50 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
             });
           });
       });
+
+      it('should keep using emulator after env var is deleted', () => {
+        const emulatorHost = 'localhost:9099';
+        process.env.FIREBASE_AUTH_EMULATOR_HOST = emulatorHost;
+
+        const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
+        stubs.push(stub);
+
+        const requestHandler = handler.init(mockApp);
+        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+        return requestHandler.getAccountInfoByUid('uid')
+          .then(() => {
+            expect(stub).to.have.been.calledOnce.and.calledWith({
+              method,
+              url: `http://${emulatorHost}/identitytoolkit.googleapis.com${path}`,
+              data,
+              headers: expectedHeadersEmulator,
+              timeout,
+            });
+          });
+      });
+
+      it('should not use emulator when env var is set after initialization', () => {
+        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+        const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
+        stubs.push(stub);
+
+        const requestHandler = handler.init(mockApp);
+        process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+
+        return requestHandler.getAccountInfoByUid('uid')
+          .then(() => {
+            expect(stub).to.have.been.calledOnce.and.calledWith({
+              method,
+              url: `https://${host}${path}`,
+              data,
+              headers: expectedHeaders,
+              timeout,
+            });
+            delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+          });
+      });
     });
 
     describe('createSessionCookie', () => {

--- a/test/unit/auth/auth.spec.ts
+++ b/test/unit/auth/auth.spec.ts
@@ -375,6 +375,46 @@ AUTH_CONFIGS.forEach((testConfig) => {
           expect(tenantManager1).to.equal(tenantManager2);
         });
       });
+
+      describe('authForTenant() emulator isolation', () => {
+        afterEach(() => {
+          delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+        });
+
+        it('should not use emulator for tenant auth when env var set after Auth init', async () => {
+          // Initialize Auth WITHOUT the emulator env var.
+          delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+          const noEmulatorAuth = new Auth(mocks.app());
+
+          // Set the env var AFTER Auth initialization.
+          process.env.FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099';
+
+          // Lazily create tenant auth — should inherit non-emulator mode.
+          const tenantAuth = noEmulatorAuth.tenantManager().authForTenant('tenant1');
+          const token = await tenantAuth.createCustomToken('uid1');
+          const decoded = jwt.decode(token, { complete: true });
+
+          // Token should be signed (not emulator-style unsigned).
+          expect(decoded).to.have.property('header').that.has.property('alg').that.does.not.equal('none');
+        });
+
+        it('should use emulator for tenant auth when env var set before Auth init', async () => {
+          // Initialize Auth WITH the emulator env var.
+          process.env.FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099';
+          const emulatorAuth = new Auth(mocks.app());
+
+          // Delete the env var AFTER Auth initialization.
+          delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+          // Lazily create tenant auth — should inherit emulator mode.
+          const tenantAuth = emulatorAuth.tenantManager().authForTenant('tenant1');
+          const token = await tenantAuth.createCustomToken('uid1');
+          const decoded = jwt.decode(token, { complete: true });
+
+          // Token should be unsigned (emulator-style).
+          expect(decoded).to.have.property('header').that.has.property('alg', 'none');
+        });
+      });
     }
 
     describe('createCustomToken()', () => {
@@ -3972,6 +4012,63 @@ AUTH_CONFIGS.forEach((testConfig) => {
         // the getUser method and get rejected (instead of succeed locally).
         await expect(mockAuth.verifyIdToken(unsignedToken))
           .to.be.rejectedWith(errorMessage);
+      });
+
+      it('verifyIdToken() should still work after env var is deleted', () => {
+        const uid = userRecord.uid;
+        const oneSecBeforeValidSince = Math.floor(validSince.getTime() / 1000 - 1);
+        const getUserStub = sinon.stub(testConfig.Auth.prototype, 'getUser')
+          .resolves(userRecord);
+        stubs.push(getUserStub);
+
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          subject: uid,
+          header: {},
+        }, {
+          iat: oneSecBeforeValidSince,
+          auth_time: oneSecBeforeValidSince,
+        }, 'secret');
+
+        // Delete the env var after init; emulator mode should persist.
+        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+        return mockAuth.verifyIdToken(unsignedToken, false)
+          .then(() => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            // Should still behave as emulator (force revocation check).
+            expect(error).to.have.property('code', 'auth/id-token-revoked');
+            expect(getUserStub).to.have.been.calledOnce.and.calledWith(uid);
+          });
+      });
+
+      it('verifySessionCookie() should still work after env var is deleted', () => {
+        const uid = userRecord.uid;
+        const oneSecBeforeValidSince = Math.floor(validSince.getTime() / 1000 - 1);
+        const getUserStub = sinon.stub(testConfig.Auth.prototype, 'getUser')
+          .resolves(userRecord);
+        stubs.push(getUserStub);
+
+        const unsignedToken = mocks.generateIdToken({
+          algorithm: 'none',
+          subject: uid,
+          issuer: 'https://session.firebase.google.com/' + mocks.projectId,
+        }, {
+          iat: oneSecBeforeValidSince,
+          auth_time: oneSecBeforeValidSince,
+        }, 'secret');
+
+        // Delete the env var after init; emulator mode should persist.
+        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+
+        return mockAuth.verifySessionCookie(unsignedToken, false)
+          .then(() => {
+            throw new Error('Unexpected success');
+          }, (error) => {
+            expect(error).to.have.property('code', 'auth/session-cookie-revoked');
+            expect(getUserStub).to.have.been.calledOnce.and.calledWith(uid);
+          });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes #2948.

`FIREBASE_AUTH_EMULATOR_HOST` was read from `process.env` on every API call, which meant it affected all initialized apps globally. This made it impossible to have one app pointing to the emulator and another to the cloud project in the same process — unlike Firestore, Database, and Storage which already capture their emulator env vars at init time.

This change captures the value of `FIREBASE_AUTH_EMULATOR_HOST` once when the `Auth` service is initialized and stores it per-instance, so each app remembers its own emulator configuration independently.

### What changed

- **`auth-api-request.ts`**: `AuthResourceUrlBuilder`, `TenantAwareAuthResourceUrlBuilder`, and `AuthHttpClient` now receive the emulator host/flag as constructor parameters instead of reading from `process.env`. `AbstractAuthRequestHandler` captures `emulatorHost()` once at construction and threads it through to all URL builders and the HTTP client. `TenantAwareAuthRequestHandler` accepts an optional emulator host override so lazily-created tenant handlers inherit the frozen value.
- **`base-auth.ts`**: `BaseAuth` derives its `emulatorMode` from the request handler captured value instead of calling `useEmulator()` on every `verifyIdToken`/`verifySessionCookie`/`_verifyAuthBlockingToken` call. `createFirebaseTokenGenerator` accepts an optional `isEmulator` override for the same reason.
- **`tenant-manager.ts`**: `TenantManager` captures the emulator host at construction and passes it to `TenantAwareAuth` instances created lazily by `authForTenant()`, so tenant auth inherits the original emulator state.

## Test plan

- [x] All 6197 existing unit tests pass (`npm test`)
- [x] Lint passes
- [x] New tests in `auth-api-request.spec.ts`:
  - Emulator mode persists after env var is deleted post-init
  - Non-emulator mode persists when env var is set after init
- [x] New tests in `auth.spec.ts`:
  - `verifyIdToken()` retains emulator behavior after env var deletion
  - `verifySessionCookie()` retains emulator behavior after env var deletion
  - `authForTenant()` does not use emulator when env var set after `Auth` init
  - `authForTenant()` uses emulator when env var set before `Auth` init (and deleted after)