### PR TITLE
fix(app): replace node-forge with native crypto for private key validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-admin",
-  "version": "13.7.0",
+  "version": "13.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-admin",
-      "version": "13.7.0",
+      "version": "13.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -17,7 +17,6 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "devDependencies": {
@@ -8873,15 +8872,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {

--- a/package.json
+++ b/package.json
@@ -222,7 +222,6 @@
     "google-auth-library": "^10.6.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.1.0",
-    "node-forge": "^1.4.0",
     "uuid": "^11.0.2"
   },
   "optionalDependencies": {

--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -16,6 +16,7 @@
  */
 
 import fs = require('fs');
+import { createPrivateKey } from 'crypto';
 
 import { Credentials as GoogleAuthCredentials, GoogleAuth, Compute, AnyAuthClient } from 'google-auth-library'
 import { Agent } from 'http';
@@ -214,10 +215,8 @@ class ServiceAccount {
       throw new FirebaseAppError(AppErrorCodes.INVALID_CREDENTIAL, errorMessage);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const forge = require('node-forge');
     try {
-      forge.pki.privateKeyFromPem(this.privateKey);
+      createPrivateKey(this.privateKey);
     } catch (error) {
       throw new FirebaseAppError(
         AppErrorCodes.INVALID_CREDENTIAL,


### PR DESCRIPTION
Fixes #3075

## Problem
`initializeApp()` with a `cert()` credential calls `require('node-forge')` synchronously during `ServiceAccount` construction. Loading `node-forge` initializes a PRNG that uses `Math.random()`, which causes errors in environments that restrict non-deterministic APIs during static rendering — specifically Next.js App Router with Partial Pre-Rendering (PPR) / SSG:

> Error: Route used `Math.random()` before accessing either uncached data or Request data...

## Solution
Replace `forge.pki.privateKeyFromPem()` with Node.js built-in `crypto.createPrivateKey()`. This provides equivalent PEM validation while removing the `node-forge` dependency entirely.

## Testing
All 6231 existing unit tests pass. The existing test `should throw given an object with a malformed "private_key" property` in `credential-internal.spec.ts` already covers the error path for invalid private keys.

## Notes
- No public API changes
- Removes ~500KB dependency (`node-forge`)
- Related: #3051 proposed the same fix but was blocked by a CLA issue