### PR TITLE
chore: Add node: prefix to crypto imports

### DIFF
--- a/src/app/credential-internal.ts
+++ b/src/app/credential-internal.ts
@@ -16,7 +16,7 @@
  */
 
 import fs = require('fs');
-import { createPrivateKey } from 'crypto';
+import { createPrivateKey } from 'node:crypto';
 
 import { Credentials as GoogleAuthCredentials, GoogleAuth, Compute, AnyAuthClient } from 'google-auth-library'
 import { Agent } from 'http';

--- a/src/remote-config/condition-evaluator-internal.ts
+++ b/src/remote-config/condition-evaluator-internal.ts
@@ -27,7 +27,7 @@ import {
   CustomSignalCondition,
   CustomSignalOperator,
 } from './remote-config-api';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 
 /**

--- a/src/utils/crypto-signer.ts
+++ b/src/utils/crypto-signer.ts
@@ -79,7 +79,7 @@ export class ServiceAccountSigner implements CryptoSigner {
    * @inheritDoc
    */
   public sign(buffer: Buffer): Promise<Buffer> {
-    const crypto = require('crypto'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const crypto = require('node:crypto'); // eslint-disable-line @typescript-eslint/no-var-requires
     const sign = crypto.createSign('RSA-SHA256');
     sign.update(buffer);
     return Promise.resolve(sign.sign(this.credential.privateKey));

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import * as url from 'url';
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
 import * as bcrypt from 'bcrypt';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';

--- a/test/unit/remote-config/condition-evaluator.spec.ts
+++ b/test/unit/remote-config/condition-evaluator.spec.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../src/remote-config/remote-config-api';
 import { v4 as uuidv4 } from 'uuid';
 import { clone } from 'lodash';
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
 
 const expect = chai.expect;
 

--- a/test/unit/utils/crypto-signer.spec.ts
+++ b/test/unit/utils/crypto-signer.spec.ts
@@ -57,7 +57,7 @@ describe('CryptoSigner', () => {
       const cert = new ServiceAccountCredential(mocks.certificateObject);
 
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const crypto = require('crypto');
+      const crypto = require('node:crypto');
       const rsa = crypto.createSign('RSA-SHA256');
       rsa.update(payload);
       const result = rsa.sign(cert.privateKey, 'base64');
@@ -104,8 +104,8 @@ describe('CryptoSigner', () => {
       const signRequest = {
         method: 'POST',
         url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@project_id.iam.gserviceaccount.com:signBlob',
-        headers: { 
-          Authorization: `Bearer ${mockAccessToken}`, 
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
           'X-Goog-Api-Client': getMetricsHeader()
         },
         data: { payload: input.toString('base64') },
@@ -162,7 +162,7 @@ describe('CryptoSigner', () => {
       const signRequest = {
         method: 'POST',
         url: 'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/discovered-service-account:signBlob',
-        headers: { 
+        headers: {
           Authorization: `Bearer ${mockAccessToken}`,
           'X-Goog-Api-Client': getMetricsHeader()
         },


### PR DESCRIPTION
Prefix native `crypto` module imports with `node:` across source files and tests. This explicitly distinguishes the built-in Node.js module from third-party packages, aligning with modern ESM and cross-runtime compatibility standards (e.g., Cloudflare Workers, Deno, Bun).