### PR TITLE
feat(dataconnect): add "X-Client-Version" header for cloud monitoring

### DIFF
--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -74,6 +74,8 @@ function getHeaders(isUsingGen: boolean): { [key: string]: string } {
   const headerValue = {
     'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
     'X-Goog-Api-Client': utils.getMetricsHeader(),
+    'x-client-platform': 'node',
+    'x-client-version': utils.getSdkVersion(),
   };
   if (isUsingGen) {
     headerValue['X-Goog-Api-Client'] += ' admin-js/gen';

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -74,8 +74,8 @@ function getHeaders(isUsingGen: boolean): { [key: string]: string } {
   const headerValue = {
     'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
     'X-Goog-Api-Client': utils.getMetricsHeader(),
-    'x-client-platform': 'node',
-    'x-client-version': utils.getSdkVersion(),
+    'X-Client-Platform': 'node',
+    'X-Client-Version': utils.getSdkVersion(),
   };
   if (isUsingGen) {
     headerValue['X-Goog-Api-Client'] += ' admin-js/gen';

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -74,8 +74,7 @@ function getHeaders(isUsingGen: boolean): { [key: string]: string } {
   const headerValue = {
     'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
     'X-Goog-Api-Client': utils.getMetricsHeader(),
-    'X-Client-Platform': 'node',
-    'X-Client-Version': utils.getSdkVersion(),
+    'X-Client-Version': `node/${utils.getSdkVersion()}`,
   };
   if (isUsingGen) {
     headerValue['X-Goog-Api-Client'] += ' admin-js/gen';

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -53,18 +53,24 @@ describe('DataConnectApiClient', () => {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
+    'x-client-platform': 'node',
+    'x-client-version': getSdkVersion(),
   };
 
   const EXPECTED_HEADERS_WITH_GEN = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader() + ' admin-js/gen',
+    'x-client-platform': 'node',
+    'x-client-version': getSdkVersion(),
   };
 
   const EMULATOR_EXPECTED_HEADERS = {
     'Authorization': 'Bearer owner',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
+    'x-client-platform': 'node',
+    'x-client-version': getSdkVersion(),
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -53,24 +53,21 @@ describe('DataConnectApiClient', () => {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
-    'X-Client-Platform': 'node',
-    'X-Client-Version': getSdkVersion(),
+    'X-Client-Version': `node/${getSdkVersion()}`,
   };
 
   const EXPECTED_HEADERS_WITH_GEN = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader() + ' admin-js/gen',
-    'X-Client-Platform': 'node',
-    'X-Client-Version': getSdkVersion(),
+    'X-Client-Version': `node/${getSdkVersion()}`,
   };
 
   const EMULATOR_EXPECTED_HEADERS = {
     'Authorization': 'Bearer owner',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
-    'X-Client-Platform': 'node',
-    'X-Client-Version': getSdkVersion(),
+    'X-Client-Version': `node/${getSdkVersion()}`,
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -53,24 +53,24 @@ describe('DataConnectApiClient', () => {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
-    'x-client-platform': 'node',
-    'x-client-version': getSdkVersion(),
+    'X-Client-Platform': 'node',
+    'X-Client-Version': getSdkVersion(),
   };
 
   const EXPECTED_HEADERS_WITH_GEN = {
     'Authorization': 'Bearer mock-token',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader() + ' admin-js/gen',
-    'x-client-platform': 'node',
-    'x-client-version': getSdkVersion(),
+    'X-Client-Platform': 'node',
+    'X-Client-Version': getSdkVersion(),
   };
 
   const EMULATOR_EXPECTED_HEADERS = {
     'Authorization': 'Bearer owner',
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
-    'x-client-platform': 'node',
-    'x-client-version': getSdkVersion(),
+    'X-Client-Platform': 'node',
+    'X-Client-Version': getSdkVersion(),
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '


### PR DESCRIPTION
This PR adds the `X-Client-Version` request header (formatted as `node/<version>`) to `DataConnectApiClient` to enable metrics collection in Cloud Monitoring.

### Highlights

* **Cloud Monitoring Metrics Header**: Added the `X-Client-Version` header (set to `node/$SDK_VERSION`) to outgoing requests in `DataConnectApiClient` to enable Cloud Monitoring telemetry.
* **Test Updates**: Updated unit test suites to verify that `X-Client-Version` is correctly attached to API client requests.

<details>

<summary><b>Changelog</b></summary>

* **data-connect-api-client-internal.ts**
  * Updated `getHeaders` to include the `X-Client-Version` header formatted as `node/${utils.getSdkVersion()}` in default request headers.
* **data-connect-api-client-internal.spec.ts**
  * Updated unit test header constants to verify `X-Client-Version` is included in request headers.

</details>
