### PR TITLE
fix(eventarc): resolve the emulator host when the client is constructed

### DIFF
--- a/src/eventarc/eventarc-client-internal.ts
+++ b/src/eventarc/eventarc-client-internal.ts
@@ -42,6 +42,7 @@ const DEFAULT_CHANNEL_REGION = 'us-central1';
  */
 export class EventarcApiClient {
   private readonly httpClient: HttpClient;
+  private readonly eventarcHost: string;
   private projectId?: string;
   private readonly resolvedChannelName: Promise<string>;
 
@@ -53,6 +54,7 @@ export class EventarcApiClient {
       });
     }
     this.httpClient = new AuthorizedHttpClient(app as FirebaseApp);
+    this.eventarcHost = process.env.CLOUD_EVENTARC_EMULATOR_HOST ?? EVENTARC_API;
     this.resolvedChannelName = this.resolveChannelName(channel.name);
   }
 
@@ -105,7 +107,7 @@ export class EventarcApiClient {
     }
     const request: HttpRequestConfig = {
       method: 'POST',
-      url: `${this.getEventarcHost()}/${channel}:publishEvents`,
+      url: `${this.eventarcHost}/${channel}:publishEvents`,
       data: JSON.stringify({ events }),
     };
     return this.sendRequest(request);
@@ -161,9 +163,5 @@ export class EventarcApiClient {
   private async resolveChannelNameProjectId(location: string, channelId: string): Promise<string> {
     const projectId = await this.getProjectId();
     return `projects/${projectId}/locations/${location}/channels/${channelId}`;
-  }
-
-  private getEventarcHost(): string {
-    return process.env.CLOUD_EVENTARC_EMULATOR_HOST ?? EVENTARC_API;
   }
 }

--- a/test/unit/eventarc/eventarc.spec.ts
+++ b/test/unit/eventarc/eventarc.spec.ts
@@ -59,6 +59,8 @@ const TEST_EVENT2 : CloudEvent = {
 };
 const TEST_EVENT2_SERIALIZED = JSON.stringify(toCloudEventProtoFormat(TEST_EVENT2));
 
