### PR TITLE
fix(dataconnect): fix deserialization of emulator gRPC error codes into detailed errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docgen/markdown/
 
 # Dataconnect integration test artifacts should not be checked in
 test/integration/dataconnect/dataconnect/.dataconnect
+test/integration/dataconnect/dataconnect-debug.log
+test/integration/dataconnect/firebase-debug.log
+test/integration/dataconnect/pglite-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,4 @@ docgen/markdown/
 
 # Dataconnect integration test artifacts should not be checked in
 test/integration/dataconnect/dataconnect/.dataconnect
-test/integration/dataconnect/dataconnect-debug.log
-test/integration/dataconnect/firebase-debug.log
-test/integration/dataconnect/pglite-debug.log
+test/integration/dataconnect/*.log

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -25,7 +25,7 @@ import {
   FirebaseDataConnectError,
   DataConnectErrorCode,
   DATA_CONNECT_ERROR_CODE_MAPPING,
-  GRPC_STATUS_CODE_TO_STRING
+  EMULATOR_GRPC_STATUS_CODE_TO_STRING
 } from './error';
 import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
@@ -421,7 +421,7 @@ export class DataConnectApiClient {
         
     let status = error.status;
     if (!status && validator.isNumber(error.code)) {
-      status = GRPC_STATUS_CODE_TO_STRING[error.code as number];
+      status = EMULATOR_GRPC_STATUS_CODE_TO_STRING[error.code as number];
     }
 
     let code: DataConnectErrorCode = DATA_CONNECT_ERROR_CODE_MAPPING.UNKNOWN;

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -415,8 +415,10 @@ export class DataConnectApiClient {
     }
 
     const data = response.data as any;
-    const error: ServerError = (validator.isNonNullObject(data) && 'error' in data) ? data.error : data || {};
-    
+    const error: ServerError = (validator.isNonNullObject(data) && validator.isNonNullObject(data.error))
+      ? data.error
+      : (validator.isNonNullObject(data) ? data : {});
+        
     let status = error.status;
     if (!status && validator.isNumber(error.code)) {
       status = GRPC_STATUS_CODE_TO_STRING[error.code as number];

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -21,7 +21,12 @@ import {
   HttpRequestConfig, HttpClient, RequestResponseError, AuthorizedHttpClient
 } from '../utils/api-request';
 import { FirebaseError, toHttpResponse } from '../utils/error';
-import { FirebaseDataConnectError, DataConnectErrorCode, DATA_CONNECT_ERROR_CODE_MAPPING } from './error';
+import {
+  FirebaseDataConnectError,
+  DataConnectErrorCode,
+  DATA_CONNECT_ERROR_CODE_MAPPING,
+  GRPC_STATUS_CODE_TO_STRING
+} from './error';
 import * as utils from '../utils/index';
 import * as validator from '../utils/validator';
 import { ConnectorConfig, ExecuteGraphqlResponse, GraphqlOptions, OperationOptions } from './data-connect-api';
@@ -409,10 +414,17 @@ export class DataConnectApiClient {
       });
     }
 
-    const error: ServerError = (response.data as ErrorResponse).error || {};
+    const data = response.data as any;
+    const error: ServerError = (validator.isNonNullObject(data) && 'error' in data) ? data.error : data || {};
+    
+    let status = error.status;
+    if (!status && validator.isNumber(error.code)) {
+      status = GRPC_STATUS_CODE_TO_STRING[error.code as number];
+    }
+
     let code: DataConnectErrorCode = DATA_CONNECT_ERROR_CODE_MAPPING.UNKNOWN;
-    if (error.status && error.status in DATA_CONNECT_ERROR_CODE_MAPPING) {
-      code = DATA_CONNECT_ERROR_CODE_MAPPING[error.status];
+    if (status && status in DATA_CONNECT_ERROR_CODE_MAPPING) {
+      code = DATA_CONNECT_ERROR_CODE_MAPPING[status];
     }
     const message = error.message || 'Unknown server error';
     return new FirebaseDataConnectError({
@@ -668,10 +680,6 @@ function emulatorHost(): string | undefined {
  */
 export function useEmulator(): boolean {
   return !!emulatorHost();
-}
-
-interface ErrorResponse {
-  error?: ServerError;
 }
 
 interface ServerError {

--- a/src/data-connect/error.ts
+++ b/src/data-connect/error.ts
@@ -69,3 +69,26 @@ export class FirebaseDataConnectError extends FirebaseError {
     });
   }
 }
