### PR TITLE
chore: Upgrade compilation target and lib to ES2021

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ var buildProject = ts.createProject('tsconfig.json', { rootDir: 'src', declarati
 
 // Include dom libraries during test compilation since we use some web SDK
 // libraries in our tests.
-var buildTest = ts.createProject('tsconfig.json', { lib: ['es2018', 'dom'] });
+var buildTest = ts.createProject('tsconfig.json', { lib: ['es2021', 'dom'] });
 
 var banner = `/*! firebase-admin v${pkg.version} */\n`;
 

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -251,11 +251,9 @@ export class Messaging {
         if (sessionErrors.length > 0) {
           // Combine the original stream error and all session errors
           const allErrors = [result.reason, ...sessionErrors];
-          // TODO: AggregateError is supported in Node 18+ but only included in the ES2021+ 
-          // We use (global as any).AggregateError as a workaround to access it in ES2020.
-          const cause = new (global as any).AggregateError(allErrors, 'Stream failure and session failures occurred');
+          const cause = new AggregateError(allErrors, 'Stream failure and session failures occurred');
 
-          const streamMessage = result.reason.message || 'Unknown stream error';
+          const streamMessage = result.reason?.message || 'Unknown stream error';
           const sessionMessage = `. Session failures: ${sessionErrors.map(e => e.message).join(', ')}`;
 
           error = new FirebaseMessagingError({

--- a/src/utils/api-request.ts
+++ b/src/utils/api-request.ts
@@ -1369,7 +1369,7 @@ export class Http2SessionHandler {
       this.http2Session.on('error', (error: any) => {
         const codePart = error?.code ? `${error.code} - ` : '';
         let errorMessage: string;
-        if (error?.name === 'AggregateError' && Array.isArray(error.errors)) {
+        if ((error instanceof AggregateError || error?.name === 'AggregateError') && Array.isArray(error.errors)) {
           errorMessage = `Session error while making requests: ${codePart}${error.name}: ` +
             `[${error.errors.map((e: any) => e.message).join(', ')}]`;
         } else {

--- a/test/integration/postcheck/tsconfig.json
+++ b/test/integration/postcheck/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2020",
+    "target": "es2021",
     "noImplicitAny": false,
-    "lib": ["es2020"],
+    "lib": ["es2021"],
     "outDir": "lib",
     "typeRoots": [
       "node_modules/@types"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2021",
     "declaration": true,
     "sourceMap": true,
     "noImplicitAny": true,
@@ -13,7 +13,7 @@
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     //"strictPropertyInitialization": true,
-    "lib": ["es2020"],
+    "lib": ["es2021"],
     "outDir": "lib",
     "stripInternal": true,
     "rootDir": "."


### PR DESCRIPTION
Upgrade TypeScript compilation target and standard library configurations from es2020 to es2021. It also cleans up a now-redundant runtime workaround for `AggregateError` in the `Messaging` module.