### PR TITLE
fix: resolve failing getApplicationDefault unit tests in gcloud env

### DIFF
--- a/src/utils/crypto-signer.ts
+++ b/src/utils/crypto-signer.ts
@@ -79,7 +79,7 @@ export class ServiceAccountSigner implements CryptoSigner {
    * @inheritDoc
    */
   public sign(buffer: Buffer): Promise<Buffer> {
-    const crypto = require('node:crypto'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const crypto = require('node:crypto');
     const sign = crypto.createSign('RSA-SHA256');
     sign.update(buffer);
     return Promise.resolve(sign.sign(this.credential.privateKey));

--- a/test/unit/app/credential-internal.spec.ts
+++ b/test/unit/app/credential-internal.spec.ts
@@ -26,6 +26,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { UserRefreshClient } from 'google-auth-library';
 
 import * as mocks from '../../resources/mocks';
 
@@ -68,11 +69,16 @@ describe('Credential', () => {
 
   beforeEach(() => {
     mockCertificateObject = _.clone(mocks.certificateObject);
-    oldProcessEnv = process.env;
+    oldProcessEnv = { ...process.env };
   });
 
   afterEach(() => {
-    process.env = oldProcessEnv;
+    for (const key of Object.keys(process.env)) {
+      if (!(key in oldProcessEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, oldProcessEnv);
   });
 
   describe('ServiceAccountCredential', () => {
@@ -310,7 +316,7 @@ describe('Credential', () => {
       expect(c).to.be.an.instanceof(ApplicationDefaultCredential);
     });
 
-    it('should return a RefreshTokenCredential with gcloud login', () => {
+    it('should return a RefreshTokenCredential with gcloud login', async () => {
       if (!fs.existsSync(GCLOUD_CREDENTIAL_PATH)) {
         // tslint:disable-next-line:no-console
         console.log(
@@ -319,7 +325,12 @@ describe('Credential', () => {
         return;
       }
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-      expect((getApplicationDefault())).to.be.an.instanceof(RefreshTokenCredential);
+      const c = getApplicationDefault();
+      expect(c).to.be.an.instanceof(ApplicationDefaultCredential);
+
+      process.env.GOOGLE_CLOUD_PROJECT = 'mock-project';
+      const client = await (c as any).googleAuth.getClient();
+      expect(client).to.be.an.instanceof(UserRefreshClient);
     });
 
     it('should return a MetadataServiceCredential as a last resort', () => {
@@ -345,7 +356,7 @@ describe('Credential', () => {
       expect(isApplicationDefault(c)).to.be.true;
     });
 
-    it('should return true for credential loaded from gcloud SDK', () => {
+    it('should return true for credential loaded from gcloud SDK', async () => {
       if (!fs.existsSync(GCLOUD_CREDENTIAL_PATH)) {
         // tslint:disable-next-line:no-console
         console.log(
@@ -355,7 +366,12 @@ describe('Credential', () => {
       }
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
       const c = getApplicationDefault();
-      expect(c).to.be.an.instanceof(RefreshTokenCredential);
+      expect(c).to.be.an.instanceof(ApplicationDefaultCredential);
+
+      process.env.GOOGLE_CLOUD_PROJECT = 'mock-project';
+      const client = await (c as any).googleAuth.getClient();
+      expect(client).to.be.an.instanceof(UserRefreshClient);
+
       expect(isApplicationDefault(c)).to.be.true;
     });
 

--- a/test/unit/utils/crypto-signer.spec.ts
+++ b/test/unit/utils/crypto-signer.spec.ts
@@ -56,7 +56,6 @@ describe('CryptoSigner', () => {
       const payload = Buffer.from('test');
       const cert = new ServiceAccountCredential(mocks.certificateObject);
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const crypto = require('node:crypto');
       const rsa = crypto.createSign('RSA-SHA256');
       rsa.update(payload);


### PR DESCRIPTION
This PR resolves the unit test failures in `getApplicationDefault` and `isApplicationDefault` that occur on local machines where `gcloud` application default credentials exist. It also fixes a potential environment pollution issue in the test suite and cleans up unused ESLint directives.

### Root Cause of Failures
In a prior migration to `google-auth-library`, `getApplicationDefault()` was refactored to return an instance of `ApplicationDefaultCredential` (which dynamically delegates credential resolution under the hood) instead of manually parsing credential files and returning specific wrappers like `RefreshTokenCredential`.

However, two unit tests still asserted that the return value of `getApplicationDefault()` was directly an `instanceof RefreshTokenCredential`. On environments without local `gcloud` credentials (like CI), these tests were silently skipped. In environments where the developer has authenticated via `gcloud`, these tests executed and failed.

### Changes Implemented
1. **Modernized Spec Assertions:**
   - Updated the spec to check that `getApplicationDefault()` returns `ApplicationDefaultCredential`.
   - Resolved the underlying authenticating client using `(c as any).googleAuth.getClient()` and verified it resolves to an instance of `UserRefreshClient` (from `google-auth-library`), preserving the exact test coverage and intent.
   - Injected a mock `process.env.GOOGLE_CLOUD_PROJECT` inside these asynchronous test cases to prevent `google-auth-library` from hanging during GCE metadata service auto-discovery on local environments.

2. **Isolated test environment variables (`process.env`):**
   - Fixed the `beforeEach` and `afterEach` environment setup/teardown in `credential-internal.spec.ts` to shallow-copy and properly restore environment variables, preventing modified environment variables from polluting other test suites.

3. **ESLint directive cleanups:**
   - Removed unused `eslint-disable-next-line @typescript-eslint/no-var-requires` comments in `crypto-signer` files to resolve linting warnings.
