### PR TITLE
fix(auth): Decouple `CreateRequest` interface from `UpdateRequest`

### DIFF
--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -232,8 +232,15 @@ export interface CreatePhoneMultiFactorInfoRequest extends BaseCreateMultiFactor
 }
 
 // @public
-export interface CreateRequest extends UpdateRequest {
+export interface CreateRequest {
+    disabled?: boolean;
+    displayName?: string;
+    email?: string;
+    emailVerified?: boolean;
     multiFactor?: MultiFactorCreateSettings;
+    password?: string;
+    phoneNumber?: string;
+    photoURL?: string;
     uid?: string;
 }
 

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -242,6 +242,11 @@ export interface CreateRequest extends UpdateRequest {
    * The user's multi-factor related properties.
    */
   multiFactor?: MultiFactorCreateSettings;
+
+  /**
+   * The user's primary phone number.
+   */
+  phoneNumber?: string;
 }
 
 /**

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -231,7 +231,43 @@ export interface UserProvider {
  * Interface representing the properties to set on a new user record to be
  * created.
  */
-export interface CreateRequest extends UpdateRequest {
+export interface CreateRequest {
+
+  /**
+   * Whether or not the user is disabled: `true` for disabled;
+   * `false` for enabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * The user's display name.
+   */
+  displayName?: string;
+
+  /**
+   * The user's primary email.
+   */
+  email?: string;
+
+  /**
+   * Whether or not the user's primary email is verified.
+   */
+  emailVerified?: boolean;
+
+  /**
+   * The user's unhashed password.
+   */
+  password?: string;
+
+  /**
+   * The user's primary phone number.
+   */
+  phoneNumber?: string;
+
+  /**
+   * The user's photo URL.
+   */
+  photoURL?: string;
 
   /**
    * The user's `uid`.
@@ -242,11 +278,6 @@ export interface CreateRequest extends UpdateRequest {
    * The user's multi-factor related properties.
    */
   multiFactor?: MultiFactorCreateSettings;
-
-  /**
-   * The user's primary phone number.
-   */
-  phoneNumber?: string;
 }
 
 /**


### PR DESCRIPTION
By inheriting `UpdateRequest`, `CreateRequest` unintentionally exposes type definitions and optional nullable contracts designed strictly for user update requests. This results in misleading and incompatible type definitions.
 
This PR explicitly defines independent property fields on the `CreateRequest` interface rather than extending `UpdateRequest`. This resolves misleading and incompatible type inheritance between user creation and user update workflows by:
* Removing `providerToLink` and `providersToUnlink` property fields from `CreateRequest`.
* Removing `null` type from the `displayName`, `photoURL`, and `phoneNumber` property fields in `CreateRequest`.

Fixes: #2450, #2929, #3152
Supersedes and closes: #2930 