### PR TITLE
fix: Replace deprecated url.parse() with WHATWG URL (DEP0169)

### DIFF
--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -23,7 +23,6 @@ import * as validator from './validator';
 import http = require('http');
 import https = require('https');
 import http2 = require('http2');
-import url = require('url');
 import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 import * as zlibmod from 'zlib';
@@ -991,23 +990,23 @@ class BaseRequestConfigImpl implements BaseRequestConfig {
     return data;
   }
 
-  protected buildUrl(): url.UrlWithStringQuery {
+  protected buildUrl(): URL {
     const fullUrl: string = this.urlWithProtocol();
+    const parsedUrl = new URL(fullUrl);
     if (!this.hasEntity() || this.isEntityEnclosingRequest()) {
-      return url.parse(fullUrl);
+      return parsedUrl;
     }
     if (!validator.isObject(this.data)) {
       throw new Error(`${this.method} requests cannot have a body`);
     }
-    // Parse URL and append data to query string.
-    const parsedUrl = new url.URL(fullUrl);
-    const dataObj = this.data as { [key: string]: string; };
+    // Append data to query string.
+    const dataObj = this.data as {[key: string]: string};
     for (const key in dataObj) {
       if (Object.prototype.hasOwnProperty.call(dataObj, key)) {
         parsedUrl.searchParams.append(key, dataObj[key]);
       }
     }
-    return url.parse(parsedUrl.toString());
+    return parsedUrl;
   }
 
   protected urlWithProtocol(): string {
@@ -1044,7 +1043,7 @@ class HttpRequestConfigImpl extends BaseRequestConfigImpl implements HttpRequest
   public buildRequestOptions(): https.RequestOptions {
     const parsed = this.buildUrl();
     const protocol = parsed.protocol;
-    let port: string | null = parsed.port;
+    let port: string = parsed.port;
     if (!port) {
       const isHttps = protocol === 'https:';
       port = isHttps ? '443' : '80';
@@ -1054,7 +1053,7 @@ class HttpRequestConfigImpl extends BaseRequestConfigImpl implements HttpRequest
       protocol,
       hostname: parsed.hostname,
       port,
-      path: parsed.path,
+      path: `${parsed.pathname}${parsed.search}`,
       method: this.method,
       agent: this.httpAgent,
       headers: Object.assign({}, this.headers),
@@ -1082,7 +1081,7 @@ class Http2RequestConfigImpl extends BaseRequestConfigImpl implements Http2Reque
 
     return {
       protocol,
-      path: parsed.path,
+      path: `${parsed.pathname}${parsed.search}`,
       method: this.method,
       headers: Object.assign({}, this.headers),
     };


### PR DESCRIPTION
Closes #3118.

`url.parse()` is deprecated (DEP0169) and emits warnings on every cold start in serverless runtimes. This swaps the two call sites in `BaseRequestConfigImpl.buildUrl()` for the WHATWG `URL` constructor, matching the pattern @lahirumaramba used for `validator.isURL()` in #3061.

### Changes

- `BaseRequestConfigImpl.buildUrl()` returns `URL` instead of `url.UrlWithStringQuery`. The method is `protected` and only used by two subclasses inside the same file, so this is not a public surface change.
- Both branches of `buildUrl()` now reuse a single `new URL(fullUrl)` instance instead of allocating one and re-parsing it via `url.parse()`.
- `parsed.path` is replaced with `${parsed.pathname}${parsed.search}` so the request path on the wire stays byte-for-byte identical.
- `parsed.port` is now `string` (always) rather than `string | null`. The existing `if (!port)` falsy check still picks up the empty case.

### Behavior

For valid inputs the request URL is byte-for-byte identical. For malformed inputs the WHATWG parser is stricter than `url.parse()`: depending on the input shape it may either canonicalize the input differently (`urlWithProtocol()` always prepends `https://`, so e.g. `//evil.com` becomes `https://evil.com/`) or throw a `TypeError`. SDK-internal callers normalize their URLs before invoking, so well-formed usage is unaffected.

### Out of scope

The transitive callers listed in #3118 (`http-proxy-agent`, `teeny-request`/`agent-base`, `faye-websocket`, `@firebase/database-compat`) live in separate repositories and need to be addressed there.

### Verification

- `npx tsc --noEmit -p .` — clean
- `npx eslint src/utils/api-request.ts` — 0 warnings
- `npx mocha test/unit/utils/api-request.spec.ts --require ts-node/register` — 199 passing
- `npx mocha test/unit/index.spec.ts --require ts-node/register` — 6231 passing

No spec changes: existing api-request tests already cover explicit non-default ports (`mockHost:8080`), POST with entity body, GET path matching, and nock interceptor URL parsing — all of which exercise the changed code paths.
