### PR TITLE
chore(docs): add custom `@excludeFromDocs` tag to filter generated docs

### DIFF
--- a/etc/firebase-admin.auth.api.md
+++ b/etc/firebase-admin.auth.api.md
@@ -31,7 +31,7 @@ export interface AllowByDefault {
 // @public
 export interface AllowByDefaultWrap {
     allowByDefault: AllowByDefault;
-    // @alpha (undocumented)
+    // (undocumented)
     allowlistOnly?: never;
 }
 
@@ -42,7 +42,7 @@ export interface AllowlistOnly {
 
 // @public
 export interface AllowlistOnlyWrap {
-    // @alpha (undocumented)
+    // (undocumented)
     allowByDefault?: never;
     allowlistOnly: AllowlistOnly;
 }
@@ -196,7 +196,7 @@ export abstract class BaseAuth {
     setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
     updateProviderConfig(providerId: string, updatedConfig: UpdateAuthProviderRequest): Promise<AuthProviderConfig>;
     updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord>;
-    // @alpha (undocumented)
+    // (undocumented)
     _verifyAuthBlockingToken(token: string, audience?: string): Promise<DecodedAuthBlockingToken>;
     verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
     verifySessionCookie(sessionCookie: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
@@ -257,7 +257,7 @@ export interface CustomStrengthOptionsConfig {
     requireUppercase?: boolean;
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface DecodedAuthBlockingToken {
     // (undocumented)
     [key: string]: any;

--- a/etc/firebase-admin.functions.api.md
+++ b/etc/firebase-admin.functions.api.md
@@ -8,7 +8,7 @@ import { Agent } from 'http';
 
 // @public
 export interface AbsoluteDelivery {
-    // @alpha (undocumented)
+    // (undocumented)
     scheduleDelaySeconds?: never;
     scheduleTime?: Date;
 }
@@ -16,7 +16,7 @@ export interface AbsoluteDelivery {
 // @public
 export interface DelayDelivery {
     scheduleDelaySeconds?: number;
-    // @alpha (undocumented)
+    // (undocumented)
     scheduleTime?: never;
 }
 

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -60,7 +60,7 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
   console.log(`\nGenerating API report for ${entryPoint}`)
   console.log('========================================================\n');
 
-  const safeName = entryPoint.replace('/', '.');
+  const safeName = entryPoint.replace(/\//g, '.');
   if (safeName.includes('..') || safeName.includes('/') || safeName.includes('\\')) {
     throw new Error(`Invalid safeName calculated: ${safeName}`);
   }

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -33,10 +33,25 @@ const config = require('./api-extractor.json');
 
 const tempConfigFile = 'api-extractor.tmp';
 
+// Regex to validate that the entrypoint name consists of safe alphanumeric, underscore,
+// and dash characters, optionally separated by single slashes.
+const ENTRY_POINT_REGEX = /^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)*$/;
+
+// Regex to validate that the typing file path is a local relative declaration file path
+// inside the "./lib" directory.
+const TYPING_FILE_PATH_REGEX = /^\.\/lib\/[a-zA-Z0-9_\-\/]+\.d\.ts$/;
+
 async function generateReports() {
   const entryPoints = require('./entrypoints.json');
   for (const entryPoint in entryPoints) {
+    // Validate entryPoint to prevent path traversal
+    if (!ENTRY_POINT_REGEX.test(entryPoint)) {
+      throw new Error(`Invalid entryPoint format: ${entryPoint}`);
+    }
     const filePath = entryPoints[entryPoint].typings;
+    if (filePath.includes('..') || !TYPING_FILE_PATH_REGEX.test(filePath)) {
+      throw new Error(`Invalid typing file path: ${filePath}`);
+    }
     await generateReportForEntryPoint(entryPoint, filePath);
   }
 }
@@ -46,6 +61,9 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
   console.log('========================================================\n');
 
   const safeName = entryPoint.replace('/', '.');
+  if (safeName.includes('..') || safeName.includes('/') || safeName.includes('\\')) {
+    throw new Error(`Invalid safeName calculated: ${safeName}`);
+  }
   console.log('Updating configuration for entry point...');
   config.apiReport.reportFileName = `${safeName}.api.md`;
   config.mainEntryPointFilePath = filePath;
@@ -75,7 +93,12 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
     console.error(`API Extractor completed successfully`);
 
     // Strip @excludeFromDocs APIs from the generated docModel so they aren't documented in reference docs.
-    const apiJsonPath = path.resolve('temp', `${safeName}.api.json`);
+    const tempDir = path.resolve('temp');
+    const apiJsonPath = path.resolve(tempDir, `${safeName}.api.json`);
+    const relativePath = path.relative(tempDir, apiJsonPath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+      throw new Error(`Path traversal detected: ${apiJsonPath}`);
+    }
     await stripHiddenDocsFromApiJson(apiJsonPath);
   } finally {
     await fs.unlink(tempConfigFile);

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -73,8 +73,37 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
     }
 
     console.error(`API Extractor completed successfully`);
+
+    // Strip @excludeFromDocs APIs from the generated docModel so they aren't documented in reference docs.
+    const apiJsonPath = path.resolve('temp', `${safeName}.api.json`);
+    await stripHiddenDocsFromApiJson(apiJsonPath);
   } finally {
     await fs.unlink(tempConfigFile);
+  }
+}
+
+async function stripHiddenDocsFromApiJson(apiJsonPath) {
+  if (!await fs.exists(apiJsonPath)) {
+    return;
+  }
+  const content = await fs.readFile(apiJsonPath, 'utf8');
+  const data = JSON.parse(content);
+
+  let removedCount = 0;
+  function removeHidden(node) {
+    if (node.members) {
+      const originalLength = node.members.length;
+      // Filter out any member whose docComment includes @excludeFromDocs
+      node.members = node.members.filter(m => !(m.docComment && /@excludeFromDocs\b/.test(m.docComment)));
+      removedCount += (originalLength - node.members.length);
+      node.members.forEach(removeHidden);
+    }
+  }
+
+  removeHidden(data);
+  if (removedCount > 0) {
+    console.log(`Removed ${removedCount} @excludeFromDocs items from ${path.basename(apiJsonPath)}`);
+    await fs.writeFile(apiJsonPath, JSON.stringify(data, null, 2));
   }
 }
 

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -48,8 +48,12 @@ async function generateReports() {
     if (!ENTRY_POINT_REGEX.test(entryPoint)) {
       throw new Error(`Invalid entryPoint format: ${entryPoint}`);
     }
-    const filePath = entryPoints[entryPoint].typings;
-    if (filePath.includes('..') || !TYPING_FILE_PATH_REGEX.test(filePath)) {
+    const rawFilePath = entryPoints[entryPoint].typings;
+    if (!TYPING_FILE_PATH_REGEX.test(rawFilePath)) {
+      throw new Error(`Invalid typing file path: ${rawFilePath}`);
+    }
+    const filePath = path.normalize(rawFilePath);
+    if (filePath.includes('..')) {
       throw new Error(`Invalid typing file path: ${filePath}`);
     }
     await generateReportForEntryPoint(entryPoint, filePath);
@@ -60,7 +64,7 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
   console.log(`\nGenerating API report for ${entryPoint}`)
   console.log('========================================================\n');
 
-  const safeName = entryPoint.replace(/\//g, '.');
+  const safeName = path.basename(entryPoint.replace(/\//g, '.'));
   if (safeName.includes('..') || safeName.includes('/') || safeName.includes('\\')) {
     throw new Error(`Invalid safeName calculated: ${safeName}`);
   }

--- a/generate-reports.js
+++ b/generate-reports.js
@@ -33,29 +33,10 @@ const config = require('./api-extractor.json');
 
 const tempConfigFile = 'api-extractor.tmp';
 
-// Regex to validate that the entrypoint name consists of safe alphanumeric, underscore,
-// and dash characters, optionally separated by single slashes.
-const ENTRY_POINT_REGEX = /^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)*$/;
-
-// Regex to validate that the typing file path is a local relative declaration file path
-// inside the "./lib" directory.
-const TYPING_FILE_PATH_REGEX = /^\.\/lib\/[a-zA-Z0-9_\-\/]+\.d\.ts$/;
-
 async function generateReports() {
   const entryPoints = require('./entrypoints.json');
   for (const entryPoint in entryPoints) {
-    // Validate entryPoint to prevent path traversal
-    if (!ENTRY_POINT_REGEX.test(entryPoint)) {
-      throw new Error(`Invalid entryPoint format: ${entryPoint}`);
-    }
-    const rawFilePath = entryPoints[entryPoint].typings;
-    if (!TYPING_FILE_PATH_REGEX.test(rawFilePath)) {
-      throw new Error(`Invalid typing file path: ${rawFilePath}`);
-    }
-    const filePath = path.normalize(rawFilePath);
-    if (filePath.includes('..')) {
-      throw new Error(`Invalid typing file path: ${filePath}`);
-    }
+    const filePath = entryPoints[entryPoint].typings;
     await generateReportForEntryPoint(entryPoint, filePath);
   }
 }
@@ -64,10 +45,7 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
   console.log(`\nGenerating API report for ${entryPoint}`)
   console.log('========================================================\n');
 
-  const safeName = path.basename(entryPoint.replace(/\//g, '.'));
-  if (safeName.includes('..') || safeName.includes('/') || safeName.includes('\\')) {
-    throw new Error(`Invalid safeName calculated: ${safeName}`);
-  }
+  const safeName = entryPoint.replace('/', '.');
   console.log('Updating configuration for entry point...');
   config.apiReport.reportFileName = `${safeName}.api.md`;
   config.mainEntryPointFilePath = filePath;
@@ -97,12 +75,7 @@ async function generateReportForEntryPoint(entryPoint, filePath) {
     console.error(`API Extractor completed successfully`);
 
     // Strip @excludeFromDocs APIs from the generated docModel so they aren't documented in reference docs.
-    const tempDir = path.resolve('temp');
-    const apiJsonPath = path.resolve(tempDir, `${safeName}.api.json`);
-    const relativePath = path.relative(tempDir, apiJsonPath);
-    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-      throw new Error(`Path traversal detected: ${apiJsonPath}`);
-    }
+    const apiJsonPath = path.resolve('temp', `${safeName}.api.json`);
     await stripHiddenDocsFromApiJson(apiJsonPath);
   } finally {
     await fs.unlink(tempConfigFile);

--- a/src/auth/auth-config.ts
+++ b/src/auth/auth-config.ts
@@ -1631,7 +1631,9 @@ export interface AllowByDefaultWrap {
    * Allow every region by default.
    */
   allowByDefault: AllowByDefault;
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   allowlistOnly?: never;
 }
 
@@ -1644,7 +1646,9 @@ export interface AllowlistOnlyWrap {
    * allowlist.
    */
   allowlistOnly: AllowlistOnly;
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   allowByDefault?: never;
 }
 

--- a/src/auth/base-auth.ts
+++ b/src/auth/base-auth.ts
@@ -1096,7 +1096,9 @@ export abstract class BaseAuth {
     return Promise.reject(new FirebaseAuthError(authClientErrorCode.INVALID_PROVIDER_ID));
   }
 
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public _verifyAuthBlockingToken(
     token: string,

--- a/src/auth/token-verifier.ts
+++ b/src/auth/token-verifier.ts
@@ -177,7 +177,9 @@ export interface DecodedIdToken {
   [key: string]: any;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingSharedUserInfo {
   uid: string;
   display_name?: string;
@@ -186,18 +188,24 @@ export interface DecodedAuthBlockingSharedUserInfo {
   phone_number?: string;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingMetadata {
   creation_time?: number;
   last_sign_in_time?: number;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingUserInfo extends DecodedAuthBlockingSharedUserInfo {
   provider_id: string;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingMfaInfo {
   uid: string;
   display_name?: string;
@@ -206,12 +214,16 @@ export interface DecodedAuthBlockingMfaInfo {
   factor_id?: string;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingEnrolledFactors {
   enrolled_factors?: DecodedAuthBlockingMfaInfo[];
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingUserRecord extends DecodedAuthBlockingSharedUserInfo {
   email_verified?: boolean;
   disabled?: boolean;
@@ -226,7 +238,9 @@ export interface DecodedAuthBlockingUserRecord extends DecodedAuthBlockingShared
   [key: string]: any;
 }
 
-/** @alpha */
+/**
+ * @excludeFromDocs
+ */
 export interface DecodedAuthBlockingToken {
   aud: string;
   exp: number;
@@ -333,7 +347,7 @@ export class FirebaseTokenVerifier {
   private readonly signatureVerifier: SignatureVerifier;
 
   constructor(clientCertUrl: string, private issuer: string, private tokenInfo: FirebaseTokenInfo,
-              private readonly app: App) {
+    private readonly app: App) {
 
     if (!validator.isURL(clientCertUrl)) {
       throw new FirebaseAuthError(
@@ -410,7 +424,9 @@ export class FirebaseTokenVerifier {
       });
   }
 
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public _verifyAuthBlockingToken(
     jwtToken: string,
@@ -448,7 +464,7 @@ export class FirebaseTokenVerifier {
           );
         }
         return Promise.resolve(projectId);
-      })
+      });
   }
 
   private decodeAndVerify(
@@ -521,10 +537,10 @@ export class FirebaseTokenVerifier {
         '"' + header.alg + '".' + verifyJwtTokenDocsMessage;
     } else if (typeof audience !== 'undefined' && !(payload.aud as string).includes(audience)) {
       errorMessage = `${this.tokenInfo.jwtName} has incorrect "aud" (audience) claim. Expected "` +
-      audience + '" but got "' + payload.aud + '".' + verifyJwtTokenDocsMessage;
+        audience + '" but got "' + payload.aud + '".' + verifyJwtTokenDocsMessage;
     } else if (typeof audience === 'undefined' && payload.aud !== projectId) {
       errorMessage = `${this.tokenInfo.jwtName} has incorrect "aud" (audience) claim. Expected "` +
-      projectId + '" but got "' + payload.aud + '".' + projectIdMatchMessage +
+        projectId + '" but got "' + payload.aud + '".' + projectIdMatchMessage +
         verifyJwtTokenDocsMessage;
     } else if (payload.iss !== this.issuer + projectId) {
       errorMessage = `${this.tokenInfo.jwtName} has incorrect "iss" (issuer) claim. Expected ` +

--- a/src/functions/functions-api.ts
+++ b/src/functions/functions-api.ts
@@ -24,7 +24,9 @@ export interface DelayDelivery {
    * This delay is added to the current time.
    */
   scheduleDelaySeconds?: number;
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   scheduleTime?: never;
 }
 
@@ -36,7 +38,9 @@ export interface AbsoluteDelivery {
    * The time when the task is scheduled to be attempted or retried.
    */
   scheduleTime?: Date;
-  /** @alpha */
+  /**
+   * @excludeFromDocs
+   */
   scheduleDelaySeconds?: never;
 }
 

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@excludeFromDocs",
+      "syntaxKind": "modifier"
+    }
+  ]
+}


### PR DESCRIPTION
This adds a new docs tag `@excludeFromDocs` used to filter out public APIs that are intended to be hidden in public docs and removes the need for manually omitting these on each release.