### PR TITLE
fix(auth): skip project config name assertion when using the Auth emulator

### DIFF
--- a/src/auth/auth-api-request.ts
+++ b/src/auth/auth-api-request.ts
@@ -2035,6 +2035,11 @@ export abstract class AbstractAuthRequestHandler {
 /** Instantiates the getConfig endpoint settings. */
 const GET_PROJECT_CONFIG = new ApiSettings('/config', 'GET')
   .setResponseValidator((response: RequestResponse) => {
+    // The Auth emulator does not populate the resource `name` field on the
+    // project config response, so skip the assertion when running against it.
+    if (useEmulator()) {
+      return;
+    }
     const data = response.data;
     // Response should always contain at least the config name.
     if (!validator.isNonEmptyString(data?.name)) {
@@ -2049,6 +2054,11 @@ const GET_PROJECT_CONFIG = new ApiSettings('/config', 'GET')
 /** Instantiates the updateConfig endpoint settings. */
 const UPDATE_PROJECT_CONFIG = new ApiSettings('/config?updateMask={updateMask}', 'PATCH')
   .setResponseValidator((response: RequestResponse) => {
+    // The Auth emulator does not populate the resource `name` field on the
+    // project config response, so skip the assertion when running against it.
+    if (useEmulator()) {
+      return;
+    }
     const data = response.data;
     // Response should always contain at least the config name.
     if (!validator.isNonEmptyString(data?.name)) {

--- a/test/unit/auth/auth-api-request.spec.ts
+++ b/test/unit/auth/auth-api-request.spec.ts
@@ -46,7 +46,7 @@ import { getMetricsHeader, getSdkVersion } from '../../../src/utils/index';
 import {
   UserImportRecord, OIDCAuthProviderConfig, SAMLAuthProviderConfig, OIDCUpdateAuthProviderRequest,
   SAMLUpdateAuthProviderRequest, UserIdentifier, UpdateRequest, UpdateMultiFactorInfoRequest,
-  CreateTenantRequest, UpdateTenantRequest,
+  CreateTenantRequest, UpdateTenantRequest, UpdateProjectConfigRequest,
 } from '../../../src/auth/index';
 
 chai.should();
@@ -4461,6 +4461,131 @@ AUTH_REQUEST_HANDLER_TESTS.forEach((handler) => {
     });
 
     if (handler.supportsTenantManagement) {
+      describe('getProjectConfig', () => {
+        const path = '/v2/projects/project_id/config';
+        const method = 'GET';
+        const expectedResult = utils.responseFrom({
+          name: 'projects/project_id/config',
+        });
+
+        afterEach(() => {
+          delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+        });
+
+        it('should be fulfilled with the project config response', () => {
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.getProjectConfig()
+            .then((result) => {
+              expect(result).to.deep.equal(expectedResult.data);
+              expect(stub).to.have.been.calledOnce.and.calledWith(callParams(path, method, {}));
+            });
+        });
+
+        it('should be rejected when the response is missing the name field', () => {
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(utils.responseFrom({}));
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.getProjectConfig()
+            .then(() => {
+              throw new Error('Unexpected success');
+            }, (error) => {
+              expect(error).to.have.property('code', 'auth/internal-error');
+              expect(error.message).to.equal('INTERNAL ASSERT FAILED: Unable to get project config');
+            });
+        });
+
+        it('should be fulfilled when the response is missing the name field and the emulator is running', () => {
+          const emulatorHost = 'localhost:9099';
+          process.env.FIREBASE_AUTH_EMULATOR_HOST = emulatorHost;
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(utils.responseFrom({}));
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.getProjectConfig()
+            .then((result) => {
+              expect(result).to.deep.equal({});
+              expect(stub).to.have.been.calledOnce.and.calledWith({
+                method,
+                url: `http://${emulatorHost}/identitytoolkit.googleapis.com${path}`,
+                headers: expectedHeadersEmulator,
+                data: {},
+                timeout,
+              });
+            });
+        });
+      });
+
+      describe('updateProjectConfig', () => {
+        const path = '/v2/projects/project_id/config';
+        const method = 'PATCH';
+        const validRequest: UpdateProjectConfigRequest = {
+          smsRegionConfig: {
+            allowlistOnly: {
+              allowedRegions: ['AC', 'AD'],
+            },
+          },
+        };
+        const expectedPath = path + '?updateMask=smsRegionConfig.allowlistOnly.allowedRegions';
+        const expectedResult = utils.responseFrom({
+          name: 'projects/project_id/config',
+        });
+
+        afterEach(() => {
+          delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+        });
+
+        it('should be fulfilled with the updated project config response', () => {
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(expectedResult);
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.updateProjectConfig(validRequest)
+            .then((result) => {
+              expect(result).to.deep.equal(expectedResult.data);
+              expect(stub).to.have.been.calledOnce.and.calledWith(
+                callParams(expectedPath, method, validRequest));
+            });
+        });
+
+        it('should be rejected when the response is missing the name field', () => {
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(utils.responseFrom({}));
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.updateProjectConfig(validRequest)
+            .then(() => {
+              throw new Error('Unexpected success');
+            }, (error) => {
+              expect(error).to.have.property('code', 'auth/internal-error');
+              expect(error.message).to.equal('INTERNAL ASSERT FAILED: Unable to update project config');
+            });
+        });
+
+        it('should be fulfilled when the response is missing the name field and the emulator is running', () => {
+          const emulatorHost = 'localhost:9099';
+          process.env.FIREBASE_AUTH_EMULATOR_HOST = emulatorHost;
+          const stub = sinon.stub(HttpClient.prototype, 'send').resolves(utils.responseFrom({}));
+          stubs.push(stub);
+
+          const requestHandler = handler.init(mockApp) as AuthRequestHandler;
+          return requestHandler.updateProjectConfig(validRequest)
+            .then((result) => {
+              expect(result).to.deep.equal({});
+              expect(stub).to.have.been.calledOnce.and.calledWith({
+                method,
+                url: `http://${emulatorHost}/identitytoolkit.googleapis.com${expectedPath}`,
+                headers: expectedHeadersEmulator,
+                data: validRequest,
+                timeout,
+              });
+            });
+        });
+      });
+
       describe('getTenant', () => {
         const path = '/v2/projects/project_id/tenants/tenant-id';
         const method = 'GET';


### PR DESCRIPTION
Closes #2461.

Thanks @nerder and @mexican-jack for the same-symptom reports on `updateProjectConfig` and password policy updates — both go through the endpoints touched here.

## Summary

`getProjectConfig()` and `updateProjectConfig()` throw `INTERNAL ASSERT FAILED: Unable to get/update project config` when the Auth emulator is running. The emulator doesn't populate the resource `name` field on `/config` responses, and both endpoint validators require `name` to be a non-empty string.

This PR skips that assertion when `useEmulator()` is true so the call succeeds against the emulator. Production behavior is unchanged.

## Behavior change

- Emulator (`FIREBASE_AUTH_EMULATOR_HOST` set): `getProjectConfig()` / `updateProjectConfig()` resolve with whatever the emulator returns.
- Production: identical to before. A backend response missing `name` still throws `INTERNAL ASSERT FAILED`.

The Identity Toolkit `projects.getConfig` / `projects.updateConfig` REST contract treats `name` as an output-only resource name that production always populates — the emulator just doesn't implement it.

## Scope

The guard is limited to `GET_PROJECT_CONFIG` and `UPDATE_PROJECT_CONFIG` because those are the two endpoints with reproductions in the issue and its comments. Other validators in the same file (`GET_TENANT`, `UPDATE_TENANT`, OIDC/SAML config) follow the same pattern but have no emulator reports — leaving them out keeps the diff narrow.

Password policy updates (raised by @mexican-jack) go through `updateProjectConfig` internally, so this PR covers that case as well.

## Implementation notes

The guard uses the existing `useEmulator()` helper at `src/auth/auth-api-request.ts:2321` — the same one `AuthResourceUrlBuilder` (line 134), `TenantAwareAuthResourceUrlBuilder` (line 200), and `AuthHttpClient` (line 232) use to branch on the emulator. Same dynamic-read pattern as the rest of `main`.

## Relationship to #3080

#3080 is open in the same area and captures the emulator host at init time instead of reading it on each call. This PR uses the dynamic `useEmulator()` read because that's what `main` does today. If #3080 lands first, I'll rebase and switch the validator guard to the captured value so the emulator semantics stay aligned.

## Test coverage

`test/unit/auth/auth-api-request.spec.ts` adds a `getProjectConfig` and an `updateProjectConfig` describe block under the `supportsTenantManagement` branch. Each has three cases:

- normal production response with `name` populated — strict `callParams` match (URL, method, body, headers, timeout) for regression coverage
- production response missing `name` — still throws (covers the existing assertion)
- response missing `name` with `FIREBASE_AUTH_EMULATOR_HOST` set — resolves, with a strict match against the emulator URL `http://localhost:9099/identitytoolkit.googleapis.com/v2/projects/project_id/config[?updateMask=...]` and the `Bearer owner` emulator headers

`afterEach` clears `FIREBASE_AUTH_EMULATOR_HOST` so emulator state doesn't bleed into other specs.

## Verification

- `npm run lint` — 0 errors.
- `npx mocha test/unit/auth/auth-api-request.spec.ts --require ts-node/register` — 746 passing, 0 failing.
- `npm run test:unit` — 6246 passing, 0 failing.

Diff: 2 files changed, +136 insertions, -1 deletion (10 LOC in `src`, the rest in test).