+const EMULATOR_HOST = 'http://127.0.0.1:9299';
+
 describe('eventarc', () => {
   let mockApp: FirebaseApp;
   let eventarc: Eventarc;
@@ -163,6 +165,77 @@ describe('eventarc', () => {
         method: 'POST',
         url: 'https://eventarcpublishing.googleapis.com/v1/projects/project_id/locations/us-central1/channels/firebase:publishEvents',
         data: `{"events":[${TEST_EVENT1_SERIALIZED},${TEST_EVENT2_SERIALIZED}]}`,
+        headers: getExpectedHeaders(mockAccessToken)
+      });
+    });
+  });
+
+  describe('emulator host', () => {
+    let mockAccessToken: string;
+    let httpStub: sinon.SinonStub;
+    let accessTokenStub: sinon.SinonStub;
+
+    before(() => {
+      mockAccessToken = utils.generateRandomAccessToken();
+      accessTokenStub = utils.stubGetAccessToken(mockAccessToken);
+    });
+
+    after(() => {
+      accessTokenStub?.restore();
+    });
+
+    afterEach(() => {
+      httpStub?.restore();
+      delete process.env.CLOUD_EVENTARC_EMULATOR_HOST;
+    });
+
+    it('is resolved at construction time', async () => {
+      delete process.env.CLOUD_EVENTARC_EMULATOR_HOST;
+      const prodChannel = eventarc.channel();
+
+      process.env.CLOUD_EVENTARC_EMULATOR_HOST = EMULATOR_HOST;
+      const emulatorChannel = eventarc.channel();
+
+      delete process.env.CLOUD_EVENTARC_EMULATOR_HOST;
+
+      httpStub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom({}));
+
+      await prodChannel.publish(TEST_EVENT1);
+      await emulatorChannel.publish(TEST_EVENT1);
+
+      expect(httpStub).to.have.been.calledTwice;
+      expect(httpStub.firstCall).to.have.been.calledWith({
+        method: 'POST',
+        url: 'https://eventarcpublishing.googleapis.com/v1/projects/project_id/locations/us-central1/channels/firebase:publishEvents',
+        data: `{"events":[${TEST_EVENT1_SERIALIZED}]}`,
+        headers: getExpectedHeaders(mockAccessToken)
+      });
+      expect(httpStub.secondCall).to.have.been.calledWith({
+        method: 'POST',
+        url: `${EMULATOR_HOST}/projects/project_id/locations/us-central1/channels/firebase:publishEvents`,
+        data: `{"events":[${TEST_EVENT1_SERIALIZED}]}`,
+        headers: getExpectedHeaders(mockAccessToken)
+      });
+    });
+
+    it('is not picked up by a channel created before it was set', async () => {
+      delete process.env.CLOUD_EVENTARC_EMULATOR_HOST;
+      const prodChannel = eventarc.channel();
+
+      process.env.CLOUD_EVENTARC_EMULATOR_HOST = EMULATOR_HOST;
+
+      httpStub = sinon
+        .stub(HttpClient.prototype, 'send')
+        .resolves(utils.responseFrom({}));
+
+      await prodChannel.publish(TEST_EVENT1);
+
+      expect(httpStub).to.have.been.calledOnce.and.calledWith({
+        method: 'POST',
+        url: 'https://eventarcpublishing.googleapis.com/v1/projects/project_id/locations/us-central1/channels/firebase:publishEvents',
+        data: `{"events":[${TEST_EVENT1_SERIALIZED}]}`,
         headers: getExpectedHeaders(mockAccessToken)
       });
     });

--- a/test/unit/eventarc/eventarc.spec.ts
+++ b/test/unit/eventarc/eventarc.spec.ts
@@ -174,14 +174,21 @@ describe('eventarc', () => {
     let mockAccessToken: string;
     let httpStub: sinon.SinonStub;
     let accessTokenStub: sinon.SinonStub;
+    let originalEmulatorHost: string | undefined;
 
     before(() => {
       mockAccessToken = utils.generateRandomAccessToken();
       accessTokenStub = utils.stubGetAccessToken(mockAccessToken);
+      originalEmulatorHost = process.env.CLOUD_EVENTARC_EMULATOR_HOST;
     });
 
     after(() => {
       accessTokenStub?.restore();
+      if (originalEmulatorHost === undefined) {
+        delete process.env.CLOUD_EVENTARC_EMULATOR_HOST;
+      } else {
+        process.env.CLOUD_EVENTARC_EMULATOR_HOST = originalEmulatorHost;
+      }
     });
 
     afterEach(() => {


### PR DESCRIPTION
### Discussion

Follows the same fix as #3167 (issue #3059), which moved `CLOUD_TASKS_EMULATOR_HOST` in `FunctionsApiClient` to construction time.

`EventarcApiClient` reads `process.env.CLOUD_EVENTARC_EMULATOR_HOST` on every publish rather than when the client is built, so the routing of an existing channel depends on whatever the environment happens to hold at publish time. Create a production client, set the variable, create an emulator client, then unset it, and both publish to production.

This moves the lookup into the constructor and stores it on a readonly field, matching `FunctionsApiClient` and `AbstractAuthRequestHandler`, which both capture their emulator host up front.

### Behavior change

Code that sets `CLOUD_EVENTARC_EMULATOR_HOST` after obtaining a channel will now keep hitting production. Nothing in the SDK, its tests, or #1686 documents that ordering as supported, and Cloud Tasks and Auth already behave this way, but it is user visible so it is worth calling out.

### Scope

This keeps `??` instead of the `.trim() || undefined` normalization used in `FunctionsApiClient`. There the value is a truthiness flag, checked in four places, so a whitespace only value has to collapse to `undefined`. Here it is a plain URL prefix used once, and normalizing it would change what `''` and `'   '` do today, which is unrelated to the caching fix.

### Testing

Two tests in `test/unit/eventarc/eventarc.spec.ts`, built the same way as the multi client test #3167 added. One covers the reported direction, an emulator channel created while the variable is set keeps using the emulator after it is cleared. The other covers the opposite direction, a production channel created before the variable is set keeps using production. Reverting the source fails both. The full unit suite passes at 6066.
