### PR TITLE
feat(ml): deprecate Machine Learning APIs

### DIFF
--- a/etc/firebase-admin.machine-learning.api.md
+++ b/etc/firebase-admin.machine-learning.api.md
@@ -8,13 +8,13 @@ import { Agent } from 'http';
 
 // Warning: (ae-forgotten-export) The symbol "FirebaseError" needs to be exported by the entry point index.d.ts
 //
-// @public
+// @public @deprecated
 export class FirebaseMachineLearningError extends FirebaseError {
     // Warning: (ae-forgotten-export) The symbol "ErrorInfo" needs to be exported by the entry point index.d.ts
     constructor(info: ErrorInfo, message?: string);
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface GcsTfliteModelOptions extends ModelOptionsBase {
     // (undocumented)
     tfliteModel: {
@@ -24,35 +24,42 @@ export interface GcsTfliteModelOptions extends ModelOptionsBase {
 
 // Warning: (ae-forgotten-export) The symbol "App" needs to be exported by the entry point index.d.ts
 //
-// @public
+// @public @deprecated
 export function getMachineLearning(app?: App): MachineLearning;
 
-// @public
+// @public @deprecated
 export interface ListModelsOptions {
     filter?: string;
     pageSize?: number;
     pageToken?: string;
 }
 
-// @public
+// @public @deprecated
 export interface ListModelsResult {
     readonly models: Model[];
     readonly pageToken?: string;
 }
 
-// @public
+// @public @deprecated
 export class MachineLearning {
     get app(): App;
+    // @deprecated
     createModel(model: ModelOptions): Promise<Model>;
+    // @deprecated
     deleteModel(modelId: string): Promise<void>;
+    // @deprecated
     getModel(modelId: string): Promise<Model>;
+    // @deprecated
     listModels(options?: ListModelsOptions): Promise<ListModelsResult>;
+    // @deprecated
     publishModel(modelId: string): Promise<Model>;
+    // @deprecated
     unpublishModel(modelId: string): Promise<Model>;
+    // @deprecated
     updateModel(modelId: string, model: ModelOptions): Promise<Model>;
 }
 
-// @public
+// @public @deprecated
 export const MachineLearningErrorCode: {
     readonly ALREADY_EXISTS: "already-exists";
     readonly AUTHENTICATION_ERROR: "authentication-error";
@@ -73,10 +80,10 @@ export const MachineLearningErrorCode: {
     readonly UNAUTHENTICATED: "unauthenticated";
 };
 
-// @public
+// @public @deprecated
 export type MachineLearningErrorCode = typeof MachineLearningErrorCode[keyof typeof MachineLearningErrorCode];
 
-// @public
+// @public @deprecated
 export class Model {
     get createTime(): string;
     get displayName(): string;
@@ -92,13 +99,14 @@ export class Model {
     };
     get updateTime(): string;
     get validationError(): string | undefined;
+    // @deprecated
     waitForUnlocked(maxTimeMillis?: number): Promise<void>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ModelOptions = ModelOptionsBase | GcsTfliteModelOptions;
 
-// @public
+// @public @deprecated
 export interface ModelOptionsBase {
     // (undocumented)
     displayName?: string;
@@ -106,7 +114,7 @@ export interface ModelOptionsBase {
     tags?: string[];
 }
 
-// @public
+// @public @deprecated
 export interface TFLiteModel {
     readonly gcsTfliteUri?: string;
     readonly sizeBytes: number;

--- a/src/machine-learning/error.ts
+++ b/src/machine-learning/error.ts
@@ -18,6 +18,11 @@ import { FirebaseError, ErrorInfo } from '../utils/error';
 
 /**
  * The constant mapping for valid Machine Learning client error codes.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export const MachineLearningErrorCode = {
   ALREADY_EXISTS: 'already-exists',
@@ -41,11 +46,21 @@ export const MachineLearningErrorCode = {
 
 /**
  * The type definition for valid Machine Learning client error codes.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export type MachineLearningErrorCode = typeof MachineLearningErrorCode[keyof typeof MachineLearningErrorCode];
 
 /**
  * Firebase Machine Learning error code structure. This extends `FirebaseError`.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export class FirebaseMachineLearningError extends FirebaseError {
   /** @internal */

--- a/src/machine-learning/index.ts
+++ b/src/machine-learning/index.ts
@@ -18,6 +18,10 @@
  * Firebase Machine Learning.
  *
  * @packageDocumentation
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 
 import { App, getApp } from '../app';
@@ -62,6 +66,11 @@ export {
  *
  * @returns The default `MachineLearning` service if no app is provided or the
  *   `MachineLearning` service associated with the provided app.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export function getMachineLearning(app?: App): MachineLearning {
   if (typeof app === 'undefined') {

--- a/src/machine-learning/machine-learning-api-client.ts
+++ b/src/machine-learning/machine-learning-api-client.ts
@@ -26,22 +26,44 @@ import { FirebaseMachineLearningError, MachineLearningErrorCode } from './error'
 
 /**
  * Firebase ML Model input objects
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export interface ModelOptionsBase {
   displayName?: string;
   tags?: string[];
 }
 
+/**
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
 export interface GcsTfliteModelOptions extends ModelOptionsBase {
   tfliteModel: {
     gcsTfliteUri: string;
   };
 }
 
+/**
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
 export type ModelOptions = ModelOptionsBase | GcsTfliteModelOptions;
 
 /**
  * Interface representing options for listing Models.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export interface ListModelsOptions {
   /**

--- a/src/machine-learning/machine-learning.ts
+++ b/src/machine-learning/machine-learning.ts
@@ -25,7 +25,14 @@ import {
 } from './machine-learning-api-client';
 import { FirebaseMachineLearningError } from './error';
 
-/** Response object for a listModels operation. */
+/**
+ * Response object for a listModels operation.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
 export interface ListModelsResult {
   /** A list of models in your project. */
   readonly models: Model[];
@@ -39,6 +46,11 @@ export interface ListModelsResult {
 
 /**
  * A TensorFlow Lite Model output object
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export interface TFLiteModel {
   /** The size of the model. */
@@ -50,6 +62,11 @@ export interface TFLiteModel {
 
 /**
  * The Firebase `MachineLearning` service interface.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export class MachineLearning {
 
@@ -88,6 +105,11 @@ export class MachineLearning {
    * @param model - The model to create.
    *
    * @returns A Promise fulfilled with the created model.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public createModel(model: ModelOptions): Promise<Model> {
     return this.signUrlIfPresent(model)
@@ -103,6 +125,11 @@ export class MachineLearning {
    * @param model - The model fields to update.
    *
    * @returns A Promise fulfilled with the updated model.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public updateModel(modelId: string, model: ModelOptions): Promise<Model> {
     const updateMask = utils.generateUpdateMask(model);
@@ -120,6 +147,11 @@ export class MachineLearning {
    * @param modelId - The ID of the model to publish.
    *
    * @returns A Promise fulfilled with the published model.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public publishModel(modelId: string): Promise<Model> {
     return this.setPublishStatus(modelId, true);
@@ -131,6 +163,11 @@ export class MachineLearning {
    * @param modelId - The ID of the model to unpublish.
    *
    * @returns A Promise fulfilled with the unpublished model.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public unpublishModel(modelId: string): Promise<Model> {
     return this.setPublishStatus(modelId, false);
@@ -142,6 +179,11 @@ export class MachineLearning {
    * @param modelId - The ID of the model to get.
    *
    * @returns A Promise fulfilled with the model object.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public getModel(modelId: string): Promise<Model> {
     return this.client.getModel(modelId)
@@ -157,6 +199,11 @@ export class MachineLearning {
    *     resolves with the current (filtered) list of models and the next page
    *     token. For the last page, an empty list of models and no page token
    *     are returned.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public listModels(options: ListModelsOptions = {}): Promise<ListModelsResult> {
     return this.client.listModels(options)
@@ -183,6 +230,11 @@ export class MachineLearning {
    * Deletes a model from the current project.
    *
    * @param modelId - The ID of the model to delete.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public deleteModel(modelId: string): Promise<void> {
     return this.client.deleteModel(modelId);
@@ -240,6 +292,11 @@ export class MachineLearning {
 
 /**
  * A Firebase ML Model output object.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+ * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+ * Firebase as an alternative for hosting custom models. For more info, see
+ * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
 export class Model {
   private model: ModelResponse;
@@ -366,6 +423,11 @@ export class Model {
    *
    * @returns A promise that resolves when the model is unlocked
    *   or the maximum wait time has passed.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027.
+   * To host custom models, you must migrate to another solution. You can use Cloud Storage for
+   * Firebase as an alternative for hosting custom models. For more info, see
+   * https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   public waitForUnlocked(maxTimeMillis?: number): Promise<void> {
     if ((this.model.activeOperations?.length ?? 0) > 0) {


### PR DESCRIPTION
The PR deprecates the Firebase Machine Learning module and its associated interfaces, classes, and methods ahead of the service turndown on June 15, 2027. Developers are instructed to migrate their custom model hosting workflows directly to Cloud Storage for Firebase.