+
+/**
+ * Mappings from gRPC status codes to their string equivalents.
+ * @internal
+ */
+export const GRPC_STATUS_CODE_TO_STRING: Record<number, string> = {
+  1: 'CANCELLED',
+  2: 'UNKNOWN',
+  3: 'INVALID_ARGUMENT',
+  4: 'DEADLINE_EXCEEDED',
+  5: 'NOT_FOUND',
+  6: 'ALREADY_EXISTS',
+  7: 'PERMISSION_DENIED',
+  8: 'RESOURCE_EXHAUSTED',
+  9: 'FAILED_PRECONDITION',
+  10: 'ABORTED',
+  11: 'OUT_OF_RANGE',
+  12: 'UNIMPLEMENTED',
+  13: 'INTERNAL',
+  14: 'UNAVAILABLE',
+  15: 'DATA_LOSS',
+  16: 'UNAUTHENTICATED',
+};

--- a/src/data-connect/error.ts
+++ b/src/data-connect/error.ts
@@ -71,10 +71,12 @@ export class FirebaseDataConnectError extends FirebaseError {
 }
 
 /**
- * Mappings from gRPC status codes to their string equivalents.
+ * Mappings from gRPC status codes to their string equivalents. Used to convert
+ * error codes from the emulator into the codes and statuses matching errors
+ * from production.
  * @internal
  */
-export const GRPC_STATUS_CODE_TO_STRING: Record<number, string> = {
+export const EMULATOR_GRPC_STATUS_CODE_TO_STRING: Record<number, string> = {
   1: 'CANCELLED',
   2: 'UNKNOWN',
   3: 'INVALID_ARGUMENT',

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -179,6 +179,27 @@ describe('DataConnectApiClient', () => {
           .and.have.property('cause', expected.cause);
       });
 
+      it('should reject when a gRPC-to-HTTP transcoded error response is received', () => {
+        const grpcError = {
+          code: 7,
+          message: 'Permission denied',
+        };
+        const mockErr = utils.errorFrom(grpcError, 403);
+        sandbox
+          .stub(HttpClient.prototype, 'send')
+          .rejects(mockErr);
+        const expected = new FirebaseDataConnectError({
+          code: 'permission-denied',
+          message: 'Permission denied',
+          httpResponse: toHttpResponse(mockErr.response),
+          cause: mockErr
+        });
+        return apiClient.executeGraphql('query', {})
+          .should.eventually.be.rejected
+          .and.deep.include(expected)
+          .and.have.property('cause', expected.cause);
+      });
+
       it('should reject with unknown-error when error code is not present', () => {
         const mockErr = utils.errorFrom({}, 404);
         sandbox


### PR DESCRIPTION
## Description
✨ Added gRPC status code mapping to ensure error responses from the local Data Connect emulator are correctly deserialized. Before these changes, when using the emulator, errors are improperly deserialized into `DataConnectError`s with `unknown-error` instead of ones with detailed `code` and `message` fields.

Verified by running the integration tests against the emulator (and production) before and after the changes. What was broken is now fixed!

## Changes
- Added `GRPC_STATUS_CODE_TO_STRING` mapping dictionary
- Updated `toFirebaseError` to handle root-level gRPC error responses
- Added FDC emulator debug log files to `.gitignore`

## Testing
- Currently, integration tests fail against the emulator. Now they pass. 
- Added unit test verifying deserialization of transcoded gRPC numeric error codes