### PR TITLE
fix(auth): add missing name field to DecodedIdToken

### DIFF
--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -697,6 +697,7 @@ export interface DecodedIdToken {
     };
     iat: number;
     iss: string;
+    name?: string;
     phone_number?: string;
     picture?: string;
     sub: string;

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -146,6 +146,11 @@ export interface DecodedIdToken {
   iss: string;
 
   /**
+   * The display name of the user to whom the ID token belongs, if available.
+   */
+  name?: string;
+
+  /**
    * The phone number of the user to whom the ID token belongs, if available.
    */
   phone_number?: string;


### PR DESCRIPTION
The DecodedIdToken returned from the `verifySessionCookie` or `verifyIdToken` methods is guaranteed to have an optional name field at runtime, but the field is not present in the type declaration.
Therefore, the name field is recognized as `any`, requiring unnecessary type guards or casting. This is a PR to resolve this issue.

[firebase docs link](https://firebase.google.com/docs/reference/js/v8/firebase.FirebaseIdToken)
In this document, the token has an optional name field.

**Changes**
- Add name?: string to DecodedIdToken
- Add a doc comment for the new field in src/auth/token-verifier.ts
- Update the generated API surface in etc/firebase-admin.auth.api.md