### PR TITLE
fix(fcm): Map topic subscription `RESOURCE_EXHAUSTED` server code to new `TOPICS_SUBSCRIPTION_RATE_EXCEEDED` SDK error code

### DIFF
--- a/etc/firebase-admin.messaging.api.md
+++ b/etc/firebase-admin.messaging.api.md
@@ -211,6 +211,7 @@ export const MessagingErrorCode: {
     readonly INVALID_PACKAGE_NAME: "invalid-package-name";
     readonly DEVICE_MESSAGE_RATE_EXCEEDED: "device-message-rate-exceeded";
     readonly TOPICS_MESSAGE_RATE_EXCEEDED: "topics-message-rate-exceeded";
+    readonly TOPICS_SUBSCRIPTION_RATE_EXCEEDED: "topics-subscription-rate-exceeded";
     readonly MESSAGE_RATE_EXCEEDED: "message-rate-exceeded";
     readonly THIRD_PARTY_AUTH_ERROR: "third-party-auth-error";
     readonly TOO_MANY_TOPICS: "too-many-topics";

--- a/src/messaging/error.ts
+++ b/src/messaging/error.ts
@@ -34,6 +34,7 @@ export const MessagingErrorCode = {
   INVALID_PACKAGE_NAME: 'invalid-package-name',
   DEVICE_MESSAGE_RATE_EXCEEDED: 'device-message-rate-exceeded',
   TOPICS_MESSAGE_RATE_EXCEEDED: 'topics-message-rate-exceeded',
+  TOPICS_SUBSCRIPTION_RATE_EXCEEDED: 'topics-subscription-rate-exceeded',
   MESSAGE_RATE_EXCEEDED: 'message-rate-exceeded',
   THIRD_PARTY_AUTH_ERROR: 'third-party-auth-error',
   TOO_MANY_TOPICS: 'too-many-topics',
@@ -110,6 +111,12 @@ export const messagingClientErrorCode: { readonly [K in keyof typeof MessagingEr
     code: MessagingErrorCode.TOPICS_MESSAGE_RATE_EXCEEDED,
     message: 'The rate of messages to subscribers to a particular topic is too ' +
       'high. Reduce the number of messages sent for this topic, and do not immediately retry sending ' +
+      'to this topic.',
+  },
+  TOPICS_SUBSCRIPTION_RATE_EXCEEDED: {
+    code: MessagingErrorCode.TOPICS_SUBSCRIPTION_RATE_EXCEEDED,
+    message: 'The rate of subscription requests to a particular topic is too ' +
+      'high. Reduce the number of requests sent for this topic, and do not immediately retry subscribing ' +
       'to this topic.',
   },
   MESSAGE_RATE_EXCEEDED: {
@@ -207,7 +214,7 @@ const TOPIC_MGT_SERVER_TO_CLIENT_CODE: Record<string, keyof typeof MessagingErro
   NOT_FOUND: 'REGISTRATION_TOKEN_NOT_REGISTERED',
   INVALID_ARGUMENT: 'INVALID_REGISTRATION_TOKEN',
   TOO_MANY_TOPICS: 'TOO_MANY_TOPICS',
-  RESOURCE_EXHAUSTED: 'TOO_MANY_TOPICS',
+  RESOURCE_EXHAUSTED: 'TOPICS_SUBSCRIPTION_RATE_EXCEEDED',
   PERMISSION_DENIED: 'AUTHENTICATION_ERROR',
   DEADLINE_EXCEEDED: 'SERVER_UNAVAILABLE',
   INTERNAL: 'INTERNAL_ERROR',

--- a/src/messaging/error.ts
+++ b/src/messaging/error.ts
@@ -117,7 +117,7 @@ export const messagingClientErrorCode: { readonly [K in keyof typeof MessagingEr
     code: MessagingErrorCode.TOPICS_SUBSCRIPTION_RATE_EXCEEDED,
     message: 'The rate of subscription management requests to a particular topic is too ' +
       'high. Reduce the number of requests sent for this topic, and do not immediately retry the ' +
-      'request for this topic.',
+      'request.',
   },
   MESSAGE_RATE_EXCEEDED: {
     code: MessagingErrorCode.MESSAGE_RATE_EXCEEDED,

--- a/src/messaging/error.ts
+++ b/src/messaging/error.ts
@@ -115,9 +115,9 @@ export const messagingClientErrorCode: { readonly [K in keyof typeof MessagingEr
   },
   TOPICS_SUBSCRIPTION_RATE_EXCEEDED: {
     code: MessagingErrorCode.TOPICS_SUBSCRIPTION_RATE_EXCEEDED,
-    message: 'The rate of subscription requests to a particular topic is too ' +
-      'high. Reduce the number of requests sent for this topic, and do not immediately retry subscribing ' +
-      'to this topic.',
+    message: 'The rate of subscription management requests to a particular topic is too ' +
+      'high. Reduce the number of requests sent for this topic, and do not immediately retry the ' +
+      'request for this topic.',
   },
   MESSAGE_RATE_EXCEEDED: {
     code: MessagingErrorCode.MESSAGE_RATE_EXCEEDED,


### PR DESCRIPTION
Previously we incorrectly mapped the topic subscription `RESOURCE_EXHAUSTED` FCM server code to `TOO_MANY_TOPICS` SDK error code leading to misleading error messaging for the cause of the error. This PR introduces a new `TOPICS_SUBSCRIPTION_RATE_EXCEEDED` to correctly attribute the error.

RELEASE_NOTE: Mapped the topic management `RESOURCE_EXHAUSTED` server error to a new `TOPICS_SUBSCRIPTION_RATE_EXCEEDED` code instead of `TOO_MANY_TOPICS` to improve subscription rate limits error messaging.