### PR TITLE
chore: Deprecate support for Node.js 20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ information on using pull requests.
 
 ### Prerequisites
 
-1. Node.js 18 or higher.
+1. Node.js 22 or higher.
 2. `npm` 6 or higher.
 3. Google Cloud SDK ([`gcloud`](https://cloud.google.com/sdk/downloads) utility).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ information on using pull requests.
 
 ### Prerequisites
 
-1. Node.js 16 or higher.
+1. Node.js 18 or higher.
 2. `npm` 6 or higher.
 3. Google Cloud SDK ([`gcloud`](https://cloud.google.com/sdk/downloads) utility).
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Environments
 
-We currently support Node.js 18 and higher, but its support is deprecated. We strongly encourage
-you to use Node.js 20 or higher as we will drop support for Node.js 18 in the next major version.
+We currently support Node.js 18 and higher, but support for Node.js 18 and Node.js 20 is deprecated. We strongly encourage
+you to use Node.js 22 or higher as we will drop support for Node.js 18 and Node.js 20 in the next major version.
 
 Please also note that the Admin SDK should only
 be used in server-side/back-end environments controlled by the app developer.


### PR DESCRIPTION
Node.js 20 has reached EOL. Deprecate support for Node.js 20