### PR TITLE
chore: fix race condition in auth tenant management tests

### DIFF
--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -2399,30 +2399,24 @@ describe('admin.auth', () => {
     });
 
     describe('tenant deletion operations', () => {
-      it('deleteTenant() should successfully delete the provided tenant', () => {
+      it('deleteTenant() should successfully delete the provided tenant', async () => {
         const allTenantIds: string[] = [];
-        const listAllTenantIds = (tenantIds: string[], nextPageToken?: string): Promise<void> => {
-          return getAuth().tenantManager().listTenants(100, nextPageToken)
-            .then((result) => {
-              result.tenants.forEach((tenant) => {
-                tenantIds.push(tenant.tenantId);
-              });
-              if (result.pageToken) {
-                return listAllTenantIds(tenantIds, result.pageToken);
-              }
-            });
+        const listAllTenantIds = async (tenantIds: string[], nextPageToken?: string): Promise<void> => {
+          const result = await getAuth().tenantManager().listTenants(100, nextPageToken);
+          result.tenants.forEach((tenant) => {
+            tenantIds.push(tenant.tenantId);
+          });
+          if (result.pageToken) {
+            await listAllTenantIds(tenantIds, result.pageToken);
+          }
         };
 
-        return getAuth().tenantManager().deleteTenant(createdTenantId)
-          .then(() => {
-            // Use listTenants() instead of getTenant() to check that the tenant
-            // is no longer present, because Auth Emulator implicitly creates the
-            // tenant in getTenant() when it is not found
-            return listAllTenantIds(allTenantIds);
-          })
-          .then(() => {
-            expect(allTenantIds).to.not.contain(createdTenantId);
-          });
+        await getAuth().tenantManager().deleteTenant(createdTenantId);
+        // Use listTenants() instead of getTenant() to check that the tenant
+        // is no longer present, because Auth Emulator implicitly creates the
+        // tenant in getTenant() when it is not found
+        await listAllTenantIds(allTenantIds);
+        expect(allTenantIds).to.not.contain(createdTenantId);
       });
     });
   });

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -2398,30 +2398,32 @@ describe('admin.auth', () => {
         });
     });
 
-    it('deleteTenant() should successfully delete the provided tenant', () => {
-      const allTenantIds: string[] = [];
-      const listAllTenantIds = (tenantIds: string[], nextPageToken?: string): Promise<void> => {
-        return getAuth().tenantManager().listTenants(100, nextPageToken)
-          .then((result) => {
-            result.tenants.forEach((tenant) => {
-              tenantIds.push(tenant.tenantId);
+    describe('tenant deletion operations', () => {
+      it('deleteTenant() should successfully delete the provided tenant', () => {
+        const allTenantIds: string[] = [];
+        const listAllTenantIds = (tenantIds: string[], nextPageToken?: string): Promise<void> => {
+          return getAuth().tenantManager().listTenants(100, nextPageToken)
+            .then((result) => {
+              result.tenants.forEach((tenant) => {
+                tenantIds.push(tenant.tenantId);
+              });
+              if (result.pageToken) {
+                return listAllTenantIds(tenantIds, result.pageToken);
+              }
             });
-            if (result.pageToken) {
-              return listAllTenantIds(tenantIds, result.pageToken);
-            }
-          });
-      };
+        };
 
-      return getAuth().tenantManager().deleteTenant(createdTenantId)
-        .then(() => {
-          // Use listTenants() instead of getTenant() to check that the tenant
-          // is no longer present, because Auth Emulator implicitly creates the
-          // tenant in getTenant() when it is not found
-          return listAllTenantIds(allTenantIds);
-        })
-        .then(() => {
-          expect(allTenantIds).to.not.contain(createdTenantId);
-        });
+        return getAuth().tenantManager().deleteTenant(createdTenantId)
+          .then(() => {
+            // Use listTenants() instead of getTenant() to check that the tenant
+            // is no longer present, because Auth Emulator implicitly creates the
+            // tenant in getTenant() when it is not found
+            return listAllTenantIds(allTenantIds);
+          })
+          .then(() => {
+            expect(allTenantIds).to.not.contain(createdTenantId);
+          });
+      });
     });
   });
 


### PR DESCRIPTION
Fixed a race condition bug in or auth tests causing the tenant to be deleted before some tests that rely on it are completed. 

Delete test now runs after all other dependent tenant management tests.