### PR TITLE
feat(dataconnect): add "X-Firebase-Sqlconnect-Affinity" header for GSLB soft stickiness

### DIFF
--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -70,7 +70,14 @@ const IMPERSONATE_MUTATION_ENDPOINT = 'impersonateMutation';
 /** @internal The maximum number of items allowed in the @allow directive's maxCount argument. */
 export const ALLOW_DIRECTIVE_MAX_COUNT = 10_000;
 
-function getHeaders(projectId: string, serviceId: string, isUsingGen: boolean): { [key: string]: string } {
+interface GetHeadersParameters {
+  projectId: string;
+  serviceId: string;
+  isUsingGen: boolean;
+}
+
+function getHeaders(parameters: GetHeadersParameters): { [key: string]: string } {
+  const { projectId, serviceId, isUsingGen } = parameters;
   const headerValue = {
     'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
     'X-Goog-Api-Client': utils.getMetricsHeader(),
@@ -391,7 +398,11 @@ export class DataConnectApiClient {
     const request: HttpRequestConfig = {
       method: 'POST',
       url,
-      headers: getHeaders(projectId, this.connectorConfig.serviceId, this.isUsingGen),
+      headers: getHeaders({
+        projectId,
+        serviceId: this.connectorConfig.serviceId,
+        isUsingGen: this.isUsingGen,
+      }),
       data,
     };
     const resp = await this.httpClient.send(request);

--- a/src/data-connect/data-connect-api-client-internal.ts
+++ b/src/data-connect/data-connect-api-client-internal.ts
@@ -70,11 +70,12 @@ const IMPERSONATE_MUTATION_ENDPOINT = 'impersonateMutation';
 /** @internal The maximum number of items allowed in the @allow directive's maxCount argument. */
 export const ALLOW_DIRECTIVE_MAX_COUNT = 10_000;
 
-function getHeaders(isUsingGen: boolean): { [key: string]: string } {
+function getHeaders(projectId: string, serviceId: string, isUsingGen: boolean): { [key: string]: string } {
   const headerValue = {
     'X-Firebase-Client': `fire-admin-node/${utils.getSdkVersion()}`,
     'X-Goog-Api-Client': utils.getMetricsHeader(),
     'X-Client-Version': `node/${utils.getSdkVersion()}`,
+    'X-Firebase-Sqlconnect-Affinity': `${projectId}${serviceId}`,
   };
   if (isUsingGen) {
     headerValue['X-Goog-Api-Client'] += ' admin-js/gen';
@@ -386,10 +387,11 @@ export class DataConnectApiClient {
    */
   private async makeGqlRequest<GraphqlResponse>(url: string, data: object): 
   Promise<ExecuteGraphqlResponse<GraphqlResponse>> {
+    const projectId = await this.getProjectId();
     const request: HttpRequestConfig = {
       method: 'POST',
       url,
-      headers: getHeaders(this.isUsingGen),
+      headers: getHeaders(projectId, this.connectorConfig.serviceId, this.isUsingGen),
       data,
     };
     const resp = await this.httpClient.send(request);

--- a/test/unit/data-connect/data-connect-api-client-internal.spec.ts
+++ b/test/unit/data-connect/data-connect-api-client-internal.spec.ts
@@ -54,6 +54,7 @@ describe('DataConnectApiClient', () => {
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
     'X-Client-Version': `node/${getSdkVersion()}`,
+    'X-Firebase-Sqlconnect-Affinity': 'test-projectmy-service',
   };
 
   const EXPECTED_HEADERS_WITH_GEN = {
@@ -61,6 +62,7 @@ describe('DataConnectApiClient', () => {
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader() + ' admin-js/gen',
     'X-Client-Version': `node/${getSdkVersion()}`,
+    'X-Firebase-Sqlconnect-Affinity': 'test-projectmy-service',
   };
 
   const EMULATOR_EXPECTED_HEADERS = {
@@ -68,6 +70,7 @@ describe('DataConnectApiClient', () => {
     'X-Firebase-Client': `fire-admin-node/${getSdkVersion()}`,
     'X-Goog-Api-Client': getMetricsHeader(),
     'X-Client-Version': `node/${getSdkVersion()}`,
+    'X-Firebase-Sqlconnect-Affinity': 'test-projectmy-service',
   };
 
   const noProjectId = 'Failed to determine project ID. Initialize the SDK with service '


### PR DESCRIPTION
This PR adds the `X-Firebase-Sqlconnect-Affinity` request header to outgoing Data Connect HTTP requests. This header enables backend server affinity routing for SQL Connect to improve server resource usage efficiency and performance.

### Highlights

* **SQL Connect Server Affinity Header**: Added the `X-Firebase-Sqlconnect-Affinity` header containing `${projectId}${serviceId}` to Data Connect HTTP request headers.
* **Unit Test Coverage**: Updated `EXPECTED_HEADERS`, `EXPECTED_HEADERS_WITH_GEN`, and `EMULATOR_EXPECTED_HEADERS` test fixtures to verify the header key and formatted value.

<details>
<summary>Changelog</summary>

* **data-connect-api-client-internal.ts**
  * Added `GetHeadersParameters` interface and updated `getHeaders` function to accept parameters by name.
  * Added `X-Firebase-Sqlconnect-Affinity` header containing `${projectId}${serviceId}` to request headers.
  * Updated `makeGqlRequest` to resolve `projectId` and pass named parameters to `getHeaders`.
* **data-connect-api-client-internal.spec.ts**
  * Added `X-Firebase-Sqlconnect-Affinity` header assertion to `EXPECTED_HEADERS`, `EXPECTED_HEADERS_WITH_GEN`, and `EMULATOR_EXPECTED_HEADERS`.

</details>
